### PR TITLE
Fix checksum problem on windows (2nd attempt at #7)

### DIFF
--- a/metadata/docker/jq/Dockerfile
+++ b/metadata/docker/jq/Dockerfile
@@ -4,15 +4,14 @@ RUN apt-get update && \
     apt-get install -y curl 
 
 WORKDIR /root
+
+# Download a jq binary and do a checksum check on it
 COPY jq.sha256 .
-RUN curl -L \
-    https://raw.githubusercontent.com/stedolan/jq/master/sig/v1.5/sha256sum.txt |\
-    grep jq-linux64 | sha256sum | \
-    sed -e 's/\-/jq.sha256/'> jq-sum.sha256 && \
-    sha256sum -c jq-sum.sha256
 RUN curl -L -o jq-linux64 \
     https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && \
     sha256sum -c jq.sha256
+
+# install jq
 RUN chmod a+x jq-linux64 && cp jq-linux64 /usr/local/bin/jq
 
 CMD ["bash"]


### PR DESCRIPTION
As discussed in #7, there was probably one more checksum than there needed to be, and the extra one was not working consistently on windows (despite the changes merged as part of #8).  This fix pulls the checksum of the checksum file out.  