### PR TITLE
Replace pynoid installation into ejsonschema Dockerfile

### DIFF
--- a/metadata/docker/ejsonschema/Dockerfile
+++ b/metadata/docker/ejsonschema/Dockerfile
@@ -1,7 +1,7 @@
 FROM oarpdr/jq:latest
 
 RUN apt-get update && apt-get install -y python python-pip python-dev unzip
-RUN pip install json-spec jsonschema requests
+RUN pip install json-spec jsonschema requests pynoid 
 
 WORKDIR /root
 RUN curl -L -o ejsonschema.zip \


### PR DESCRIPTION
The `Dockerfile` in `metadata/docker/ejsonschema` sets up python-related dependencies.  Somewhere in my rush to merge in the checksum fixes (#7), I seem to have lost a previous update that installs the pynoid python library, needed by the `pdl2resources.py` script.