### PR TITLE
fix jq conversion problems:  hasEmail, theme

### DIFF
--- a/metadata/jq/pod2nerdm.jq
+++ b/metadata/jq/pod2nerdm.jq
@@ -146,6 +146,7 @@ def podds2resource:
         
         description: [ .description ],
         keyword,
+        theme,
 
         references,
         accessLevel,
@@ -159,6 +160,7 @@ def podds2resource:
     if .references then .references = (.references | map(cvtref)) else del(.references) end |
     if .components then .components = (.components | map(dist2comp)) else del(.components) end |
     if .doi then . else del(.doi) end |
+    if .theme then . else del(.theme) end |
     if .issued then . else del(.issued) end 
 ;
 

--- a/metadata/model/nerdm-schema.json
+++ b/metadata/model/nerdm-schema.json
@@ -686,7 +686,7 @@
                     }
                 },
             
-                "email": {
+                "hasEmail": {
                     "title": "Email",
                     "description": "The email address of the resource contact",
                     "type": "string",


### PR DESCRIPTION
Som found a few issues that are fixed in this PR:
* converter was output-ing a "hasEmail" property instead of "email" as specified by schema; changed to schema to change property name to "hasEmail" for closer correspondance to pod.  (This introduces a little naming inconsistency within ContactInfo, though.)
* converter was not passing "theme"; updated `pod2nerdm.jq`