### PR TITLE
mdserver: ensure all files appear in dataHierarchy property

### DIFF
--- a/python/nistoar/pdr/preserv/bagit/bag.py
+++ b/python/nistoar/pdr/preserv/bagit/bag.py
@@ -10,7 +10,7 @@ from .. import NERDError, PODError, StateException
 from .exceptions import BadBagRequest
 from ... import def_jq_libdir, def_merge_etcdir
 from ....nerdm.merge import MergerFactory
-from ....nerdm.convert import ComponentCounter
+from ....nerdm.convert import ComponentCounter, HierarchyBuilder
 
 POD_FILENAME = "pod.json"
 NERDMD_FILENAME = "nerdm.json"
@@ -24,7 +24,7 @@ class NISTBag(PreservationSystem):
     an interface for reading data in a NIST-compliant BagIt bag.
     """
 
-    # NOTE: this is an imcomplete implementation 
+    # NOTE: this is an incomplete implementation 
 
     def __init__(self, rootdir, merge_annots=False):
         if not os.path.isdir(rootdir):
@@ -122,16 +122,43 @@ class NISTBag(PreservationSystem):
                 out['components'].append(comp)
 
         if 'inventory' not in out:
-            self.inventory(out)
+            self.update_inventory_in(out)
+        self.update_hierarchy_in(out)
+        
         return out
 
-    def inventory(self, resmd):
+    @classmethod
+    def update_inventory_in(cls, resmd):
+        """
+        For the given NERDm record, add or update its 'inventory' 
+        property to reflect its current set of components.
+        """
         resmd['inventory'] = {}
 
         if 'components' in resmd:
             components = resmd['components']
             cc = ComponentCounter(JQLIB)
             resmd['inventory'] = cc.inventory(components)
+
+        return resmd
+
+    @classmethod
+    def update_hierarchy_in(cls, resmd):
+        """
+        For the given NERDm record, add or update its 'dataHierarchy' 
+        property to reflect its current set of components.  If the 
+        components do not include any DataFile or Subcollection components,
+        the 'dataHierarchy' property will be remove from the given record (or
+        otherwise not added).  
+        """
+        hier = []
+        if 'dataHierarchy' in resmd:
+            del resmd['dataHierarchy']
+        if 'components' in resmd:
+            hb = HierarchyBuilder(JQLIB)
+            hier = hb.build_hierarchy(resmd['components'])
+        if hier:
+            resmd['dataHierarchy'] = hier
 
         return resmd
 

--- a/python/nistoar/pdr/preserv/bagit/builder.py
+++ b/python/nistoar/pdr/preserv/bagit/builder.py
@@ -745,6 +745,10 @@ class BagBuilder(PreservationSystem):
         if 'inventory' in mdata:
             # we'll recalculate the inventory at the end; for now, get rid of it.
             del mdata['inventory']
+        if 'dataHierarchy' in mdata:
+            # we'll recalculate the dataHierarchy at the end; for now, get rid
+            # of it.
+            del mdata['dataHierarchy']
         if 'ediid' in mdata:
             # this will trigger updates to DataFile components
             self.ediid = mdata['ediid']

--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
@@ -109,6 +109,7 @@ class TestMIDASMetadataBaggerMixed(test.TestCase):
         del data['components']
         del src['components']
         del src['inventory']
+        del src['dataHierarchy']
         self.assertEqual(data, src)
         self.assertEqual(data.keys(), src.keys())  # same order
 

--- a/python/tests/nistoar/pdr/preserv/bagit/test_bag.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/test_bag.py
@@ -13,6 +13,23 @@ import nistoar.pdr.exceptions as exceptions
 datadir = os.path.join( os.path.dirname(os.path.dirname(__file__)), "data" )
 bagdir = os.path.join(datadir, "metadatabag")
 
+baghier = [
+    {
+        "filepath": "trial1.json"
+    },
+    {
+        "filepath": "trial2.json"
+    },
+    {
+        "filepath": "trial3",
+        "children": [
+            {
+                "filepath": "trial3/trial3a.json"
+            }
+        ]
+    }
+]
+
 class TestNISTBag(test.TestCase):
 
     def setUp(self):
@@ -66,6 +83,8 @@ class TestNISTBag(test.TestCase):
         self.assertEqual(len(data['inventory']), 2)
         self.assertEqual(data['inventory'][0]['childCount'], 4)
         self.assertEqual(data['inventory'][0]['descCount'], 5)
+
+        self.assertEqual(data['dataHierarchy'], baghier)
 
     def test_comp_exists(self):
         self.assertTrue( self.bag.comp_exists("trial1.json") )

--- a/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
@@ -389,6 +389,8 @@ class TestBuilder(test.TestCase):
             data = json.load(fd)
         self.assertEqual(data['ediid'], '3A1EE2F169DD3B8CE0531A570681DB5D1491')
         self.assertEqual(len(data['components']), 1)
+        self.assertNotIn('inventory', data)
+        self.assertNotIn('dataHierarchy', data)
 
         with open(os.path.join(mdir,
                   "1491_optSortSphEvaluated20160701.cdf","nerdm.json")) as fd:


### PR DESCRIPTION
From [ODD-446](http://mml.nist.gov:8080/browse/ODD-446):
> The mdserver examines datasets under construction via MIDAS and creates NERDm records from them which can be rendered by the internal landing page service. The service is not correctly generating a `dataHierarchy` property in the NERDm record that fully reflects the contents in the components listing. Since the landing page service uses the former to generate the file listing in HTML, the landing page fails to list some of the files.

This PDR fixes this bug by using the [related fix to oar-metadata](https://github.com/usnistgov/oar-metadata/pull/10) and ensuring that a complete `dataHierarchy` is generated based on the files present in the input directories (and not just what was mentioned in the POD record).   