### PR TITLE
ODD-604: md service: don't lose external distributions

### DIFF
--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
@@ -125,8 +125,8 @@ class TestMIDASMetadataBaggerMixed(test.TestCase):
         data = self.bagr.resmd
         self.assertEqual(data['@id'], "ark:/88434/mds00hw91v")
         self.assertEqual(data['doi'], "doi:10.18434/T4SW26")
-        self.assertEqual(len(data['components']), 3)
-        self.assertEqual(data['components'][2]['@type'][0], 'nrd:Hidden')
+        self.assertEqual(len(data['components']), 4)
+        self.assertEqual(data['components'][3]['@type'][0], 'nrd:Hidden')
         self.assertIsInstance(data['@context'], list)
         self.assertEqual(len(data['@context']), 2)
         self.assertEqual(data['@context'][1]['@base'], data['@id'])
@@ -148,6 +148,16 @@ class TestMIDASMetadataBaggerMixed(test.TestCase):
         # copy of trial3a.json in upload overrides
         self.assertEqual(datafiles["trial3/trial3a.json"],
                          os.path.join(uplsip, "trial3/trial3a.json"))
+
+    def test_data_file_distribs(self):
+        # pod has not been loaded yet
+        self.assertEqual(self.bagr.data_file_distribs(), [])
+
+        self.bagr.ensure_res_metadata()
+        files = self.bagr.data_file_distribs()
+        self.assertIn('trial1.json', files)
+        self.assertIn('trial2.json', files)
+        self.assertEqual(len(files), 3) # {trial1,trial2,sim}.json + access_comp
 
     def test_ensure_file_metadata(self):
         self.assertFalse(os.path.exists(self.bagdir))

--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
@@ -538,6 +538,18 @@ class TestPreservationBagger(test.TestCase):
                                                    "metadata", "trial1.json")))
         self.assertTrue(os.path.isfile(os.path.join(self.bagr.bagdir,
                                       "metadata", "trial1.json", "nerdm.json")))
+        self.assertTrue(os.path.isdir(os.path.join(self.bagr.bagdir,
+                                                   "metadata", "trial2.json")))
+        self.assertTrue(os.path.isfile(os.path.join(self.bagr.bagdir,
+                                      "metadata", "trial2.json", "nerdm.json")))
+        self.assertTrue(os.path.isdir(os.path.join(self.bagr.bagdir,
+                                          "metadata", "trial3", "trial3a.json")))
+        self.assertTrue(os.path.isfile(os.path.join(self.bagr.bagdir,
+                            "metadata", "trial3", "trial3a.json", "nerdm.json")))
+        self.assertTrue(os.path.isdir(os.path.join(self.bagr.bagdir,
+                                                   "metadata", "sim.json")))
+        self.assertTrue(os.path.isfile(os.path.join(self.bagr.bagdir,
+                                      "metadata", "sim.json", "nerdm.json")))
 
         self.assertTrue(os.path.isfile(os.path.join(self.bagr.bagdir,
                                                    "data", "trial1.json")))
@@ -545,6 +557,8 @@ class TestPreservationBagger(test.TestCase):
                                                    "data", "trial2.json")))
         self.assertTrue(os.path.isfile(os.path.join(self.bagr.bagdir,
                                              "data", "trial3", "trial3a.json")))
+        self.assertFalse(os.path.isfile(os.path.join(self.bagr.bagdir,
+                                                     "data", "sim.json")))
 
         # test if we lost the downloadURLs
         mdf = os.path.join(self.bagr.bagdir,

--- a/python/tests/nistoar/pdr/preserv/data/midassip/review/1491/_pod.json
+++ b/python/tests/nistoar/pdr/preserv/data/midassip/review/1491/_pod.json
@@ -23,6 +23,13 @@
             "title": "JSON version of the Mathematica notebook"
         },
         {
+            "description": "Simulation of experiment",
+            "downloadURL": "https://s3.amazonaws.com/nist-midas/1491/sim.json",
+            "mediaType": "application/json",
+            "title": "JSON version of the Mathematica notebook"
+            
+        },
+        {
             "accessURL": "http://doi.org/10.18434/T4SW26",
             "description": "Software to predict the optical sorting of particles in a standing-wave laser interference field",
             "format": "Digital Object Identifier, a persistent identifier",

--- a/python/tests/nistoar/pdr/preserv/data/midassip/upload/1491/_pod.json
+++ b/python/tests/nistoar/pdr/preserv/data/midassip/upload/1491/_pod.json
@@ -23,6 +23,13 @@
             "title": "JSON version of the Mathematica notebook"
         },
         {
+            "description": "Simulation of experiment",
+            "downloadURL": "https://s3.amazonaws.com/nist-midas/1491/sim.json",
+            "mediaType": "application/json",
+            "title": "JSON version of the Mathematica notebook"
+            
+        },
+        {
             "accessURL": "http://doi.org/10.18434/T4SW26",
             "description": "Software to predict the optical sorting of particles in a standing-wave laser interference field",
             "format": "Digital Object Identifier, a persistent identifier",

--- a/python/tests/nistoar/pdr/publish/mdserv/test_serv.py
+++ b/python/tests/nistoar/pdr/publish/mdserv/test_serv.py
@@ -112,20 +112,22 @@ class TestPrePubMetadataService(test.TestCase):
         self.assertIn("components", data)
         self.assertIn("inventory", data)
 
-        self.assertEqual(len(data['components']), 5)
+        self.assertEqual(len(data['components']), 6)
         self.assertEqual(data['inventory'][0]['forCollection'], "")
         self.assertEqual(len(data['inventory']), 2)
-        self.assertEqual(data['inventory'][0]['childCount'], 4)
-        self.assertEqual(data['inventory'][0]['descCount'], 5)
+        self.assertEqual(data['inventory'][0]['childCount'], 5)
+        self.assertEqual(data['inventory'][0]['descCount'], 6)
 
         comps = data['components']
         dlcount = 0
         for comp in comps:
             if 'downloadURL' in comp:
                 dlcount += 1
+                if comp['filepath'] == 'sim.json':
+                    continue
                 self.assertTrue(comp['downloadURL'].startswith('https://data.nist.gov/od/ds/3A1EE2F169DD3B8CE0531A570681DB5D1491/'),
                                 "{0} does not start with https://data.nist.gov/od/ds/3A1EE2F169DD3B8CE0531A570681DB5D1491/".format(comp['downloadURL']))
-        self.assertEquals(dlcount, 3)
+        self.assertEquals(dlcount, 4)
         
     def test_make_nerdm_record_cvt_dlurls(self):
         metadir = os.path.join(self.bagdir, 'metadata')
@@ -143,20 +145,22 @@ class TestPrePubMetadataService(test.TestCase):
         self.assertIn("components", data)
         self.assertIn("inventory", data)
 
-        self.assertEqual(len(data['components']), 5)
+        self.assertEqual(len(data['components']), 6)
         self.assertEqual(data['inventory'][0]['forCollection'], "")
         self.assertEqual(len(data['inventory']), 2)
-        self.assertEqual(data['inventory'][0]['childCount'], 4)
-        self.assertEqual(data['inventory'][0]['descCount'], 5)
+        self.assertEqual(data['inventory'][0]['childCount'], 5)
+        self.assertEqual(data['inventory'][0]['descCount'], 6)
         
         comps = data['components']
         dlcount = 0
         for comp in comps:
             if 'downloadURL' in comp:
                 dlcount += 1
+                if comp['filepath'] == 'sim.json':
+                    continue
                 self.assertTrue(comp['downloadURL'].startswith('https://mdserv.nist.gov/'+self.midasid+'/'),
                                 "Bad conversion of URL: "+comp['downloadURL'])
-        self.assertEquals(dlcount, 3)
+        self.assertEquals(dlcount, 4)
 
         datafiles = { "trial1.json": "blah/blah/trial1.json" }
         data = self.srv.make_nerdm_record(bagdir, datafiles, 
@@ -173,7 +177,7 @@ class TestPrePubMetadataService(test.TestCase):
                 else:
                     self.assertFalse(comp['downloadURL'].startswith('https://mdserv.nist.gov/'+self.midasid+'/'),
                                 "Bad conversion of URL: "+comp['downloadURL'])
-        self.assertEquals(dlcount, 3)
+        self.assertEquals(dlcount, 4)
 
         
         

--- a/python/tests/nistoar/pdr/publish/mdserv/test_webservice.py
+++ b/python/tests/nistoar/pdr/publish/mdserv/test_webservice.py
@@ -89,7 +89,7 @@ class TestWebServer(test.TestCase):
 
         data = json.loads(resp.read())
         self.assertEqual(data['ediid'], '3A1EE2F169DD3B8CE0531A570681DB5D1491')
-        self.assertEqual(len(data['components']), 5)
+        self.assertEqual(len(data['components']), 6)
         
 
 

--- a/python/tests/nistoar/pdr/publish/mdserv/test_wsgi.py
+++ b/python/tests/nistoar/pdr/publish/mdserv/test_wsgi.py
@@ -86,7 +86,7 @@ class TestApp(test.TestCase):
         self.assertGreater(len([l for l in self.resp if "Content-Type:" in l]),0)
         data = json.loads(body[0])
         self.assertEqual(data['ediid'], '3A1EE2F169DD3B8CE0531A570681DB5D1491')
-        self.assertEqual(len(data['components']), 5)
+        self.assertEqual(len(data['components']), 6)
         
     def test_head_good_id(self):
         req = {


### PR DESCRIPTION
This PR addresses [ODD-604 ("PDR-publish misses external distributions")](http://mml.nist.gov:8080/browse/ODD-604) which considers a problem handling a MIDAS SIP that includes distributions available from external URLs--i.e. not through the distribution service (including via s3.amazonaws.com and cloud front).  Such distributions would not get translated into the NERDm record via the metadata service.  Thus, these distributions would not be listed on the landing page.  

This scenario came up with a MIDAS SIP that was initiated prior to the MIDAS-PDR integration but is ready to publish afterward.  However, this problem would likely also arise when updating datasets that were published prior to the MIDAS-PDR integration.

Previously, NERDm record components were based exclusively on the datafiles present in the SIP input directories and not on the distribution metadata in the POD record (handled within the `nistoar.pdr.preserv.bagger.midas` module).  In this change, the POD distribution metadata is converted and retained; those that match data files in the input directories have their metadata enhanced (e.g. with size, checksum values).  The code for detecting when data files have been removed had to be updated.  