### PR TITLE
ODD-604:  preservation service: don't delete empty data directory

### DIFF
--- a/python/nistoar/pdr/preserv/bagit/builder.py
+++ b/python/nistoar/pdr/preserv/bagit/builder.py
@@ -1061,6 +1061,9 @@ format(nerdm['title'])
         droot = os.path.join(self.bagdir, "data")
         mroot = os.path.join(self.bagdir, "metadata")
         for ddir, subdirs, files in os.walk(droot, topdown=False):
+            if ddir == droot:
+                # don't delete the root "data" directory
+                continue
             subdirs = [d for d in subdirs
                          if os.path.exists(os.path.join(ddir, d))]
             if len(files) == 0 and len(subdirs) == 0:


### PR DESCRIPTION
This PR is a follow-up to PR #28 which addresses [ODD-604 ("PDR-publish misses external distributions")](http://mml.nist.gov:8080/browse/ODD-604); that issue considers a problem handling a MIDAS SIP that includes distributions available from external URLs--i.e. not through the distribution service (including via s3.amazonaws.com and cloud front).  It's typical that a dataset with at least one external distribution will have all its distributions external.  Thus, a preservation bag for the dataset will contain no payload data under its `data` directory.  A feature of the service to eliminate empty subdirectories under `data` (e.g. when data files have been remove) was, in such a case, also eliminating the `data` directory, making it no longer a compliant bag.  

This PR fixes the folder trimming routine in the preservation service to prevent eliminating an empty `data` directory.  