### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/python/nistoar/pdr/preserv/bagit/builder.py
+++ b/python/nistoar/pdr/preserv/bagit/builder.py
@@ -832,7 +832,7 @@ class BagBuilder(PreservationSystem):
 
                 # landing page
                 if nerdm.get('doi'):
-                    print("More information:\nhttps://dx.doi.org/" +
+                    print("More information:\nhttps://doi.org/" +
                           nerdm.get('doi'), file=fd)
                 elif nerdm.get('landingPage'):
                     print("More information:\n" + nerdm.get('landingPage'),

--- a/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
@@ -1004,7 +1004,7 @@ class TestBuilder(test.TestCase):
         self.assertIn("         Phone: 1-301-975-", lines[12])
         self.assertIn("Software to", lines[14])
         self.assertIn("More information:", lines[17])
-        self.assertIn("https://dx.doi.org/10.18434/", lines[18])
+        self.assertIn("https://doi.org/10.18434/", lines[18])
             
 
 if __name__ == '__main__':

--- a/python/tests/nistoar/pdr/preserv/data/metadatabag/metadata/nerdm.json
+++ b/python/tests/nistoar/pdr/preserv/data/metadatabag/metadata/nerdm.json
@@ -40,7 +40,7 @@
             "@type": "deo:BibliographicReference",
             "@id": "#ref:10.1364/OE.24.014100",
             "refType": "IsReferencedBy",
-            "location": "https://dx.doi.org/10.1364/OE.24.014100",
+            "location": "https://doi.org/10.1364/OE.24.014100",
             "_extensionSchemas": [
                 "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference"
             ]
@@ -50,7 +50,7 @@
     "license": "http://www.nist.gov/open/license.cfm",
     "components": [
         {
-            "accessURL": "http://doi.org/10.18434/T4SW26",
+            "accessURL": "https://doi.org/10.18434/T4SW26",
             "description": "Software to predict the optical sorting of particles in a standing-wave laser interference field",
             "format": "Digital Object Identifier, a persistent identifier",
             "mediaType": "application/zip",

--- a/python/tests/nistoar/pdr/preserv/data/metadatabag/metadata/pod.json
+++ b/python/tests/nistoar/pdr/preserv/data/metadatabag/metadata/pod.json
@@ -29,7 +29,7 @@
             "title": "JSON version of the Mathematica notebook"
         },
         {
-            "accessURL": "http://doi.org/10.18434/T4SW26",
+            "accessURL": "https://doi.org/10.18434/T4SW26",
             "description": "Software to predict the optical sorting of particles in a standing-wave laser interference field",
             "format": "Digital Object Identifier, a persistent identifier",
             "mediaType": "application/zip",
@@ -57,7 +57,7 @@
         "name": "National Institute of Standards and Technology"
     },
     "references": [
-        "https://dx.doi.org/10.1364/OE.24.014100"
+        "https://doi.org/10.1364/OE.24.014100"
     ],
     "theme": [
         "Optical physics"

--- a/python/tests/nistoar/pdr/preserv/data/midassip/review/1491/_pod.json
+++ b/python/tests/nistoar/pdr/preserv/data/midassip/review/1491/_pod.json
@@ -30,7 +30,7 @@
             
         },
         {
-            "accessURL": "http://doi.org/10.18434/T4SW26",
+            "accessURL": "https://doi.org/10.18434/T4SW26",
             "description": "Software to predict the optical sorting of particles in a standing-wave laser interference field",
             "format": "Digital Object Identifier, a persistent identifier",
             "mediaType": "application/zip",
@@ -58,7 +58,7 @@
         "name": "National Institute of Standards and Technology"
     },
     "references": [
-        "https://dx.doi.org/10.1364/OE.24.014100"
+        "https://doi.org/10.1364/OE.24.014100"
     ],
     "theme": [
         "Optical physics"

--- a/python/tests/nistoar/pdr/preserv/data/midassip/upload/1491/_pod.json
+++ b/python/tests/nistoar/pdr/preserv/data/midassip/upload/1491/_pod.json
@@ -30,7 +30,7 @@
             
         },
         {
-            "accessURL": "http://doi.org/10.18434/T4SW26",
+            "accessURL": "https://doi.org/10.18434/T4SW26",
             "description": "Software to predict the optical sorting of particles in a standing-wave laser interference field",
             "format": "Digital Object Identifier, a persistent identifier",
             "mediaType": "application/zip",
@@ -58,7 +58,7 @@
         "name": "National Institute of Standards and Technology"
     },
     "references": [
-        "https://dx.doi.org/10.1364/OE.24.014100"
+        "https://doi.org/10.1364/OE.24.014100"
     ],
     "theme": [
         "Optical physics"

--- a/python/tests/nistoar/pdr/preserv/data/samplembag/about.txt
+++ b/python/tests/nistoar/pdr/preserv/data/samplembag/about.txt
@@ -10,4 +10,4 @@ Software to predict the optical sorting of particles in a standing-
 wave laser interference field
 
 More information:
-https://dx.doi.org/doi:10.18434/T4SW26
+https://doi.org/doi:10.18434/T4SW26

--- a/python/tests/nistoar/pdr/preserv/data/samplembag/metadata/nerdm.json
+++ b/python/tests/nistoar/pdr/preserv/data/samplembag/metadata/nerdm.json
@@ -40,7 +40,7 @@
             "@type": "deo:BibliographicReference",
             "@id": "#ref:10.1364/OE.24.014100",
             "refType": "IsReferencedBy",
-            "location": "https://dx.doi.org/10.1364/OE.24.014100",
+            "location": "https://doi.org/10.1364/OE.24.014100",
             "_extensionSchemas": [
                 "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference"
             ]
@@ -50,7 +50,7 @@
     "license": "http://www.nist.gov/open/license.cfm",
     "components": [
         {
-            "accessURL": "http://doi.org/10.18434/T4SW26",
+            "accessURL": "https://doi.org/10.18434/T4SW26",
             "description": "Software to predict the optical sorting of particles in a standing-wave laser interference field",
             "format": "Digital Object Identifier, a persistent identifier",
             "mediaType": "application/zip",

--- a/python/tests/nistoar/pdr/preserv/data/samplembag/metadata/pod.json
+++ b/python/tests/nistoar/pdr/preserv/data/samplembag/metadata/pod.json
@@ -23,7 +23,7 @@
             "title": "JSON version of the Mathematica notebook"
         },
         {
-            "accessURL": "http://doi.org/10.18434/T4SW26",
+            "accessURL": "https://doi.org/10.18434/T4SW26",
             "description": "Software to predict the optical sorting of particles in a standing-wave laser interference field",
             "format": "Digital Object Identifier, a persistent identifier",
             "mediaType": "application/zip",
@@ -51,7 +51,7 @@
         "name": "National Institute of Standards and Technology"
     },
     "references": [
-        "https://dx.doi.org/10.1364/OE.24.014100"
+        "https://doi.org/10.1364/OE.24.014100"
     ],
     "theme": [
         "Optical physics"

--- a/python/tests/nistoar/pdr/preserv/data/simplesip/_nerdm.json
+++ b/python/tests/nistoar/pdr/preserv/data/simplesip/_nerdm.json
@@ -56,7 +56,7 @@
         {
             "@type": "deo:BibliographicReference",
             "refType": "IsReferencedBy",
-            "location": "https://dx.doi.org/10.1364/OE.24.014100",
+            "location": "https://doi.org/10.1364/OE.24.014100",
             "_extensionSchemas": [
                 "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference"
             ]
@@ -93,7 +93,7 @@
             ]
         },
         {
-            "accessURL": "http://doi.org/10.18434/T4SW26",
+            "accessURL": "https://doi.org/10.18434/T4SW26",
             "mediaType": "application/zip",
             "title": "DOI access for OptSortSph: Sorting Spherical Dielectric Particles in a Standing-Wave Interference Field",
             "description": "Software to predict the optical sorting of particles in a standing-wave laser interference field",

--- a/python/tests/nistoar/pdr/preserv/data/simplesip/_pod.json
+++ b/python/tests/nistoar/pdr/preserv/data/simplesip/_pod.json
@@ -29,7 +29,7 @@
             "title": "JSON version of the Mathematica notebook"
         },
         {
-            "accessURL": "http://doi.org/10.18434/T4SW26",
+            "accessURL": "https://doi.org/10.18434/T4SW26",
             "description": "Software to predict the optical sorting of particles in a standing-wave laser interference field",
             "format": "Digital Object Identifier, a persistent identifier",
             "mediaType": "application/zip",
@@ -57,7 +57,7 @@
         "name": "National Institute of Standards and Technology"
     },
     "references": [
-        "https://dx.doi.org/10.1364/OE.24.014100"
+        "https://doi.org/10.1364/OE.24.014100"
     ],
     "theme": [
         "Optical physics"


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates static DOI links and the code that generates new ones.

Cheers!