### PR TITLE
ODD-612: urlencode the filepath when converting to downloadURL

### DIFF
--- a/python/nistoar/pdr/preserv/bagit/builder.py
+++ b/python/nistoar/pdr/preserv/bagit/builder.py
@@ -7,6 +7,7 @@ import pynoid as noid
 from shutil import copy as filecopy, rmtree
 from copy import deepcopy
 from collections import Mapping, Sequence, OrderedDict
+from urllib import quote as urlencode
 
 from .. import (SIPDirectoryError, SIPDirectoryNotFound, 
                 ConfigurationException, StateException, PODError)
@@ -253,7 +254,7 @@ class BagBuilder(PreservationSystem):
 
     def _download_url(self, ediid, destpath):
         path = "/".join(destpath.split(os.sep))
-        return self._distbase + ediid + '/' + path
+        return self._distbase + ediid + '/' + urlencode(path)
 
     def ensure_bagdir(self):
         """
@@ -702,7 +703,7 @@ class BagBuilder(PreservationSystem):
         if disttype not in self._file_types:
             raise ValueError("Unsupported file distribution type: "+disttype)
         out = {
-            "@id": "cmps/" + destpath,
+            "@id": "cmps/" + urlencode(destpath),
             "@type": deepcopy(self._file_types[disttype][0]),
             "filepath": destpath,
         }
@@ -725,7 +726,7 @@ class BagBuilder(PreservationSystem):
 
     def _create_init_collmd_for(self, destpath):
         out = {
-            "@id": "cmps/" + destpath,
+            "@id": "cmps/" + urlencode(destpath),
             "@type": [ ":".join([NERDPUB_PRE, "Subcollection"]) ],
             "filepath": destpath,
             "_extensionSchemas": [ NERDPUB_DEF + "Subcollection" ]

--- a/python/nistoar/pdr/preserv/bagit/builder.py
+++ b/python/nistoar/pdr/preserv/bagit/builder.py
@@ -53,6 +53,7 @@ NERDMPUB_SCH_ID = NERDMPUB_SCH_ID_BASE + NERDMPUB_SCH_VER + "#"
 NERD_DEF = NERDM_SCH_ID + "/definitions/"
 NERDPUB_DEF = NERDMPUB_SCH_ID + "/definitions/"
 DATAFILE_TYPE = NERDPUB_PRE + ":DataFile"
+DOWNLOADABLEFILE_TYPE = NERDPUB_PRE + ":DownloadableFile"
 SUBCOLL_TYPE = NERDPUB_PRE + ":Subcollection"
 DISTSERV = "https://data.nist.gov/od/ds/"
 
@@ -1261,7 +1262,8 @@ format(nerdm['title'])
                 raise NERDTypeError("list", str(type(mdata['components'])),
                                     'components')
             for i in range(len(components)-1, -1, -1):
-                if DATAFILE_TYPE in components[i].get('@type',[]):
+                tps = components[i].get('@type',[])
+                if DOWNLOADABLEFILE_TYPE in tps or DATAFILE_TYPE in tps:
                     if savefilemd and 'filepath' not in components[i]:
                         msg = "DataFile missing 'filepath' property"
                         if '@id' in components[i]:

--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
@@ -607,9 +607,9 @@ class TestPreservationBagger(test.TestCase):
         self.assertTrue(os.path.isfile(os.path.join(self.bagr.bagdir,
                             "metadata", "trial3", "trial3a.json", "nerdm.json")))
         self.assertTrue(os.path.isdir(os.path.join(self.bagr.bagdir,
-                                                   "metadata", "sim.json")))
+                                                   "metadata", "sim++.json")))
         self.assertTrue(os.path.isfile(os.path.join(self.bagr.bagdir,
-                                      "metadata", "sim.json", "nerdm.json")))
+                                      "metadata", "sim++.json", "nerdm.json")))
 
         self.assertTrue(os.path.isfile(os.path.join(self.bagr.bagdir,
                                                    "data", "trial1.json")))
@@ -618,7 +618,7 @@ class TestPreservationBagger(test.TestCase):
         self.assertTrue(os.path.isfile(os.path.join(self.bagr.bagdir,
                                              "data", "trial3", "trial3a.json")))
         self.assertFalse(os.path.isfile(os.path.join(self.bagr.bagdir,
-                                                     "data", "sim.json")))
+                                                     "data", "sim++.json")))
 
         # test if we lost the downloadURLs
         mdf = os.path.join(self.bagr.bagdir,

--- a/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
@@ -303,6 +303,25 @@ class TestBuilder(test.TestCase):
         self.assertIn('downloadURL', md)
         self.assertEqual(md['downloadURL'], dlurl)
 
+    def test_init_filemd_for_encoding(self):
+        path = os.path.join("trial 1","1%gold","iron+wine.dat")
+        epath = "trial%201/1%25gold/iron%2Bwine.dat"
+        self.bag._ediid = "gooberid"
+        need = {
+            "@id": "cmps/"+epath,
+            "@type": [ "nrdp:DataFile", "nrdp:DownloadableFile", "dcat:Distribution" ],
+            "filepath": path,
+            "downloadURL": "https://data.nist.gov/od/ds/gooberid/trial%201/1%25gold/iron%2Bwine.dat",
+            "_extensionSchemas": [ "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile" ]
+        }
+        mdf = os.path.join(self.bag.bagdir, "metadata", path, "nerdm.json")
+        self.assertFalse(os.path.exists(mdf))
+        self.assertEqual(self.bag._distbase, "https://data.nist.gov/od/ds/")
+
+        md = self.bag.init_filemd_for(path)
+        self.assertEquals(md, need)
+        self.assertFalse(os.path.exists(mdf))
+
     def test_init_filemd_for_checksumfile(self):
         path = os.path.join("trial1","gold","file.dat")
         need = {

--- a/python/tests/nistoar/pdr/preserv/data/midassip/review/1491/_pod.json
+++ b/python/tests/nistoar/pdr/preserv/data/midassip/review/1491/_pod.json
@@ -24,7 +24,7 @@
         },
         {
             "description": "Simulation of experiment",
-            "downloadURL": "https://s3.amazonaws.com/nist-midas/1491/sim.json",
+            "downloadURL": "https://s3.amazonaws.com/nist-midas/1491/sim%2B%2B.json",
             "mediaType": "application/json",
             "title": "JSON version of the Mathematica notebook"
             


### PR DESCRIPTION
This addresses [ODD-612 ("PDR-publish: files with URL-encodable parameters get listed twice")](http://mml.nist.gov:8080/browse/ODD-612) which describes how special characters in filenames were confusing the metadata service and causing them to be added twice, one with the characters URL-encoded and one unencoded.  The key to fixing this is ensuring that when converting between `downloadURL` and `filepath` properties, it is necessary to url-encode and decode.  

This PR has a companion [PR 25 to oar-metadata](https://github.com/usnistgov/oar-metadata/pull/25).  In this PR, the `bagit/builder` module was updated to encode the `filepath` when converting it to a `downloadURL` or a component ID (`@id`).  (The [oar-metadata PR 25](https://github.com/usnistgov/oar-metadata/pull/25) handles url-encoding.) 