### PR TITLE
Fix preservation failures due to funny descriptions and retries

### DIFF
--- a/python/nistoar/pdr/preserv/bagit/builder.py
+++ b/python/nistoar/pdr/preserv/bagit/builder.py
@@ -993,7 +993,7 @@ format(nerdm['title'])
 
         initdata['External-Identifier'] = [self.id]
         if nerdm.get('doi'):
-            initdata['External-Identifier'].append(nerdm['doi'])
+            initdata['External-Identifier'].append("doi:"+nerdm['doi'])
 
         # Calculate the payload Oxum
         oxum = self._measure_oxum(self._bag._datadir)

--- a/python/nistoar/pdr/preserv/bagit/builder.py
+++ b/python/nistoar/pdr/preserv/bagit/builder.py
@@ -983,8 +983,9 @@ class BagBuilder(PreservationSystem):
         initdata['Bag-Group-Identifier'] = nerdm.get('ediid') or self.ediid
         initdata['Internal-Sender-Identifier'] = self.bagname
 
-        if nerdm.get('description'):
-            initdata['External-Description'] = nerdm['description']
+        desc = [p for p in nerdm.get('description', []) if len(p.strip()) > 0]
+        if desc:
+            initdata['External-Description'] = desc
         else:
             initdata['External-Description'] = \
 "This collection contains data for the NIST data resource entitled, {0}". \

--- a/python/nistoar/pdr/utils.py
+++ b/python/nistoar/pdr/utils.py
@@ -2,7 +2,7 @@
 Utility functions useful across the pdr package
 """
 from collections import OrderedDict, Mapping
-import hashlib, json, re, shutil, os
+import hashlib, json, re, shutil, os, time
 
 from .exceptions import (NERDError, PODError, StateException)
 
@@ -150,5 +150,7 @@ def rmtree(rootdir, retries=1):
         except OSError as ex:
             if retries <= 0:
                 raise
+            # wait a little for NFS to catch up
+            time.sleep(0.25)
             rmtree(root, retries=retries-1)
     

--- a/python/nistoar/pdr/utils.py
+++ b/python/nistoar/pdr/utils.py
@@ -2,7 +2,7 @@
 Utility functions useful across the pdr package
 """
 from collections import OrderedDict, Mapping
-import hashlib, json, re
+import hashlib, json, re, shutil, os
 
 from .exceptions import (NERDError, PODError, StateException)
 
@@ -133,3 +133,22 @@ def checksum_of(filepath):
             sum.update(buf)
     return sum.hexdigest()
 
+def rmtree(rootdir, retries=1):
+    """
+    an implementation of rmtree that is intended to work on NSF-mounted 
+    directories where shutil.rmtree can often fail.
+    """
+    if not os.path.exists(rootdir):
+        return
+    if not os.path.isdir(rootdir):
+        os.remove(rootdir)
+        return
+    
+    for root,subdirs,files in os.walk(rootdir, topdown=False):
+        try:
+            shutil.rmtree(root)
+        except OSError as ex:
+            if retries <= 0:
+                raise
+            rmtree(root, retries=retries-1)
+    


### PR DESCRIPTION
This PR addresses two bugs causing preservation failures, one related to descriptions with empty paragraphs and the other resulting when preservation is retried after an initial failure.  

As described in the [oar-metadata PR 26](https://github.com/usnistgov/oar-metadata/pull/26), a preservation bagging failure can occur one of the values in the NERDm record's (Resource-level) `description` property array is an empty string (or one containing only spaces): when the description is used to fill in the `External-Description` property in the `bag-info.txt` file, one of its entries would have no value, causing a bag validation error.  The origin of this error was MIDAS users being over-eager with the return key when entering a resource description.  The [oar-metadata PR](https://github.com/usnistgov/oar-metadata/pull/26) addresses the problem upstream by filtering out `description` values that have no content.  This oar-pdr PR addresses the problem downstream when writing the `bag-info.txt` file, filtering out any empty description values that might have crept in elsewhere.  

The second bug occurs when preservation is retried after a failure.  During preservation, the output bag is staged into a subdirectory of the review SIP directory.  When preservation is retried after failure, this proto-bag may still exist; if the bagger finds it, it tries to delete it before building a new one, using the python method, `shutil.rmtree()`.  Although, it shouldn't, this call was often failing on the test and production systems.  This appears to be due to an oft reported limitation of that method which can fail when operating on a directory on an NFS-mounted filesystem (due to NFS's use of hidden files).  This PR attempts to fix this with a custom implementation, `pdr.utils.rmtree()`, which upon failure will sleep a quarter-second and retry.  This hopefully gives NFS enough time to catch up, but it is hard to test definitively.  