### PR TITLE
ODD-636: Support annotations in the PDR publishing system

### DIFF
--- a/python/nistoar/pdr/preserv/bagger/midas.py
+++ b/python/nistoar/pdr/preserv/bagger/midas.py
@@ -27,7 +27,8 @@ DEF_MBAG_VERSION = "0.3"
 DEF_MIDAS_POD_FILE = "_pod.json"
 SUPPORTED_CHECKSUM_ALGS = [ "sha256" ]
 DEF_CHECKSUM_ALG = "sha256"
-DEF_MERGE_CONV = "dev"
+DEF_MERGE_CONV = "initdef"  # For merging MIDAS-generated metadata with
+                            # initial defaults
 
 def _midadid_to_dirname(midasid, log=None):
     out = midasid

--- a/python/nistoar/pdr/preserv/bagger/midas.py
+++ b/python/nistoar/pdr/preserv/bagger/midas.py
@@ -25,8 +25,9 @@ log = logging.getLogger(_sys.system_abbrev).getChild(_sys.subsystem_abbrev)
 
 DEF_MBAG_VERSION = "0.3"
 DEF_MIDAS_POD_FILE = "_pod.json"
-SUPPORTED_CHECKSUM_ALGS = [ "sha256" ];
+SUPPORTED_CHECKSUM_ALGS = [ "sha256" ]
 DEF_CHECKSUM_ALG = "sha256"
+DEF_MERGE_CONV = "dev"
 
 def _midadid_to_dirname(midasid, log=None):
     out = midasid
@@ -65,7 +66,7 @@ class MIDASMetadataBagger(SIPBagger):
     :prop update_by_checksum_size_lim int (0):  a size limit in bytes for which 
                                  files less than this will be checked to see 
                                  if it has changed (not yet implemented).
-    :prop conponent_merge_convention str ("dev"): the merge convention name to 
+    :prop component_merge_convention str ("dev"): the merge convention name to 
                                  use to merge MIDAS-provided component metadata
                                  with the PDR's initial component metadata.
     :prop relative_to_indir bool (False):  If True, the output bag directory 
@@ -292,10 +293,13 @@ class MIDASMetadataBagger(SIPBagger):
                     log.info("Extending file metadata for %s", destpath)
         
         if update:
+            # generate some default metadata for the file
             init = self.bagbldr.init_filemd_for(destpath, examine=inpath,
                                                 disttype=disttype)
             if nerd:
-                conv = self.cfg.get('component_merge_convention', 'dev')
+                # merge with the data passed to this method (e.g. as
+                # generated from the POD record.
+                conv = self.cfg.get('component_merge_convention', DEF_MERGE_CONV)
                 merger = self._merger_for(conv, "DataFile")
                 nerd = merger.merge(nerd, init)
             else:

--- a/python/nistoar/pdr/preserv/bagit/bag.py
+++ b/python/nistoar/pdr/preserv/bagit/bag.py
@@ -18,15 +18,17 @@ ANNOTS_FILENAME = "annot.json"
 DEFAULT_MERGE_CONVENTION = "dev"
 
 JQLIB = def_jq_libdir
+MERGECONF = def_merge_etcdir
 
 class NISTBag(PreservationSystem):
     """
     an interface for reading data in a NIST-compliant BagIt bag.
     """
 
-    # NOTE: this is an incomplete implementation 
+    # NOTE: this is an incomplete implementation
+    # (what's missing?)
 
-    def __init__(self, rootdir, merge_annots=False):
+    def __init__(self, rootdir, merge_annots=False, merge_conf_dir=None):
         if not os.path.isdir(rootdir):
             raise StateException("Bag directory does not exist as a directory: "+
                                  rootdir, sys=self)
@@ -40,6 +42,13 @@ class NISTBag(PreservationSystem):
         self._mbagdir = None
 
         self._mergeannots = merge_annots
+
+        # this is the directory containing schemas annotated with merging
+        # directives
+        self._mergeconf = merge_conf_dir
+        if not self._mergeconf:
+            self._mergeconf = MERGECONF
+        self._mergerfact = None
 
     @property
     def dir(self):
@@ -149,21 +158,31 @@ class NISTBag(PreservationSystem):
 
         if merge_annots is None:
             merge_annots = self._mergeannots
+            
         annotfile = os.path.join(os.path.dirname(nerdfile), ANNOTS_FILENAME)
         if merge_annots and os.path.exists(annotfile):
             if merge_annots is True:
                 merge_annots = DEFAULT_MERGE_CONVENTION
-            compmerger = MergerFactory.make_merger(merge_annots, 'Component')
-            
+
+            merge_type = "Component"
+            if filepath == "":
+                merge_type = "Resource"
+
+            compmerger = self._make_merger(merge_annots, merge_type)
             if isinstance(merge_annots, Merger):
                 compmerger = merge_annots
             else:
-                compmerger = MergerFactory.make_merger(merge_annots, 'Component')
+                compmerger = self._make_merger(merge_annots, merge_type)
 
             annots = self.read_nerd(annotfile)
-            comp = compmerger.merge(comp, annots)
+            out = compmerger.merge(out, annots)
 
         return out
+
+    def _make_merger(self, stratconvname, typename):
+        if not self._mergerfact:
+            self._mergerfact = MergerFactory(MERGECONF)
+        return self._mergerfact.make_merger(stratconvname, typename)
 
     def nerdm_record(self, merge_annots=None):
         """
@@ -183,7 +202,7 @@ class NISTBag(PreservationSystem):
             merge_annots = DEFAULT_MERGE_CONVENTION
         compmerger = None
         if merge_annots:
-            compmerger = MergerFactory.make_merger(merge_annots, 'Component')
+            compmerger = self._make_merger(merge_annots, 'Component')
 
         out = None
         for root, subdirs, files in os.walk(self._metadir):
@@ -196,8 +215,7 @@ class NISTBag(PreservationSystem):
                     annotfile = os.path.join(root,ANNOTS_FILENAME)
                     if os.path.exists(annotfile):
                         annots = self.read_nerd(annotfile)
-                        merger = MergerFactory.make_merger(merger_annots,
-                                                           'Resource')
+                        merger = self._make_merger(merge_annots, 'Resource')
                         out = merger.merge(out, annots)
 
             elif NERDMD_FILENAME in files:
@@ -357,6 +375,22 @@ class NISTBag(PreservationSystem):
             for f in files:
                 # if f.startswith('.'):
                 #     continue
+                yield os.path.join(reldir, f)
+
+    def iter_data_components(self):
+        """
+        iterate through components that have entries in the metadata directory,
+        returning the filepath for those components
+
+        :return generator:  
+        """
+        for dir, subdirs, files in os.walk(self.metadata_dir):
+            reldir = dir[len(self.metadata_dir)+1:]
+            for f in subdirs:
+                # if f.startswith('.'):
+                #     continue
+                if f.startswith('_'):
+                    continue
                 yield os.path.join(reldir, f)
 
     def iter_fetch_records(self):

--- a/python/nistoar/pdr/preserv/bagit/bag.py
+++ b/python/nistoar/pdr/preserv/bagit/bag.py
@@ -15,7 +15,7 @@ from ....nerdm.convert import ComponentCounter, HierarchyBuilder
 POD_FILENAME = "pod.json"
 NERDMD_FILENAME = "nerdm.json"
 ANNOTS_FILENAME = "annot.json"
-DEFAULT_MERGE_CONVENTION = "dev"
+DEFAULT_MERGE_CONVENTION = "midas0"
 
 JQLIB = def_jq_libdir
 MERGECONF = def_merge_etcdir

--- a/python/nistoar/pdr/preserv/bagit/builder.py
+++ b/python/nistoar/pdr/preserv/bagit/builder.py
@@ -56,7 +56,7 @@ DATAFILE_TYPE = NERDPUB_PRE + ":DataFile"
 DOWNLOADABLEFILE_TYPE = NERDPUB_PRE + ":DownloadableFile"
 SUBCOLL_TYPE = NERDPUB_PRE + ":Subcollection"
 DISTSERV = "https://data.nist.gov/od/ds/"
-DEF_MERGE_CONV = "dev"
+DEF_MERGE_CONV = "midas0"
 
 class BagBuilder(PreservationSystem):
     """

--- a/python/nistoar/pdr/publish/mdserv/serv.py
+++ b/python/nistoar/pdr/publish/mdserv/serv.py
@@ -167,7 +167,7 @@ class PrePubMetadataService(PublishSystem):
                             'download_base_url' is set (see above).  
         """
         bag = NISTBag(bagdir)
-        out = bag.nerdm_record()
+        out = bag.nerdm_record(merge_annots=True)
 
         if not baseurl:
             baseurl = self.cfg.get('download_base_url')

--- a/python/tests/nistoar/pdr/preserv/bagit/test_bag.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/test_bag.py
@@ -84,6 +84,7 @@ class TestNISTBag(test.TestCase):
         self.assertNotIn('foo', nerd)
         self.assertTrue(nerd['title'].startswith("OptSortSph: Sorting "))
         self.assertEqual(nerd['ediid'], "3A1EE2F169DD3B8CE0531A570681DB5D1491")
+        self.assertEqual(nerd['@type'], ["nrdp:PublicDataResource"])
 
         nerd = self.bag.nerd_metadata_for("", True)
         self.assertIn('authors', nerd)
@@ -94,6 +95,8 @@ class TestNISTBag(test.TestCase):
         self.assertEqual(nerd['authors'][0]['givenName'], "Kevin")
         self.assertEqual(nerd['authors'][1]['givenName'], "Jianming")
         self.assertEqual(len(nerd['authors']), 2)
+        self.assertEqual(nerd['@type'],
+                         ["nrdp:DataPublication", "nrdp:PublicDataResource"])
 
         nerd = self.bag.nerd_metadata_for("trial1.json")
         self.assertNotIn("previewURL", nerd)
@@ -139,6 +142,7 @@ class TestNISTBag(test.TestCase):
         self.assertNotIn('authors', nerd)
         self.assertTrue(nerd['title'].startswith("OptSortSph: Sorting "))
         self.assertEqual(nerd['ediid'], "3A1EE2F169DD3B8CE0531A570681DB5D1491")
+        self.assertEqual(nerd['@type'], ["nrdp:PublicDataResource"])
         trial1 = [c for c in nerd['components']
                     if 'filepath' in c and c['filepath'] == "trial1.json"][0]
         self.assertNotIn('previewURL', trial1)
@@ -152,6 +156,8 @@ class TestNISTBag(test.TestCase):
         self.assertEqual(nerd['authors'][0]['givenName'], "Kevin")
         self.assertEqual(nerd['authors'][1]['givenName'], "Jianming")
         self.assertEqual(len(nerd['authors']), 2)
+        self.assertEqual(nerd['@type'],
+                         ["nrdp:DataPublication", "nrdp:PublicDataResource"])
 
         trial1 = [c for c in nerd['components']
                     if 'filepath' in c and c['filepath'] == "trial1.json"][0]

--- a/python/tests/nistoar/pdr/preserv/data/metadatabag/metadata/annot.json
+++ b/python/tests/nistoar/pdr/preserv/data/metadatabag/metadata/annot.json
@@ -1,0 +1,28 @@
+{
+    "authors": [
+        {
+            "fn": "Kevin R. Gurney",
+            "givenName": "Kevin",
+            "middleName": "R.",
+            "familyName": "Gurney",
+            "affiliation": [{
+                "@type": [ "org:Organization" ],
+                "title": "Arizona State University",
+                "@id": "sdporg:AZ-SU"
+            }]
+        },
+        {
+            "fn": "Jianming Liang",
+            "givenName": "Jianming",
+            "familyName": "Liang",
+            "affiliation": [{
+                "@type": [ "org:Organization" ],
+                "title": "Arizona State University",
+                "@id": "sdporg:AZ-SU"
+            }]
+        }
+    ],
+    "title": "A much better title",
+    "ediid": "Ha ha!",
+    "foo": "bar"
+}

--- a/python/tests/nistoar/pdr/preserv/data/metadatabag/metadata/annot.json
+++ b/python/tests/nistoar/pdr/preserv/data/metadatabag/metadata/annot.json
@@ -1,4 +1,5 @@
 {
+    "@type": [ "nrdp:DataPublication", "nrdp:PublicDataResource" ],
     "authors": [
         {
             "fn": "Kevin R. Gurney",

--- a/python/tests/nistoar/pdr/preserv/data/metadatabag/metadata/trial1.json/annot.json
+++ b/python/tests/nistoar/pdr/preserv/data/metadatabag/metadata/trial1.json/annot.json
@@ -1,0 +1,4 @@
+{
+    "previewURL": "https://data.nist.gov/od/id/3A1EE2F169DD3B8CE0531A570681DB5D1491/trial1.json/preview",
+    "title": "a better title"
+}


### PR DESCRIPTION
This PR addresses ODD-636 ("Complete support for NERDm annotations in PDR Publishing system") which will allow us to make manual modifications to NERDm records that are simultaneously being edited via MIDAS. (Annotations are edits to the metadata that would normally occur through the PDR publishing interface; these are merged with metadata that originate from MIDAS via the POD record.) This PR requires the [oar-metadata PR 27](https://github.com/usnistgov/oar-metadata/pull/27) which provides needed updates to the merging conventions.

To "turn on" annotation support (which was largely already implemented), I had to:
- Have the metadata server request NERDm records with annotations merged in
- Implement the place-holder `ensure_merged_annotations()` function to merge annotations into the final NERDm metadata sent to the preservation service
- incorporate the use of [new merge strategy conventions (from oar-metadata)](https://github.com/usnistgov/oar-metadata/pull/27)
- debug merging functionality in the `NISTBag` class