### PR TITLE
preservation service bug fix: correct failing async response message

### DIFF
--- a/docker/pdrtest/entrypoint.sh
+++ b/docker/pdrtest/entrypoint.sh
@@ -15,7 +15,7 @@ function launch_test_mdserv {
     workdir=$PWD/_ppmdserver-test-$$
     [ ! -e "$workdir" ] || rm -r $workdir
     mkdir -p $workdir
-    uwsgi --daemonize $workdir/uwsgi.log --plugin python --uwsgi-socket :9090 --wsgi-file scripts/ppmdserver-uwsgi.py --pidfile $OAR_HOME/var/mdserv.pid --set-ph oar_testmode_workdir=$workdir
+    uwsgi --daemonize $workdir/uwsgi.log --plugin python --enable-threads --uwsgi-socket :9090 --wsgi-file scripts/ppmdserver-uwsgi.py --pidfile $OAR_HOME/var/mdserv.pid --set-ph oar_testmode_workdir=$workdir
     echo starting nginx...
     sudo service nginx start
 }
@@ -61,7 +61,7 @@ case "$1" in
         
         curl http://localhost:8080/midas/3A1EE2F169DD3B8CE0531A570681DB5D1491/trial1.json \
              > mdserv_out.txt && \
-            python -c 'import sys, json; fd = open("mdserv_out.txt"); data = json.load(fd); sys.exit(0 if data["name"]=="tx1" else 21)' || \
+            python -c 'import sys, json; fd = open("mdserv_out.txt"); data = json.load(fd); sys.exit(0 if data["name"]=="tx1" else 12)' || \
             stat=$?
         set +x
 
@@ -71,22 +71,22 @@ case "$1" in
         set -x
         curl http://localhost:8080/preserve/ \
              > stat_out.txt; \
-             python -c 'import sys, json; fd = open("stat_out.txt"); data = json.load(fd); sys.exit(0 if data==["midas"] else 11)' || \
+             python -c 'import sys, json; fd = open("stat_out.txt"); data = json.load(fd); sys.exit(0 if data==["midas"] else 13)' || \
              stat=$?
         
         curl http://localhost:8080/preserve/midas/3A1EE2F169DD3B8CE0531A570681DB5D1491 \
              > stat_out.txt; \
-             python -c 'import sys, json; fd = open("stat_out.txt"); data = json.load(fd); sys.exit(0 if data["state"]=="ready" else 11)' || \
+             python -c 'import sys, json; fd = open("stat_out.txt"); data = json.load(fd); sys.exit(0 if data["state"]=="ready" else 14)' || \
              stat=$?
         
         curl http://localhost:8080/preserve/midas/goober \
              > stat_out.txt; \
-             python -c 'import sys, json; fd = open("stat_out.txt"); data = json.load(fd); sys.exit(0 if data["state"]=="not found" else 11)' || \
+             python -c 'import sys, json; fd = open("stat_out.txt"); data = json.load(fd); sys.exit(0 if data["state"]=="not found" else 15)' || \
              stat=$?; 
         
         curl -X PUT http://localhost:8080/preserve/midas/3A1EE2F169DD3B8CE0531A570681DB5D1491 \
              > stat_out.txt; \
-             python -c 'import sys, json; fd = open("stat_out.txt"); data = json.load(fd); sys.exit(0 if data["state"]=="successful" else 11)' || \
+             python -c 'import sys, json; fd = open("stat_out.txt"); data = json.load(fd); sys.exit(0 if data["state"]=="successful" else 16)' || \
              stat=$?; 
         set +x
         

--- a/python/nistoar/pdr/preserv/service/wsgi.py
+++ b/python/nistoar/pdr/preserv/service/wsgi.py
@@ -321,7 +321,7 @@ class Handler(object):
             else:
                 log.info("SIP preservation request in progress asynchronously: "+
                          sipid)
-                self.set_response(202, "SIP "+out.message)
+                self.set_response(202, "SIP "+out['message'])
 
             out = json.dumps(out)
 


### PR DESCRIPTION
A large data submission triggered asynchronous completion of the preservation request, triggering a failure in submitting the HTTP response message.  This was due to a bug in an incorrect retrieval on the message from the preservation status object.  This has been corrected.  

I note that despite this failure, the preservation request should have still continued to successful completion, but it did not.  With further investigation, it was found that the `uwsgi` launching program was missing a required `--enable-threads` argument.  Apart from the context of PDR unit testing, this is handle by [`oar-docker`](https://github.com/usnistgov/oar-docker/); thus there is [a companion PR for that repository (PR 100)](https://github.com/usnistgov/oar-docker/pull/100) as well.  