### PR TITLE
Preservation Service bug fix: allow for unicode when writing about.txt

### DIFF
--- a/python/nistoar/pdr/preserv/bagit/builder.py
+++ b/python/nistoar/pdr/preserv/bagit/builder.py
@@ -833,11 +833,12 @@ class BagBuilder(PreservationSystem):
                                  mf + ": " + str(ex), cause=ex)
 
         try:
+            ec = 'utf-8'
             with open(os.path.join(self.bagdir, "about.txt"), 'w') as fd:
                 print("This data package contain NIST Public Data\n", file=fd)
 
                 # title
-                print(textwrap.fill(podm['title'], 79), file=fd)
+                print(textwrap.fill(podm['title'].encode(ec), 79), file=fd)
 
                 # authors, if available
                 if 'authors' in nerdm:
@@ -870,12 +871,13 @@ class BagBuilder(PreservationSystem):
                             aus = auths[0] + " and " + auths[1]
                         else:
                             aus = " ".join(auths[:-1]) + ", and " + auths[-1]
-                        print( re.sub(r'=', ' ', textwrap.fill(aus)), file=fd )
+                        print( re.sub(r'=', ' ', textwrap.fill(aus.encode(ec))),
+                               file=fd )
 
                         i=1
                         for affil in affils:
-                           print(textwrap.fill("[{0}] {1}".format(i, affil)),
-                                 file=fd)
+                           print(textwrap.fill("[{0}] {1}".format(i, affil)
+                                                          .encode(ec)), file=fd)
 
                 # identifier(s)
                 if nerdm.get('doi'):
@@ -891,24 +893,26 @@ class BagBuilder(PreservationSystem):
                     cp = nerdm['contactPoint']
                     if cp.get('fn') and cp.get('hasEmail'):
                         aus = re.sub('^mailto:\s*', '', cp['hasEmail'])
-                        print("Contact: {0} ({1})".format(cp['fn'], aus),
-                              file=fd)
+                        print("Contact: {0} ({1})".format(cp['fn'], aus)
+                                                  .encode(ec), file=fd)
                     else:
                         print("Contact: {0}".format(cp.get('fn') or
                                                     cp.get('hasEmail')),
                               file=fd)
                     if 'postalAddress' in cp:
                         for line in cp['postalAddress']:
-                            print("         {0}".format(line.strip()), file=fd)
+                            print("         {0}".format(line.strip()).encode(ec),
+                                  file=fd)
                     if 'phoneNumber' in cp:
                         print("         Phone: {0}".format(
-                                                      cp['phoneNumber'].strip()),
+                                          cp['phoneNumber'].strip()).encode(ec),
                               file=fd)
                     fd.write("\n")
 
                 # description
                 if podm.get('description'):
-                    print( textwrap.fill(podm['description']), file=fd )
+                    print( textwrap.fill(podm['description'].encode(ec)),
+                           file=fd )
                     fd.write("\n")
 
                 # landing page
@@ -916,7 +920,8 @@ class BagBuilder(PreservationSystem):
                     print("More information:\nhttps://doi.org/" +
                           nerdm.get('doi'), file=fd)
                 elif nerdm.get('landingPage'):
-                    print("More information:\n" + nerdm.get('landingPage'),
+                    print("More information:\n" +
+                          nerdm.get('landingPage').encode(ec),
                           file=fd)
                 
         except OSError, ex:

--- a/python/nistoar/pdr/preserv/bagit/builder.py
+++ b/python/nistoar/pdr/preserv/bagit/builder.py
@@ -1127,7 +1127,7 @@ format(nerdm['title'])
                    not isinstance(vals, Sequence):
                     vals = [vals]
                 for val in vals:
-                    out = "{0}: {1}".format(name, val)
+                    out = "{0}: {1}".format(name, val.encode('utf-8'))
                     if len(out) > 79:
                         out = textwrap.fill(out, 79, subsequent_indent=' ')
                     print(out, file=fd)

--- a/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
@@ -948,6 +948,9 @@ class TestBuilder(test.TestCase):
         infofile = os.path.join(self.bag.bagdir,"bag-info.txt")
         self.assertFalse(os.path.exists(infofile))
 
+        # Make sure we can handle unicode data
+        data['Description'] = u"The data is at \u03bb = 20cm."
+        
         self.bag.write_baginfo_data(data, overwrite=True)
 
         self.assertTrue(os.path.exists(infofile))

--- a/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
@@ -1060,6 +1060,9 @@ class TestBuilder(test.TestCase):
         podfile = os.path.join(datadir, "_pod.json")
         with open(podfile) as fd:
             poddata = json.load(fd)
+
+        # Make sure we can handle unicode data
+        poddata['description'] += u" at \u03bb = 20cm."
         self.bag.add_ds_pod(poddata, convert=False)
 
         aboutfile = os.path.join(self.bag.bagdir,"about.txt")


### PR DESCRIPTION
We saw a failure in the preservation service when the description contained a unicode character.  This was traced to `nistoar.pdr.preserv.bagit.builder` when writing the `about.txt` file to the preservation bag: the unicode character was not getting properly encoded for the ASCII-formatted file, resulting in an `UnicodeEncodingError`.  This PR fixes this bug.  All metadata from the source POD and NERDm files are properly encoded for "utc-8" as they are written to the `about.txt` file.  The associated unit test was updated to inject a unicode character to test proper encoding.  

