### PR TITLE
multibag validation: fix check of self-deprecation

### DIFF
--- a/python/nistoar/pdr/preserv/bagit/validate/multibag.py
+++ b/python/nistoar/pdr/preserv/bagit/validate/multibag.py
@@ -168,7 +168,7 @@ class MultibagValidator(ValidatorBase):
                 parts = [p.strip() for p in val.split(',')]
                 if len(parts) > 2:
                     badfmt.append(val)
-                selfdeprecating = selfdeprecating or val == headver or \
+                selfdeprecating = selfdeprecating or parts[0] == headver or \
                                   (len(parts) > 1 and parts[1] == bag.name)
 
             t = self._issue("2-Head-Deprecates",


### PR DESCRIPTION
The Multibag BagIt Profile spec allows an info tag element called `Multibag-Head-Deprecates` that can be used to indicate the existence of previous versions of the aggregation.  The Multibag validator (`nistoar.pdr.preserv.bagit.validate`) checks to make sure a head bag doesn't claim to deprecate itself ("self-deprecation").  There was a bug in how this check was down, and this PR fixes it.  

