### PR TITLE
Fix/odd 658 pdr urls rewrite

### DIFF
--- a/angular/src/app/app-routing.module.ts
+++ b/angular/src/app/app-routing.module.ts
@@ -85,7 +85,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [ RouterModule.forRoot(routes) ],
+  imports: [ RouterModule.forRoot(routes,{ initialNavigation: 'enabled' }) ],
   exports: [ RouterModule ],
   providers: [ SearchResolve ]
 })

--- a/angular/src/app/app.module.ts
+++ b/angular/src/app/app.module.ts
@@ -32,7 +32,7 @@ import { DatacartComponent} from './datacart/datacart.component';
 import { CartService } from "./datacart/cart.service";
 import { AppShellNoRenderDirective } from './directives/app-shell-no-render.directive';
 import { AppShellRenderDirective } from './directives/app-shell-render.directive';
-
+import { FragmentPolyfillModule } from "./fragment-polyfill.module";
 /**
  * Initialize the configs for backend services
  */
@@ -52,7 +52,9 @@ const appInitializerFn = (appConfig: AppConfig) => {
     AppShellNoRenderDirective, AppShellRenderDirective 
   ],
   imports: [
-   
+    FragmentPolyfillModule.forRoot({
+      smooth: true
+  }),
     FormsModule, ReactiveFormsModule,
     AppRoutingModule, HttpClientModule,
     CommonModule, SharedModule, BrowserAnimationsModule, FormsModule,TooltipModule,

--- a/angular/src/app/fragment-polyfill.module.ts
+++ b/angular/src/app/fragment-polyfill.module.ts
@@ -1,0 +1,206 @@
+// Import the core angular services.
+import { ActivatedRoute } from "@angular/router";
+import { Directive } from "@angular/core";
+import { ElementRef } from "@angular/core";
+import { Inject } from "@angular/core";
+import { InjectionToken } from "@angular/core";
+import { ModuleWithProviders } from "@angular/core";
+import { NgModule } from "@angular/core";
+import { OnDestroy } from "@angular/core";
+import { OnInit } from "@angular/core";
+import { Subscription } from "rxjs/Subscription";
+
+// ----------------------------------------------------------------------------------- //
+// ----------------------------------------------------------------------------------- //
+
+export interface WindowScrollerOptions {
+	smooth: boolean;
+}
+
+export var WINDOW_SCROLLER_OPTIONS = new InjectionToken<WindowScrollerOptions>( "WindowScroller.Options" );
+
+// I provide the dependency-injection token for the window-scroller so that it can be
+// more easily injected into the FragmentTarget directive. This allows other developers
+// to provide an override that implements this Type without have to deal with the silly
+// @Inject() decorator.
+export abstract class WindowScroller {
+	abstract scrollIntoView( elementRef: ElementRef ) : void;
+}
+
+// I provide an implementation for scrolling a given Element Reference into view. By
+// default, it uses the native .scrollIntoView() method; but, it can be overridden to
+// use something like a jQuery plug-in, or other custom implementation.
+export class NativeWindowScroller implements WindowScroller {
+
+	private behavior: "auto" | "smooth";
+	private timer: any;
+
+	// I initialize the window scroller implementation.
+	public constructor( @Inject( WINDOW_SCROLLER_OPTIONS ) options: WindowScrollerOptions ) {
+
+		this.behavior = ( options.smooth ? "smooth" : "auto" );
+		this.timer = null;
+
+	}
+
+	// ---
+	// PUBLIC METHODS.
+	// ---
+
+	// I scroll the given ElementRef into the client's viewport.
+	public scrollIntoView( elementRef: ElementRef ) : void {
+
+		// NOTE: There is an odd race-condition that I cannot figure out. The initial
+		// scrollToView() will not work when the BROWSER IS REFRESHED. It will work if
+		// the page is opened in a new tab; it only fails on refresh (WAT?!). To fix this
+		// peculiarity, I'm putting the first scroll operation behind a timer. The rest
+		// of the scroll operations will initiate synchronously.
+		if ( this.timer ) {
+
+			this.doScroll( elementRef );
+
+		} else {
+
+			this.timer = setTimeout(
+				() : void => {
+
+					this.doScroll( elementRef );
+
+				},
+				0
+			);
+
+		}
+
+	}
+
+	// ---
+	// PRIVATE METHOD.
+	// ---
+
+	// I perform the scrolling of the viewport.
+	private doScroll( elementRef: ElementRef ) : void {
+
+		elementRef.nativeElement.scrollIntoView({
+			behavior: this.behavior,
+			block: "start"
+		});
+
+	}
+
+}
+
+// ----------------------------------------------------------------------------------- //
+// ----------------------------------------------------------------------------------- //
+
+@Directive({
+	selector: "[id], a[name]",
+	inputs: [ "id", "name" ]
+})
+export class FragmentTargetDirective implements OnInit, OnDestroy {
+
+	public id: string;
+	public name: string;
+
+	private activatedRoute: ActivatedRoute;
+	private elementRef: ElementRef;
+	private fragmentSubscription: Subscription;
+	private windowScroller: WindowScroller;
+
+	// I initialize the fragment-target directive.
+	constructor(
+		activatedRoute: ActivatedRoute,
+		elementRef: ElementRef,
+		windowScroller: WindowScroller
+		) {
+
+		this.activatedRoute = activatedRoute;
+		this.elementRef = elementRef;
+		this.windowScroller = windowScroller;
+
+		this.id = null;
+		this.fragmentSubscription = null;
+		this.name = null;
+
+	}
+
+	// ---
+	// PUBLIC METHODS.
+	// ---
+
+	// I get called once when the directive is being destroyed.
+	public ngOnDestroy() : void {
+
+		( this.fragmentSubscription ) && this.fragmentSubscription.unsubscribe();
+
+	}
+
+
+	// I get called once after the inputs have been bound for the first time.
+	public ngOnInit() : void {
+
+		this.fragmentSubscription = this.activatedRoute.fragment.subscribe(
+			( fragment: string ) : void => {
+
+				if ( ! fragment ) {
+
+					return;
+
+				}
+
+				if (
+					( fragment !== this.id ) &&
+					( fragment !== this.name )
+					) {
+
+					return;
+
+				}
+
+				this.windowScroller.scrollIntoView( this.elementRef );
+
+			}
+		);
+
+	}
+
+}
+
+// ----------------------------------------------------------------------------------- //
+// ----------------------------------------------------------------------------------- //
+
+interface ModuleOptions {
+	smooth?: boolean;
+}
+
+@NgModule({
+	exports: [
+		FragmentTargetDirective
+	],
+	declarations: [
+		FragmentTargetDirective
+	]
+})
+export class FragmentPolyfillModule {
+
+	static forRoot( options?: ModuleOptions ) : ModuleWithProviders {
+
+		return({
+			ngModule: FragmentPolyfillModule,
+			providers: [
+				{
+					provide: WINDOW_SCROLLER_OPTIONS,
+					useValue: {
+						smooth: ( ( options && options.smooth ) || false )
+					}
+				},
+				{
+					provide: WindowScroller,
+					useClass: NativeWindowScroller
+				}
+			]
+		});
+
+	}
+
+}

--- a/angular/src/app/landing/landing.component.html
+++ b/angular/src/app/landing/landing.component.html
@@ -140,10 +140,10 @@
               </div>
               <div class="ui-g">
                   <div class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-12">
-                      <div *ngIf="metadata != true && similarResources != true ">
+                      <div [hidden]="metadata">
                           <description-resources [record]="record" [files]="files" [distdownload]="distdownload" [isInternal]="isInternal" [filescount]="filescount" ></description-resources>
                       </div>
-                      <div *ngIf="metadata == true && similarResources != true ">
+                      <div [hidden]="!metadata">
                           <metadata-detail [record]="record" [serviceApi]="serviceApi" ></metadata-detail>
                       </div>
                   </div>
@@ -153,7 +153,6 @@
                               <button style="position:relative; float:right; background-color:#1E6BA1; " type="button" pButton icon="faa faa-close" (click)="closeDialog()"></button>
                           </p-header>
                           <span>Copy the recommended text to cite this resource:</span> <br><br>
-                          
                           <p contenteditable="false" style="font-size: 14px;" >{{ citeString }}</p>
                           <br>
                           <a target="citationsRecommendation" href="https://www.nist.gov/director/copyright-fair-use-and-licensing-statements-srd-data-and-software#citations">See also NIST Citation Recommendations</a>

--- a/angular/src/app/landing/landing.component.ts
+++ b/angular/src/app/landing/landing.component.ts
@@ -8,8 +8,8 @@ import 'rxjs/add/operator/map';
 import { Subscription } from 'rxjs/Subscription';
 import { environment } from '../../environments/environment';
 import { AppConfig } from '../shared/config-service/config.service';
-// import { ErrorComponent } from './error.component';
-// import { ResComponents, DataHierarchy } from "./datacomponents.component";
+import {  PLATFORM_ID, APP_ID, Inject } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 
 interface reference {
   refType? : string,
@@ -120,24 +120,14 @@ export class LandingComponent implements OnInit {
    */
   constructor(private route: ActivatedRoute, private el: ElementRef, 
               private titleService: Title, private appConfig : AppConfig, private router: Router
-              ) {
+              ,@Inject(PLATFORM_ID) private platformId: Object,
+              @Inject(APP_ID) private appId: string) {
     
     this.rmmApi = this.appConfig.getRMMapi();
     this.distApi = this.appConfig.getDistApi();
     this.landing = this.appConfig.getLandingBackend();
 
-    router.events.subscribe(s => {
-      if (s instanceof NavigationEnd) {
-        const tree = router.parseUrl(router.url);
-        if (tree.fragment) {
-          const element = document.querySelector("#" + tree.fragment);
-          
-          if (element) { 
-            element.scrollIntoView(true); 
-           }
-        }
-      }
-    });
+  
   }
 
    /**
@@ -229,17 +219,20 @@ updateMenu(){
   var descItem = this.createMenuItem ("Description","faa faa-arrow-circle-right",(event)=>{
     this.metadata = false; this.similarResources =false;
     this.router.navigate(['/od/id/', this.record.ediid],{fragment:'description'});
+    this.gotoSelection(); 
    },"");
 
   var refItem = this.createMenuItem ("References","faa faa-arrow-circle-right ",(event)=>{
     this.metadata = false; this.similarResources =false;
     this.router.navigate(['/od/id/', this.record.ediid],{fragment:'reference'});
+    this.gotoSelection(); 
     },'');
 
   var filesItem = this.createMenuItem("Data Access","faa faa-arrow-circle-right", (event)=>{
     this.metadata = false;
     this.similarResources =false;
     this.router.navigate(['/od/id/', this.record.ediid],{fragment:'dataAccess'});
+    this.gotoSelection(); 
     },'');
   var itemsMenu2:MenuItem[] = [];
       itemsMenu2.push(descItem);
@@ -294,7 +287,8 @@ updateMenu(){
    */
   ngOnInit() {
     // console.log("test:"+paramid);
-    var paramid = this.route.snapshot.paramMap.get('id');
+    this.searchValue = this.route.snapshot.paramMap.get('id');
+    console.log(this.searchValue);
     this.files =[];
       this.route.data.map(data => data.searchService )
        .subscribe((res)=>{
@@ -304,10 +298,30 @@ updateMenu(){
           this.onError(" There is an error");
           // throw new ErrorComponent(this.route);
        });
-    
   }
 
-  ngAfterViewInit(){}
+  gotoSelection(){
+    this.router.events.subscribe(s => {
+      if (s instanceof NavigationEnd) {
+        const tree = this.router.parseUrl(this.router.url);
+        if (tree.fragment) {
+          const element = document.querySelector("#" + tree.fragment);
+         console.log("Element"+tree.fragment);
+          if (element) { 
+            //element.scrollIntoView(true); 
+            element.scrollIntoView({behavior: "instant", block: "start", inline: "start"});
+           }
+        }
+      }
+    });
+  }
+
+  ngAfterViewInit(){
+    this.gotoSelection();
+    if (this.record != null && isPlatformBrowser(this.platformId) )  {
+      window.history.replaceState( {} , 'pdr/od/id/', '/od/id/'+this.searchValue );
+    }
+  }
 
   //This is to check if empty
   isEmptyObject(obj) {

--- a/angular/src/app/landing/metadata/metadata.component.ts
+++ b/angular/src/app/landing/metadata/metadata.component.ts
@@ -1,7 +1,5 @@
 import { Component, Input, Pipe,PipeTransform } from '@angular/core';
 
-
-
 @Component({
   selector: 'metadata-detail',
   template: `
@@ -11,7 +9,7 @@ import { Component, Input, Pipe,PipeTransform } from '@angular/core';
         <span style="">
           For more information about the metadata click on <a href="./nerdm">NERDm</a> documentation. 
         </span>
-        <button style="position:relative; float:right;" type="button" pButton icon="faa faa-file-code-o"
+        <button style="position:relative; float:right; background-color: #1371AE;" type="button" pButton icon="faa faa-file-code-o"
                 title="Get Metadata in JSON format." label="json" (click)="onjson()"></button>
         <br>
         <span style="font-size:8pt;color:grey;" >* item[number] indicates an array not a key name</span>

--- a/angular/src/app/landing/metadata/metadataview.component.ts
+++ b/angular/src/app/landing/metadata/metadataview.component.ts
@@ -1,6 +1,4 @@
 import {Component, Input} from '@angular/core';
-import { FieldsetModule } from 'primeng/primeng';
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 @Component ({
   selector: 'fieldset-view',
   moduleId: module.id,
@@ -10,7 +8,6 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
       <div *ngIf="!isArrayOrObject(node.value)" class="ui-g break-long-words" style="padding:0;">
         <div class="ui-g-2 ui-md-3 ui-lg-2 ui-sm-3" style="padding:0;">
           <span style="color:#1471AE; word-wrap: break-word;">{{ifIntegerThenitem(node.key)}}</span>
-          <!--span *ngIf="isInteger(node.key)" style="color:grey; word-wrap: break-word;">{{ifIntegerThenitem(node.key)}}</span-->
         </div>
         <div class="ui-g-10 ui-md-9 ui-lg-10 ui-sm-9" style="padding:0;">
           <span class="font10"> {{node.value}}</span>
@@ -28,8 +25,7 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 })
 export class MetadataView {
   @Input() entry:any[];
-  // [ngClass]="{'customlegend': isInteger(node.key), 'notcustomlegend':!isInteger(node.key) }"
-
+  
   isArray(obj : any ) {
     return Array.isArray(obj);
   }
@@ -65,4 +61,5 @@ export class MetadataView {
       return value;
     }
   }
+  
 }


### PR DESCRIPTION
This pull request has changes mainly for the issue 
[ODD-658](http://mml.nist.gov:8080/browse/ODD-658)
Added code to rewrite the url after landing page loading completes in browser. 
It removes /pdr part from URL to match with only /od/id pattern.

There are some changes with respect to 
[ODD-666](http://mml.nist.gov:8080/browse/ODD-666) 
Added new polyfill to jump to anchor section of url
e.g. http://localhost/od/id/<ediid>#dataaccess 
will jump to data access section of landing page.
The issue of going from metadata view to main page view section is still not completely resolved. 
But these changes are helpful for general anchors.

