### PR TITLE
Fix/odd 666 from metadata section to mainpage anchors

### DIFF
--- a/angular/src/app/landing/description/description.component.html
+++ b/angular/src/app/landing/description/description.component.html
@@ -1,4 +1,7 @@
-<h3 id="description" name="desscription"><b>Description</b></h3><br> 
+<div id="description">
+
+ <div [hidden]="metadata">
+<h3  name="desscription"><b>Description</b></h3><br> 
 <div contenteditable="true" id="recordDescription" class="well welldesc">
     <p  *ngFor="let topic of record['description']; let i =index">
         {{ record["description"][i] }}
@@ -19,9 +22,12 @@
     </span> 
 </div>
 <br>
+</div>
+</div>
                   
-<div class="font14">
-    <h3 id="dataAccess"><b>Data Access</b></h3><br> 
+<div id="dataAccess"> 
+    <div class="font14" [hidden]="metadata">
+    <h3><b>Data Access</b></h3><br> 
     <span style="margin-left:0em" *ngIf="record['accessLevel'] === 'public'">
         <i class="faa faa-globe"></i> These data are public. 
     </span>
@@ -44,7 +50,7 @@
                </i><br>
         </span>
     </span>
-</div> 
+
 <div *ngIf="files.length  > 0">        
     <br>
     <span><b>Files</b> </span>   
@@ -89,10 +95,15 @@
         </ng-template>
     </p-treeTable>
 </div>
-                         
+       
+</div> 
+</div>
+
+<div id="reference"> 
+<div [hidden]="metadata">
 <br>
 <div *ngIf="checkReferences()">
-    <h3 id="reference" name="reference"><b>References</b></h3>
+    <h3 ><b>References</b></h3>
     <span class="font14"  *ngIf="isDocumentedBy"> 
         This data is discussed in :
         <span  *ngFor="let refs of record['references']">
@@ -116,7 +127,9 @@
         </span>
     </span>
 </div>
-    <p-overlayPanel class="fileDialog" #op3 [dismissable]="true"  [showCloseIcon]="true" [style]="{'width':'400px'}" [appendTo]="'body'">
+</div> 
+</div>
+<p-overlayPanel class="fileDialog" #op3 [dismissable]="true"  [showCloseIcon]="true" [style]="{'width':'400px'}" [appendTo]="'body'">
         <div *ngIf="isNodeSelected" class="filecard">
             <div class="ui-g filesection">
                 <div *ngIf="fileNode" class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-10">

--- a/angular/src/app/landing/description/description.component.html
+++ b/angular/src/app/landing/description/description.component.html
@@ -1,6 +1,5 @@
 <div id="description">
-
- <div [hidden]="metadata">
+<div [hidden]="metadata">
 <h3  name="desscription"><b>Description</b></h3><br> 
 <div contenteditable="true" id="recordDescription" class="well welldesc">
     <p  *ngFor="let topic of record['description']; let i =index">
@@ -56,7 +55,6 @@
     <span><b>Files</b> </span>   
     
     <span>
-            <!-- pTooltip="'Download All Files' coming soon!" tooltipPosition="bottom" tooltipStyleClass="customToolTip" -->
         <a  class="faa faa-file-archive-o" style="color:grey; margin-left:0.5em; " title="Download All Files" ></a>
     </span>
     <!-- <a href="javascript:;" (click)="addFilesToCart()" class="faa faa-cart-plus " style="margin-left:0.5em; color:#1E6BA1;" title="Add All files to datacart" ></a> -->
@@ -94,8 +92,7 @@
             </tr>            
         </ng-template>
     </p-treeTable>
-</div>
-       
+</div>   
 </div> 
 </div>
 

--- a/angular/src/app/landing/description/description.component.html
+++ b/angular/src/app/landing/description/description.component.html
@@ -34,7 +34,7 @@
     </span>
     <span  *ngIf="record['landingPage'] && record['landingPage'].indexOf('/od/id') === -1 ">
         For more information, please visit the
-         <a href="record.landingPage">home page</a>.
+         <a target="_blank" href="{{ record['landingPage'] }}">home page</a>.
     </span> 
     <span style="margin-left:0em" *ngIf="isAccessPage">
         <br>Data is available via the following locations: 
@@ -45,7 +45,7 @@
         </span>
     </span>
 </div> 
-<div *ngIf="files.length != 0">        
+<div *ngIf="files.length  > 0">        
     <br>
     <span><b>Files</b> </span>   
     
@@ -70,7 +70,7 @@
             </th>
           </tr>
         </ng-template>
-        <ng-template pTemplate="body" let-rowNode let-rowData="rowData"  let-columns="columns">
+        <ng-template  pTemplate="body" let-rowNode let-rowData="rowData"  let-columns="columns">
             <tr [ttSelectableRow]="rowNode">
                 <td><p-treeTableToggler [rowNode]="rowNode"></p-treeTableToggler>
                     <a (click)="openDetails($event,rowData,op3)"> {{rowData.name}} </a>
@@ -119,7 +119,7 @@
     <p-overlayPanel class="fileDialog" #op3 [dismissable]="true"  [showCloseIcon]="true" [style]="{'width':'400px'}" [appendTo]="'body'">
         <div *ngIf="isNodeSelected" class="filecard">
             <div class="ui-g filesection">
-                <div class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-10">
+                <div *ngIf="fileNode" class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-10">
                     <span class="font8" style="color:grey" >
                         <span *ngIf="fileNode.filetype == 'nrdp:DataFile' ">Selected File</span>
                         <span *ngIf="fileNode.filetype == 'nrdp:ChecksumFile' ">Selected Checksum File</span>

--- a/angular/src/app/landing/description/description.component.ts
+++ b/angular/src/app/landing/description/description.component.ts
@@ -137,6 +137,7 @@ checkReferences(){
  }
  ngOnInit(){
     this.cdr.detectChanges();
+    if(this.files.length != 0)
     this.files  =<TreeNode[]>this.files[0].data;
     this.cols = [
         { field: 'name', header: 'Name', width: '60%' },

--- a/angular/src/app/landing/description/description.component.ts
+++ b/angular/src/app/landing/description/description.component.ts
@@ -22,6 +22,7 @@ export class DescriptionComponent {
  @Input() distdownload: string;
  @Input() editContent: boolean;
  @Input() filescount: number;
+ @Input() metadata: boolean;
 
  addAllFileSpinner:boolean = false;
  fileDetails:string = '';
@@ -157,9 +158,7 @@ checkReferences(){
  ngOnChanges(){
     this.checkAccesspages();
  }
- editDecription(){
 
- }
  //Datacart related code
  addFilesToCart() {
 

--- a/angular/src/app/landing/description/description.component.ts
+++ b/angular/src/app/landing/description/description.component.ts
@@ -1,12 +1,8 @@
-import { Component, Input,ChangeDetectorRef ,Inject, Injectable,PLATFORM_ID} from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { Component, Input,ChangeDetectorRef } from '@angular/core';
 import { TreeNode} from 'primeng/api';
 import { CartService} from '../../datacart/cart.service';
 import { Data} from '../../datacart/data';
-import {OverlayPanelModule} from 'primeng/overlaypanel';
 import { OverlayPanel} from 'primeng/overlaypanel';
-import {DialogModule} from 'primeng/dialog';
-import { CommonModule } from "@angular/common";
 
 @Component({
   moduleId: module.id,
@@ -40,27 +36,6 @@ export class DescriptionComponent {
  selectedNode : TreeNode;
  cols: any[];
  fileNode: TreeNode;
- 
-
-//  onNodeSelect(event, sdata){
-//      alert("Node select ::"+sdata.name);
-//  }
-// nodeSelect(event) {
-//     var test = this.getComponentDetails(this.record["components"],event.node.data);
-//     let i =0;
-//     this.fileDetails = '';
-//     for(let t of test){
-//         this.isFileDetails = true;
-//         this.fileDetails = t;
-//     }
-//     alert("TEST");
-// }
-
-// getComponentDetails(data,filepath) {
-//   return data.filter(
-//       function(data){return data.filepath == filepath }
-//   );
-// }
 
 keys() : Array<string> {
     return Object.keys(this.fileDetails);
@@ -230,11 +205,6 @@ addtoCart(fileName:string,fileSize:number,fileFormat:string,
  }
 
  display: boolean = false;
-
-//  showDialog(selectedNode: TreeNode) {
-//      this.selectedNode = selectedNode;
-//      this.display = true;
-//  }
  /**
    * Function to display bytes in appropriate format.
    **/ 
@@ -245,6 +215,6 @@ addtoCart(fileName:string,fileSize:number,fileFormat:string,
      e=["Bytes","kB","MB","GB","TB","PB","EB","ZB","YB"],
      f=Math.floor(Math.log(bytes)/Math.log(base));
     return (bytes/Math.pow(base,f)).toFixed(d)+" "+e[f]
-}
+    }
  
 }

--- a/angular/src/app/landing/keyvalue.pipe.spec.ts
+++ b/angular/src/app/landing/keyvalue.pipe.spec.ts
@@ -4,11 +4,9 @@ describe('KeyValuePipe', () => {
   // This pipe is a pure, stateless function so no need for BeforeEach
   let pipe = new KeyValuePipe();
   let entry = { tag: 'Physics: Optical physics', type: "Concept"};
-  
   let expected = { key: 'tag', value: 'Physics: Optical physics' } ;
   it('transforms entry to key value', () => {
-       let trans = JSON.stringify(pipe.transform(entry)[0]);
-        
+       let trans = JSON.stringify(pipe.transform(entry)[0]); 
        expect(trans).toBe(JSON.stringify(expected));
   });
 });

--- a/angular/src/app/landing/landing.component.css
+++ b/angular/src/app/landing/landing.component.css
@@ -216,6 +216,7 @@
   height: 1.5em;
 }
 
+
 :host /deep/  .ui-dialog .ui-dialog-titlebar{
   background-color: #f1f1f1;
   color: #212121;

--- a/angular/src/app/landing/landing.component.html
+++ b/angular/src/app/landing/landing.component.html
@@ -1,4 +1,4 @@
-<!-- <style id="antiClickjack">
+<style id="antiClickjack">
     body {
       display: none !important;
     }
@@ -12,7 +12,7 @@
     } else {
       top.location = self.location;
     }
-  </script> -->
+  </script>
   
   <div class="ui-grid ui-grid-responsive ui-grid-pad center">
   <div class="card landingcard">

--- a/angular/src/app/landing/landing.component.html
+++ b/angular/src/app/landing/landing.component.html
@@ -140,12 +140,8 @@
               </div>
               <div class="ui-g">
                   <div class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-12">
-                      <div [hidden]="metadata">
-                          <description-resources [record]="record" [files]="files" [distdownload]="distdownload" [isInternal]="isInternal" [filescount]="filescount" ></description-resources>
-                      </div>
-                      <div [hidden]="!metadata">
-                          <metadata-detail [record]="record" [serviceApi]="serviceApi" ></metadata-detail>
-                      </div>
+                     <description-resources  [record]="record" [files]="files" [distdownload]="distdownload" [isInternal]="isInternal" [filescount]="filescount" [metadata]="metadata" ></description-resources> 
+                     <metadata-detail  [record]="record" [serviceApi]="serviceApi" [metadata]="metadata"  ></metadata-detail>    
                   </div>
                   <div *ngIf="record.length !== 0">
                       <p-dialog  class="citationDialog" [closable]="false" [(visible)]="display" modal="modal" width="550" height="330" responsive="true" #citeDialog>

--- a/angular/src/app/landing/landing.component.html
+++ b/angular/src/app/landing/landing.component.html
@@ -148,12 +148,13 @@
                       </div>
                   </div>
                   <div *ngIf="record.length !== 0">
-                      <p-dialog  class="citationDialog" [closable]="false" [(visible)]="display" modal="modal" width="600" height="350" responsive="true" #citeDialog>
+                      <p-dialog  class="citationDialog" [closable]="false" [(visible)]="display" modal="modal" width="550" height="330" responsive="true" #citeDialog>
                           <p-header> Citation
                               <button style="position:relative; float:right; background-color:#1E6BA1; " type="button" pButton icon="faa faa-close" (click)="closeDialog()"></button>
                           </p-header>
-                          <span>Copy the recommended text to cite this resource:</span> <br><br>
+                          <span><b>Copy the recommended text to cite this resource </b></span> <br><br>
                           <p contenteditable="false" style="font-size: 14px;" >{{ citeString }}</p>
+                         
                           <br>
                           <a target="citationsRecommendation" href="https://www.nist.gov/director/copyright-fair-use-and-licensing-statements-srd-data-and-software#citations">See also NIST Citation Recommendations</a>
                       </p-dialog>

--- a/angular/src/app/landing/landing.component.ts
+++ b/angular/src/app/landing/landing.component.ts
@@ -183,6 +183,7 @@ createMenuItem(label :string, icon:string, command: any, url : string ){
       testItem.command = command;
   if(url !== '')
       testItem.url = url;
+      testItem.target ="_blank";
   return testItem;
 }
 

--- a/angular/src/app/landing/landing.component.ts
+++ b/angular/src/app/landing/landing.component.ts
@@ -236,9 +236,10 @@ updateMenu(){
     },'');
   var itemsMenu2:MenuItem[] = [];
       itemsMenu2.push(descItem);
-      if(this.files.length !== 0)
+      if(this.files.length !== 0 || (this.record['landingPage'] && this.record['landingPage'].indexOf('/od/id') === -1 ))
         itemsMenu2.push(filesItem);
-      itemsMenu2.push(refItem);
+      if(this.record['references'])
+        itemsMenu2.push(refItem);
  
   this.rightmenu = [ { label: 'Go To ..', items: itemsMenu2},
       { label: 'Record Details', items: itemsMenu },

--- a/angular/src/app/landing/landing.component.ts
+++ b/angular/src/app/landing/landing.component.ts
@@ -114,6 +114,7 @@ export class LandingComponent implements OnInit {
     displayContact: boolean = false; 
     private meta: Meta;
     private newer : reference = {};  
+    navigationSubscription : any;
   /**
    * Creates an instance of the SearchPanel
    *
@@ -126,8 +127,6 @@ export class LandingComponent implements OnInit {
     this.rmmApi = this.appConfig.getRMMapi();
     this.distApi = this.appConfig.getDistApi();
     this.landing = this.appConfig.getLandingBackend();
-
-  
   }
 
    /**
@@ -213,6 +212,7 @@ updateMenu(){
     this.metadata = true;
     this.similarResources =false;
     this.router.navigate(['/od/id/', this.record.ediid],{fragment:'metadata'});
+    this.gotoSelection(); 
   },'');
     itemsMenu.push(metaItem);
     itemsMenu.push(metadata);   
@@ -310,15 +310,17 @@ updateMenu(){
           const element = document.querySelector("#" + tree.fragment);
          console.log("Element"+tree.fragment);
           if (element) { 
-            //element.scrollIntoView(true); 
-            element.scrollIntoView({behavior: "instant", block: "start", inline: "start"});
-           }
+            //element.scrollIntoView(); 
+            setTimeout(() => {
+            element.scrollIntoView({behavior: "smooth", block: "start", inline: "nearest"});
+           }, 1);
         }
       }
-    });
+    }});
   }
 
   ngAfterViewInit(){
+    console.log("after view init");
     this.gotoSelection();
     if (this.record != null && isPlatformBrowser(this.platformId) )  {
       window.history.replaceState( {} , 'pdr/od/id/', '/od/id/'+this.searchValue );

--- a/angular/src/app/landing/landing.component.ts
+++ b/angular/src/app/landing/landing.component.ts
@@ -145,7 +145,7 @@ export class LandingComponent implements OnInit {
     }  
     this.type = this.record['@type'];
     this.titleService.setTitle(this.record['title']);
-    // this.meta.addTag({ "testdescription": this.record['description'] });
+    //this.meta.addTag({ "testdescription": this.record['description'] });
     //let dh = new ResComponents(this.record['components']).dataHierarchy();
     this.createNewDataHierarchy();
     if(this.record['doi'] !== undefined && this.record['doi'] !== "" )
@@ -155,8 +155,7 @@ export class LandingComponent implements OnInit {
      this.assessNewer();
     
     this.updateMenu();
-    //this.updateLeftMenu();
-    //this.updateRightMenu();
+
   }
 
   /**
@@ -288,9 +287,9 @@ updateMenu(){
    * Get the params OnInit
    */
   ngOnInit() {
-    // console.log("test:"+paramid);
+  
     this.searchValue = this.route.snapshot.paramMap.get('id');
-    console.log(this.searchValue);
+   
     this.files =[];
       this.route.data.map(data => data.searchService )
        .subscribe((res)=>{
@@ -308,7 +307,6 @@ updateMenu(){
         const tree = this.router.parseUrl(this.router.url);
         if (tree.fragment) {
           const element = document.querySelector("#" + tree.fragment);
-         console.log("Element"+tree.fragment);
           if (element) { 
             //element.scrollIntoView(); 
             setTimeout(() => {
@@ -320,7 +318,6 @@ updateMenu(){
   }
 
   ngAfterViewInit(){
-    console.log("after view init");
     this.gotoSelection();
     if (this.record != null && isPlatformBrowser(this.platformId) )  {
       window.history.replaceState( {} , 'pdr/od/id/', '/od/id/'+this.searchValue );
@@ -335,12 +332,10 @@ updateMenu(){
   filescount : number = 0;
   createNewDataHierarchy(){
     var testdata = {}
-    // console.log(dnode);
-    // console.log(this.record['components']);
     if(this.record['components'] != null){
-    testdata["data"] = this.arrangeIntoTree(this.record['components']);
-   
-    this.files.push(testdata);}
+      testdata["data"] = this.arrangeIntoTree(this.record['components']);
+      this.files.push(testdata);
+    }
   }
   //This is to create a tree structure
   private arrangeIntoTree(paths) {
@@ -413,7 +408,6 @@ updateMenu(){
       }
       i= i+1;
    });
-   //console.log("Return tree"+ JSON.stringify(tree));
    return tree;
   }
 

--- a/angular/src/app/landing/landing.component.ts
+++ b/angular/src/app/landing/landing.component.ts
@@ -333,9 +333,10 @@ updateMenu(){
     var testdata = {}
     // console.log(dnode);
     // console.log(this.record['components']);
+    if(this.record['components'] != null){
     testdata["data"] = this.arrangeIntoTree(this.record['components']);
    
-    this.files.push(testdata);
+    this.files.push(testdata);}
   }
   //This is to create a tree structure
   private arrangeIntoTree(paths) {
@@ -344,7 +345,7 @@ updateMenu(){
     // This example uses the underscore.js library.
     var i = 0;
     var tempfiletest = "";
-   
+    
     paths.forEach((path) => { 
      
       

--- a/angular/src/app/landing/metadata/metadata.component.ts
+++ b/angular/src/app/landing/metadata/metadata.component.ts
@@ -3,9 +3,9 @@ import { Component, Input, Pipe,PipeTransform } from '@angular/core';
 @Component({
   selector: 'metadata-detail',
   template: `
-    <div class="ui-g" #metadata id="metadata">
-     <div class = "ui-g-12 ui-md-12 ui-lg-12 ui-sm-12" >
-       <h3 id="metadata" name="metadata"><b>Metadata</b></h3>
+    <div class="ui-g">
+     <div [hidden]="!metadata" class = "ui-g-12 ui-md-12 ui-lg-12 ui-sm-12" >
+       <h3><b>Metadata</b></h3>
         <span style="">
           For more information about the metadata click on <a href="./nerdm">NERDm</a> documentation. 
         </span>
@@ -24,7 +24,7 @@ export class MetadataComponent {
   
   @Input() record: any[];
   @Input() serviceApi : string;
-   
+  @Input() metadata : boolean;
   ngOnInit() {
       delete this.record["_id"];
   }

--- a/angular/src/app/shared/footbar/footbar.component.html
+++ b/angular/src/app/shared/footbar/footbar.component.html
@@ -1,4 +1,4 @@
-<!-- <style id="antiClickjack">
+<style id="antiClickjack">
   body {
     display: none !important;
   }
@@ -10,7 +10,7 @@
   } else {
     top.location = self.location;
   }
-</script> -->
+</script>
 
 <div id="footer" class="region region-footer ">
   <div class="footer__inner">

--- a/angular/src/assets/environment.json
+++ b/angular/src/assets/environment.json
@@ -4,5 +4,5 @@
     "PDRAPI":  "http://localhost/od/id/",
     "DISTAPI": "http://localhost/disturl/",
     "METAPI":  "http://localhost/metaurl/",
-    "LANDING": "http://oardev.nist.gov/rmm/"
+    "LANDING": "http://localhost:8085/rmm/"
 }


### PR DESCRIPTION
This pull request mostly addresses the issue with the metadata view and anchors on main page.
The issue is 
 If User is in metadata view and wants to go to reference section on main page. After clicking on reference link on the menu, it still goes to start of the page. 
I reorganized some anchors and cleared the code. Since when metadata view is clicked all other elements are hidden, instead of keeping anchors inside hidden divs, separated them and kept anchors outside. Updated scrollintoview function as well.
The issue is in described in Jira ticket [ODD-666](http://mml.nist.gov:8080/browse/ODD-666)

Other than this main issue: following changes are implemented
1. Added anticlickjack code back to pages
2. Cleaned up some stale code 
3.  Removed unnecessary log statements