### PR TITLE
LPS: Fix errors in looking for a newer version of a dataset

### DIFF
--- a/angular/src/app/landing/landing.component.ts
+++ b/angular/src/app/landing/landing.component.ts
@@ -526,10 +526,16 @@ updateMenu(){
     if (this.record['version'] && this.record['versionHistory']) {
         let history = this.record['versionHistory'];
         history.sort(compare_histories);
+        
+        var thisversion = this.record['version'];
+        var p = thisversion.indexOf('+');    // presence indicates this is an update
+        if (p >= 0) thisversion = thisversion.substring(0, p)   // strip off +...
+        
         if (compare_histories(history[history.length-1],
-                              { version: this.record['version'], 
+                              { version: thisversion,
                                 issued: this.record['modified']  }) > 0)
         {
+            // this version is older than the latest one in the history
             this.newer = history[history.length-1];
             if (! this.newer['refid']) this.newer['refid'] = this.newer['@id'];
             this.newer['label'] = this.newer['version'];

--- a/angular/src/app/landing/landing.component.ts
+++ b/angular/src/app/landing/landing.component.ts
@@ -29,21 +29,22 @@ function compare_versions(a: string, b: string) : number {
       }
   }
   aflds = aflds.map(toint);
-  aflds = bflds.map(toint);
-   let i :number = 0;
+  bflds = bflds.map(toint);
+  let i :number = 0;
   let out : number = 0;
   for (i=0; i < aflds.length && i < bflds.length; i++) {
       if (typeof aflds[i] === "number") {
           if (typeof bflds[i] === "number") {
               out = <number>aflds[i] - <number>bflds[i];
-              if (out == 0) continue;
+              if (out != 0) return out;
           }
           else 
               return +1;
       }
       else if (typeof bflds[i] === "number") 
           return -1;
-      return a.localeCompare(b);
+      else
+          return a.localeCompare(b);
   }
   return out;
 }


### PR DESCRIPTION
This PR fixes the `assessNewer()` function in the landing page service (LPS) which examines the version information in the resource metadata to determine if there exists a newer version that the user should know about.  If there is, a message to this affect appears on the page (just under the version label).  This was not working correctly, causing the message to display when looking at the latest version.

This fixes the bug reported as part of the review of [oar-docker PR#102](https://github.com/usnistgov/oar-docker/pull/102) by @GRG2; that PR tests, among other things, the new server-side-generated landing pages.