### PR TITLE
Preservation Service: add support for X-HTTP-Method-Override for MIDAS

### DIFF
--- a/docker/pdrtest/entrypoint.sh
+++ b/docker/pdrtest/entrypoint.sh
@@ -88,6 +88,11 @@ case "$1" in
              > stat_out.txt; \
              python -c 'import sys, json; fd = open("stat_out.txt"); data = json.load(fd); sys.exit(0 if data["state"]=="successful" else 16)' || \
              stat=$?; 
+        
+        curl -X GOOB -H 'X-HTTP-Method-Override: GET'  http://localhost:8080/preserve/midas/3A1EE2F169DD3B8CE0531A570681DB5D1491 \
+             > stat_out.txt; \
+             python -c 'import sys, json; fd = open("stat_out.txt"); data = json.load(fd); sys.exit(0 if data["state"]=="successful" else 17)' || \
+             stat=$?; 
         set +x
         
         [ "$stat" != "0" ] && {

--- a/python/nistoar/pdr/preserv/service/wsgi.py
+++ b/python/nistoar/pdr/preserv/service/wsgi.py
@@ -86,6 +86,11 @@ class Handler(object):
         self._start(stat, self._hdr.items())
 
     def handle(self):
+        # This accommadates MIDAS whose HTTP client api is unable to
+        # submit against some standard methods.  
+        if self._env.get('HTTP_X_HTTP_METHOD_OVERRIDE'):
+            self._meth = self._env.get('HTTP_X_HTTP_METHOD_OVERRIDE')
+
         meth_handler = 'do_'+self._meth
 
         path = self._env.get('PATH_INFO', '/').strip('/')

--- a/python/tests/nistoar/pdr/preserv/service/test_wsgi.py
+++ b/python/tests/nistoar/pdr/preserv/service/test_wsgi.py
@@ -371,10 +371,11 @@ class TestApp(test.TestCase):
         self.assertGreater(len(self.resp), 0)
         self.assertIn("403", self.resp[0])
 
-    def test_good_patch(self):
+    def test_patch_override(self):
         req = {
             'PATH_INFO': '/midas/'+self.midasid+'/',
-            'REQUEST_METHOD': 'PATCH'
+            'REQUEST_METHOD': 'POST',
+            'HTTP_X_HTTP_METHOD_OVERRIDE': 'PATCH'
         }
 
         body = self.svc(req, self.start)
@@ -389,7 +390,8 @@ class TestApp(test.TestCase):
         self.resp = []
         req = {
             'PATH_INFO': '/midas/',
-            'REQUEST_METHOD': 'GET'
+            'REQUEST_METHOD': 'GOOB',
+            'HTTP_X_HTTP_METHOD_OVERRIDE': 'GET'
         }
 
         body = self.svc(req, self.start)


### PR DESCRIPTION
This PR addresses a special issue with the MIDAS interface (and addresses a request from Chris).  MIDAS, as a Java application on the backend, uses the default Java 8 URL classes to connect to a service; these default classes do _not_, as is, support the lesser-used (though standard) HTTP methods like PATCH.  The simplest work-around is to use the [X-HTTP-Method-Override header variable](https://stackoverflow.com/questions/25163131/httpurlconnection-invalid-http-method-patch); however, this variable must be explicitly supported on the server.  This PR adds that support which allows a POST support to be converted to a PATCH.
