### PR TITLE
Preservation Service Bug fix: don't lose filesizes while publishing update

### DIFF
--- a/python/nistoar/pdr/preserv/bagit/bag.py
+++ b/python/nistoar/pdr/preserv/bagit/bag.py
@@ -187,6 +187,19 @@ class NISTBag(PreservationSystem):
             self._mergerfact = MergerFactory(MERGECONF)
         return self._mergerfact.make_merger(stratconvname, typename)
 
+    def annotations_metadata_for(self, filepath):
+        """
+        return the component metadata saved as annotations for a given path to 
+        a component.
+        """
+        annotfile = self.annotations_file_for(filepath)
+        if not os.path.exists(os.path.dirname(annotfile)):
+            raise ComponentNotFound("Component not found: " + filepath, 
+                                    os.path.basename(self._name))
+        if not os.path.exists(annotfile):
+            return OrderedDict()
+        return self.read_nerd(annotfile)
+
     def nerdm_record(self, merge_annots=None):
         """
         return a full NERDm resource record for the data in this bag.

--- a/python/nistoar/pdr/publish/mdserv/serv.py
+++ b/python/nistoar/pdr/publish/mdserv/serv.py
@@ -284,7 +284,7 @@ class PrePubMetadataService(PublishSystem):
 
         # determine the MIME type to send data as
         bag = NISTBag(bagger.bagdir, True)
-        dfmd = bag.nerd_metadata_for(filepath)
+        dfmd = bag.nerd_metadata_for(filepath, merge_annots=True)
         if 'mediaType' in dfmd and dfmd['mediaType']:
             mt = str(dfmd['mediaType'])
         else:

--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
@@ -190,7 +190,6 @@ class TestMIDASMetadataBaggerMixed(test.TestCase):
         destpath = os.path.join("trial3", "trial3a.json")
         dlurl = "https://data.nist.gov/od/ds/gurn/"+destpath
         dfile = os.path.join(self.upldir, self.midasid[32:], destpath)
-        pdb.set_trace()
         self.bagr.ensure_file_metadata(dfile, destpath)
 
         mdfile = os.path.join(self.bagdir, 'metadata', destpath, "nerdm.json")

--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
@@ -111,7 +111,6 @@ class TestMIDASMetadataBaggerMixed(test.TestCase):
     def test_ensure_res_metadata(self):
         self.assertFalse(os.path.exists(self.bagdir))
         self.assertIsNone(self.bagr.inpodfile)
-        
         self.bagr.ensure_res_metadata()
         
         self.assertTrue(os.path.exists(self.bagdir))
@@ -191,6 +190,7 @@ class TestMIDASMetadataBaggerMixed(test.TestCase):
         destpath = os.path.join("trial3", "trial3a.json")
         dlurl = "https://data.nist.gov/od/ds/gurn/"+destpath
         dfile = os.path.join(self.upldir, self.midasid[32:], destpath)
+        pdb.set_trace()
         self.bagr.ensure_file_metadata(dfile, destpath)
 
         mdfile = os.path.join(self.bagdir, 'metadata', destpath, "nerdm.json")

--- a/python/tests/nistoar/pdr/preserv/bagger/test_prepupd.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_prepupd.py
@@ -131,7 +131,7 @@ class TestSimServices(test.TestCase):
 
         data = cli.get_json("ABCDEFG/_aip/_v/latest/_head")
         self.assertEqual(data, {"aipid": "ABCDEFG", "sinceVersion": "2", 
-                                "contentLength": 9715, "multibagSequence" : 4,
+                                "contentLength": 10075, "multibagSequence" : 4,
                                 "multibagProfileVersion" : "0.4",
                                 "contentType": "application/zip",
                                 "serialization": "zip",
@@ -140,7 +140,7 @@ class TestSimServices(test.TestCase):
 
         data = cli.get_json("ABCDEFG/_aip/_v/1/_head")
         self.assertEqual(data, {"aipid": "ABCDEFG", "sinceVersion": "1", 
-                                "contentLength": 9715, "multibagSequence" : 2,
+                                "contentLength": 10075, "multibagSequence" : 2,
                                 "multibagProfileVersion" : "0.4",
                                 "contentType": "application/zip",
                                 "serialization": "zip",

--- a/python/tests/nistoar/pdr/preserv/bagit/test_bag.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/test_bag.py
@@ -63,6 +63,32 @@ class TestNISTBag(test.TestCase):
         self.assertEqual(self.bag.nerd_file_for("trial3/trial3a.json"),
                          os.path.join(bagdir, "metadata", "trial3", 
                                       "trial3a.json", "nerdm.json"))
+
+    def test_annotations_file_for(self):
+        self.assertEqual(self.bag.annotations_file_for(""),
+                         os.path.join(bagdir, "metadata", "annot.json"))
+        self.assertEqual(self.bag.annotations_file_for("trial1.json"),
+                         os.path.join(bagdir, "metadata", "trial1.json",
+                                      "annot.json"))
+        self.assertEqual(self.bag.annotations_file_for("trial2.json"),
+                         os.path.join(bagdir, "metadata", "trial2.json",
+                                      "annot.json"))
+        self.assertEqual(self.bag.annotations_file_for("trial3"),
+                         os.path.join(bagdir, "metadata", "trial3",
+                                      "annot.json"))
+        self.assertEqual(self.bag.annotations_file_for("trial3/trial3a.json"),
+                         os.path.join(bagdir, "metadata", "trial3", 
+                                      "trial3a.json", "annot.json"))
+
+    def test_annotations_metadata_for(self):
+        data = self.bag.annotations_metadata_for("")
+        self.assertEqual(len(data), 0)  # empty
+        data = self.bag.annotations_metadata_for("trial1.json")
+        self.assertEqual(len(data), 0)  # empty
+        data = self.bag.annotations_metadata_for("trial2.json")
+        self.assertIn("size", data)
+        self.assertIn("checksum", data)
+        self.assertNotIn("title", data)
         
     def test_nerd_metadata_for(self):
         data = self.bag.nerd_metadata_for("")

--- a/python/tests/nistoar/pdr/preserv/data/samplembag/metadata/trial2.json/annot.json
+++ b/python/tests/nistoar/pdr/preserv/data/samplembag/metadata/trial2.json/annot.json
@@ -1,0 +1,10 @@
+{
+    "size": 69,
+    "checksum": {
+        "hash": "d5eed5092f409bce7e88d057eb98b376534b372f9f6b7c14e57744b259c65d35",
+        "algorithm": {
+            "tag": "sha256",
+            "@type": "Thing"
+        }
+    }
+}

--- a/python/tests/nistoar/pdr/publish/mdserv/test_serv.py
+++ b/python/tests/nistoar/pdr/publish/mdserv/test_serv.py
@@ -54,12 +54,27 @@ def tearDownModule():
         loghdlr = None
     rmtmpdir()
 
+def to_dict(odict):
+    out = dict(odict)
+    for prop in out:
+        if isinstance(out[prop], OrderedDict):
+            out[prop] = to_dict(out[prop])
+        if isinstance(out[prop], (list, tuple)):
+            for i in range(len(out[prop])):
+                if isinstance(out[prop][i], OrderedDict):
+                    out[prop][i] = to_dict(out[prop][i])
+    return out
 
 class TestPrePubMetadataService(test.TestCase):
 
     testsip = os.path.join(datadir, "midassip")
     midasid = '3A1EE2F169DD3B8CE0531A570681DB5D1491'
 
+    def assertEqualOD(self, od1, od2, message=None):
+        d1 = to_dict(od1)
+        d2 = to_dict(od2)
+        self.assertEqual(d1, od2, message)
+    
     def setUp(self):
         self.tf = Tempfiles()
         self.workdir = self.tf.mkdir("mdserv")
@@ -258,7 +273,7 @@ class TestPrePubMetadataService(test.TestCase):
 
         # resolve_id() needs to be indepodent
         data = self.srv.resolve_id(self.midasid)
-        self.assertEqual(data, mdata)
+        self.assertEqualOD(data, mdata)
 
         with self.assertRaises(serv.IDNotFound):
             self.srv.resolve_id("asldkfjsdalfk")

--- a/python/tests/nistoar/pdr/publish/mdserv/test_serv_update.py
+++ b/python/tests/nistoar/pdr/publish/mdserv/test_serv_update.py
@@ -121,6 +121,18 @@ def stopServices():
     except:
         pass
 
+def to_dict(odict):
+    out = dict(odict)
+    for prop in out:
+        if isinstance(out[prop], OrderedDict):
+            out[prop] = to_dict(out[prop])
+        if isinstance(out[prop], (list, tuple)):
+            for i in range(len(out[prop])):
+                if isinstance(out[prop][i], OrderedDict):
+                    out[prop][i] = to_dict(out[prop][i])
+    return out
+
+
 class TestPrePubMetadataService(test.TestCase):
 
     testsip = os.path.join(datadir, "midassip")
@@ -183,7 +195,7 @@ class TestPrePubMetadataService(test.TestCase):
 
         # resolve_id() needs to be indepodent
         data = self.srv.resolve_id(self.midasid)
-        self.assertEqual(data, mdata)
+        self.assertEqual(to_dict(data), to_dict(mdata))
 
         with self.assertRaises(serv.IDNotFound):
             self.srv.resolve_id("asldkfjsdalfk")


### PR DESCRIPTION
As noted as part of #54 (see [comment](https://github.com/usnistgov/oar-pdr/pull/54#issuecomment-433209594)), the preservation service was losing file sizes during a publishing update for files that were not being updated.  Processing the updated POD file during an update was blowing away the size values (and other metadata extracted from the files, like the checksum).  To fix this, the file-extracted metadata were written out as annotations to the metadata (which are protected from updates to the POD).  As part of this, the code needed to be cleaned up where assumptions were made that annotations would not have such metadata.  