### PR TITLE
Fix MacOS-specific bug preventing makedist from working

### DIFF
--- a/oar-build/_run.sh
+++ b/oar-build/_run.sh
@@ -23,7 +23,7 @@ LOGPATH=$PWD/$LOGFILE
 . $OAR_BUILD_DIR/_logging.sh
 
 function set_interactive {
-    shcmds=:`echo $SHELL_COMMANDS | sed -re 's/ +/:/'`:
+    shcmds=:`echo $SHELL_COMMANDS | perl -pe 's/ +/:/'`:
     cmd=$1
     [ -z "$cmd" ] && cmd=build
 

--- a/oar-build/_setversion.sh
+++ b/oar-build/_setversion.sh
@@ -15,7 +15,7 @@ function get_reponame {
         if [ -f "$PACKAGE_DIR/VERSION" ]; then
             awk '{print $1}' "$PACKAGE_DIR/VERSION"
         else
-            basename $PACKAGE_DIR | sed -re '/^oar-[^\-]+-/ s/-[^\-]+$//'
+            basename $PACKAGE_DIR | perl -pe 's/-[^\-]+$// if /^oar-[^\-]+-/'
         fi
     else
         echo ${prog}: Not a git repository; unable to determine package name
@@ -28,7 +28,7 @@ function get_branchname {
         branch=`git rev-parse --abbrev-ref HEAD`
         echo $branch
     elif (basename "$PACKAGE_DIR" | grep -sqP '^oar-[^\-]+-'); then
-        basename "$PACKAGE_DIR" | sed -re 's/^.*-//'
+        basename "$PACKAGE_DIR" | perl -pe 's/^.*-//'
     else
         echo "(unknown)"
     fi

--- a/scripts/makedist
+++ b/scripts/makedist
@@ -31,9 +31,24 @@ set -e
 prog=`basename $0`
 execdir=`dirname $0`
 [ "$execdir" = "" -o "$execdir" = "." ] && execdir=$PWD
-execdir=`realpath $execdir`
 PACKAGE_DIR=`dirname $execdir`
 VERSION=
+
+# this is needed because realpath is not on macs
+function realpath {
+    if [ -d "$1" ]; then
+        (cd $1 && pwd)
+    elif [ -f "$1" ]; then
+        file=`basename $1`
+        parent=`dirname $1`
+        realdir=`(cd $parent && pwd)`
+        echo "$realdir/$file"
+    elif [[ $1 = /* ]]; then
+        echo $1
+    else
+        echo "$PWD/${1#./}"
+    fi
+}
 
 # Update this list with the names of the individual component names
 # 
@@ -98,7 +113,7 @@ scripts/setversion.sh $VERSION
 set +x
 [ -n "$PACKAGE_NAME" ] || PACKAGE_NAME=`cat VERSION | awk '{print $1}'`
 version=`cat VERSION | awk '{print $2}'`
-vers4fn=`echo $version | sed -re 's#[/ ]+#_#g'`
+vers4fn=`echo $version | perl -pe 's#[/ ]+#_#g'`
 
 build_py=
 build_ang=

--- a/scripts/makedist.angular
+++ b/scripts/makedist.angular
@@ -133,7 +133,7 @@ cd $SOURCE_DIR
 [ -n "$PACKAGE_NAME" ] || PACKAGE_NAME=`cat $PACKAGE_DIR/VERSION | awk '{print $1}'`
 version=$VERSION
 [ -n "$version" ] || version=`cat $PACKAGE_DIR/VERSION | awk '{print $2}'`
-vers4fn=`echo $version | sed -re 's#[/ ]+#_#g'`
+vers4fn=`echo $version | perl -pe 's#[/ \t]+#_#g'`
 
 # install required modules
 nodemodarg=

--- a/scripts/makedist.angular
+++ b/scripts/makedist.angular
@@ -31,6 +31,23 @@ set -e
 prog=`basename $0`
 execdir=`dirname $0`
 [ "$execdir" = "" -o "$execdir" = "." ] && execdir=$PWD
+
+# this is needed because realpath is not on macs
+function realpath {
+    if [ -d "$1" ]; then
+        (cd $1 && pwd)
+    elif [ -f "$1" ]; then
+        file=`basename $1`
+        parent=`dirname $1`
+        realdir=`(cd $parent && pwd)`
+        echo "$realdir/$file"
+    elif [[ $1 = /* ]]; then
+        echo $1
+    else
+        echo "$PWD/${1#./}"
+    fi
+}
+
 execdir=`realpath $execdir`
 PACKAGE_DIR=`dirname $execdir`
 DIST_DIR=$PACKAGE_DIR/dist

--- a/scripts/makedist.python
+++ b/scripts/makedist.python
@@ -29,6 +29,23 @@ set -e
 prog=`basename $0`
 execdir=`dirname $0`
 [ "$execdir" = "" -o "$execdir" = "." ] && execdir=$PWD
+
+# this is needed because realpath is not on macs
+function realpath {
+    if [ -d "$1" ]; then
+        (cd $1 && pwd)
+    elif [ -f "$1" ]; then
+        file=`basename $1`
+        parent=`dirname $1`
+        realdir=`(cd $parent && pwd)`
+        echo "$realdir/$file"
+    elif [[ $1 = /* ]]; then
+        echo $1
+    else
+        echo "$PWD/${1#./}"
+    fi
+}
+
 execdir=`realpath $execdir`
 PACKAGE_DIR=`dirname $execdir`
 SOURCE_DIR=$PACKAGE_DIR/python

--- a/scripts/makedist.python
+++ b/scripts/makedist.python
@@ -127,7 +127,7 @@ mkdir -p $BUILD_DIR $DIST_DIR
 [ -n "$PACKAGE_NAME" ] || PACKAGE_NAME=`cat $PACKAGE_DIR/VERSION | awk '{print $1}'`
 version=$VERSION
 [ -n "$version" ] || version=`cat $PACKAGE_DIR/VERSION | awk '{print $2}'`
-vers4fn=`echo $version | sed -re 's#[/ ]+#_#g'`
+vers4fn=`echo $version | perl -pe 's#[/ \t]+#_#g'`
 
 echo '#########################'
 echo '#'


### PR DESCRIPTION
The `makedist` and `setversion.sh` shell scripts both contained commands that are not supported on MacOS--`realpath` and `sed -r`--causing `makedist` to fail on that platform.  These have been replaced with Mac-compatible alternatives.  (See also [oar-sdp PR# 199](https://github.com/usnistgov/oar-sdp/pull/199)).  

To test, just run `scripts/makedist` on a Mac to make sure it builds successfully.  It is not necessary to run the PDR application.  
