### PR TITLE
ODD-712:  close bag's log on failure

### DIFF
--- a/angular/package.json
+++ b/angular/package.json
@@ -143,7 +143,7 @@
     "traceur": "^0.0.111",
     "ts-node": "~6.1.1",
     "tslint": "~5.10.0",
-    "typescript": "~2.7.2",
+    "typescript": "~2.8.4",
     "walk": "^2.3.13",
     "webpack-cli": "^3.0.0"
   }

--- a/python/nistoar/pdr/preserv/service/siphandler.py
+++ b/python/nistoar/pdr/preserv/service/siphandler.py
@@ -439,8 +439,11 @@ class MIDASSIPHandler(SIPHandler):
 
         # Create the bag.  Note: make_bag() can raise exceptions
         self._status.record_progress("Collecting metadata and files")
-        bagdir = self.bagger.make_bag()
-        self.bagger.bagbldr._unset_logfile()  # disengage the internal log
+        try:
+            bagdir = self.bagger.make_bag()
+        finally:
+            if hasattr(self.bagger, 'bagbldr') and self.bagger.bagbldr:
+                self.bagger.bagbldr._unset_logfile() # disengage the internal log
 
         # Stage the full NERDm record for ingest into the RMM
         if self._ingester:

--- a/scripts/testall.python
+++ b/scripts/testall.python
@@ -17,5 +17,8 @@ PACKAGE_DIR=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
 export OAR_PYTHONPATH=`ls -d $PACKAGE_DIR/python/build/lib.* | head -1`
 export OAR_JQ_LIB=$PACKAGE_DIR/oar-metadata/jq
 export OAR_MERGE_ETC=$PACKAGE_DIR/oar-metadata/etc/merge
+export OAR_SCHEMA_DIR=$PACKAGE_DIR/oar-metadata/model
+export OAR_ETC_DIR=$PACKAGE_DIR/etc
+export OAR_HOME=$PACKAGE_DIR
 exec $PACKAGE_DIR/python/runtests.py
 


### PR DESCRIPTION
[ODD-712](http://mml.nist.gov:8080/browse/ODD-712) briefly describes how when a fatal failure occurs during preservation, the bag's internal log file does not get closed.  This causes problems removing the failed bag when the bag is on an NFS-mounted system, as it is on the test and production platforms. 

This small fix corrects this bug.  This PR also includes a fix to the `scripts/testall.python` script that ensures that it can run standalone.  
