### PR TITLE
ODD-715: update typescript version

### DIFF
--- a/angular/package.json
+++ b/angular/package.json
@@ -143,7 +143,7 @@
     "traceur": "^0.0.111",
     "ts-node": "~6.1.1",
     "tslint": "~5.10.0",
-    "typescript": "~2.7.2",
+    "typescript": "~2.8.4",
     "walk": "^2.3.13",
     "webpack-cli": "^3.0.0"
   }


### PR DESCRIPTION
[ODD-715](http://mml.nist.gov:8080/browse/ODD-715) describes an error that arose recently when building oar-pdr from scratch due to a recent update to the rxjs package.  (See the [JIRA ticket](http://mml.nist.gov:8080/browse/ODD-715) for error message details.) The [rxjs repo](https://github.com/ReactiveX/rxjs) indicates that it requires at least v2.8 for typescript; our `package.json` file was set to use `~2.7.4`.  This PR updates that file to use `~2.8.4`.  