### PR TITLE
Fix/odd770 filepath 771 missing item

### DIFF
--- a/angular/src/app/datacart/datacart.component.html
+++ b/angular/src/app/datacart/datacart.component.html
@@ -88,7 +88,7 @@
     </tr>
     <tbody *ngIf="showUnhandledFiles">
       <tr *ngFor="let file of bundlePlanUnhandledFiles">
-        <td width="30%" style="padding-left:.5em;border-bottom:1pt solid black;">{{file.resFilePath}}</td>
+        <td width="30%" style="padding-left:.5em;border-bottom:1pt solid black;">{{file.filePath}}</td>
         <td width="30%" style="padding-left:.5em;border-bottom:1pt solid black;">{{file.downloadUrl}}
         </td>
         <td width="40%" style="padding-left:.5em;border-bottom:1pt solid black;">{{file.message}}</td>

--- a/angular/src/app/landing/description/description.component.ts
+++ b/angular/src/app/landing/description/description.component.ts
@@ -160,7 +160,7 @@ export class DescriptionComponent {
         downloadUrl: null,
         description: null,
         filetype: null,
-        resId: "files",
+        resId: "/",
         filePath: "/",
         downloadProgress: 0,
         downloadInstance: null,

--- a/angular/src/app/landing/landing.component.ts
+++ b/angular/src/app/landing/landing.component.ts
@@ -466,7 +466,7 @@ export class LandingComponent implements OnInit {
                 downloadUrl: path.downloadURL,
                 description: path.description,
                 filetype: path['@type'][0],
-                resId: path["filepath"].replace(/^.*[\\\/]/, ''),
+                resId: tempId,
                 filePath: path.filepath,
                 downloadProgress: 0,
                 downloadInstance: null,


### PR DESCRIPTION
ODD770: http://mml.nist.gov:8080/browse/ODD-770
Now display file path in the warning message of bundle download.

ODD771: http://mml.nist.gov:8080/browse/ODD-771
Now use full path instead of file name as resID to avoid duplication.
