### PR TITLE
New framework for setting and using configuration data

### DIFF
--- a/angular/src/app/app.browser.module.ts
+++ b/angular/src/app/app.browser.module.ts
@@ -1,6 +1,3 @@
-import { TransferHttpCacheModule } from '@nguniversal/common';
-
-// future
 import { NgModule } from '@angular/core';
 import { BrowserModule, BrowserTransferStateModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -10,10 +7,10 @@ import { AppComponent } from './app.component';
 
 @NgModule({
     imports: [
-        BrowserModule.withServerTransition({ appId: 'PDR-LandingPage' }),
+        BrowserModule.withServerTransition({ appId: 'PDR-LandingPageService' }),
         BrowserAnimationsModule,
         AppModule,
-        TransferHttpCacheModule
+        BrowserTransferStateModule
     ],
     bootstrap: [ AppComponent ]
 })

--- a/angular/src/app/app.browser.module.ts
+++ b/angular/src/app/app.browser.module.ts
@@ -1,13 +1,18 @@
-import { BrowserModule, BrowserTransferStateModule } from '@angular/platform-browser';
+import { TransferHttpCacheModule } from '@nguniversal/common';
+
+// future
 import { NgModule } from '@angular/core';
+import { BrowserModule, BrowserTransferStateModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
 import { AppModule } from './app.module';
 import { AppComponent } from './app.component';
-import { TransferHttpCacheModule } from '@nguniversal/common';
 
 @NgModule({
     imports: [
-        AppModule,
         BrowserModule.withServerTransition({ appId: 'PDR-LandingPage' }),
+        BrowserAnimationsModule,
+        AppModule,
         TransferHttpCacheModule
     ],
     bootstrap: [ AppComponent ]

--- a/angular/src/app/app.component.ts
+++ b/angular/src/app/app.component.ts
@@ -8,7 +8,7 @@ import { Router, NavigationStart, NavigationEnd, NavigationCancel, NavigationErr
   styleUrls: ['./app.component.css']
 })
 export class AppComponent {
-  title = 'app';
+  title = 'PDR Resource Landing Page';
 }
 
 /* 

--- a/angular/src/app/app.module.ts
+++ b/angular/src/app/app.module.ts
@@ -27,7 +27,6 @@ import { SearchResolve } from './landing/search-service.resolve';
 import { SharedModule } from './shared/shared.module';
 import { SearchService } from './shared/search-service/index';
 import { CommonVarService } from './shared/common-var/index';
-import { AppConfig } from './shared/config-service/config.service';
 import { DatacartComponent } from './datacart/datacart.component';
 import { CartService } from "./datacart/cart.service";
 import { AppShellNoRenderDirective } from './directives/app-shell-no-render.directive';
@@ -55,16 +54,6 @@ import { AppRoutingModule } from './app-routing.module';
 enableProdMode();
 // used to create fake backend
 import { fakeBackendProvider } from './_helpers/fakeBackendInterceptor';
-
-/**
- * Initialize the configs for backend services
- */
-const appInitializerFn = (appConfig: AppConfig) => {
-  return () => {
-    //console.log("**** CAlling APP Initialization ***");
-    return appConfig.loadAppConfig();
-  };
-};
 
 @NgModule({
   declarations: [
@@ -98,17 +87,10 @@ const appInitializerFn = (appConfig: AppConfig) => {
     SearchResolve,
     CommonVarService,
     CartService,
-    AppConfig,
     DownloadService,
     TestDataService,
     ConfirmationService,
-    CommonFunctionService,
-    {
-      provide: APP_INITIALIZER,
-      useFactory: appInitializerFn,
-      multi: true,
-      deps: [AppConfig]
-    },
+    CommonFunctionService
     // provider used to create fake backend
     // fakeBackendProvider
   ],
@@ -116,12 +98,6 @@ const appInitializerFn = (appConfig: AppConfig) => {
 })
 
 export class AppModule {
-  constructor(
-    @Inject(PLATFORM_ID) private platformId: Object,
-    @Inject(APP_ID) private appId: string) {
-    const platform = isPlatformBrowser(platformId) ?
-      'in the browser' : 'on the server';
-  }
 }
 
 

--- a/angular/src/app/app.module.ts
+++ b/angular/src/app/app.module.ts
@@ -1,12 +1,11 @@
 import { Title, Meta } from '@angular/platform-browser';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import {
-  NgModule, APP_INITIALIZER, PLATFORM_ID, APP_ID, Inject,
+  APP_INITIALIZER, PLATFORM_ID, APP_ID, Inject,
   CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA
 } from '@angular/core';
 import { isPlatformBrowser, CommonModule } from '@angular/common';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { HttpClientModule } from '@angular/common/http';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { Collaspe } from './landing/collapseDirective/collapse.directive';
 import { TreeModule, FieldsetModule, DialogModule, OverlayPanelModule } from 'primeng/primeng';
@@ -15,7 +14,6 @@ import { TreeTableModule } from 'primeng/treetable';
 import { ButtonModule } from 'primeng/button';
 import { TooltipModule } from 'primeng/tooltip';
 import { AppComponent } from './app.component';
-import { AppRoutingModule } from './app-routing.module';
 import { LandingComponent } from './landing/landing.component';
 import { DescriptionComponent } from './landing/description/description.component';
 import { MetadataComponent } from './landing/metadata/metadata.component';
@@ -43,6 +41,17 @@ import { TestDataService } from './shared/testdata-service/testDataService';
 import { CommonFunctionService } from './shared/common-function/common-function.service';
 import {enableProdMode} from '@angular/core';
 
+// future
+import { BrowserModule, BrowserTransferStateModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+import { ErrorHandler } from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
+
+import { FrameModule } from './frame/frame.module';
+import { ConfigModule } from './config/config.module';
+import { AppRoutingModule } from './app-routing.module';
+
+
 enableProdMode();
 // used to create fake backend
 import { fakeBackendProvider } from './_helpers/fakeBackendInterceptor';
@@ -67,15 +76,19 @@ const appInitializerFn = (appConfig: AppConfig) => {
     AppShellNoRenderDirective, AppShellRenderDirective,
   ],
   imports: [
-    FragmentPolyfillModule.forRoot({
-      smooth: true
-    }),
-    FormsModule, ReactiveFormsModule,
-    AppRoutingModule, HttpClientModule,
-    CommonModule, SharedModule, BrowserAnimationsModule, FormsModule, TooltipModule,
-    TreeTableModule, TreeModule, MenuModule, FieldsetModule, DialogModule, OverlayPanelModule,
-    ButtonModule, ProgressSpinnerModule, ConfirmDialogModule, ProgressBarModule,
-    NgbModule.forRoot()
+      HttpClientModule,
+      ConfigModule,        // provider for AppConfig
+      FrameModule,
+      AppRoutingModule,
+
+      FragmentPolyfillModule.forRoot({
+          smooth: true
+      }),
+      FormsModule, ReactiveFormsModule,
+      CommonModule, SharedModule, BrowserAnimationsModule, FormsModule, TooltipModule,
+      TreeTableModule, TreeModule, MenuModule, FieldsetModule, DialogModule, OverlayPanelModule,
+      ButtonModule, ProgressSpinnerModule, ConfirmDialogModule, ProgressBarModule,
+      NgbModule.forRoot()
   ],
   exports: [Collaspe],
   providers: [

--- a/angular/src/app/app.server.module.ts
+++ b/angular/src/app/app.server.module.ts
@@ -1,22 +1,25 @@
 import { NgModule } from '@angular/core';
-import { ServerModule } from '@angular/platform-server';
+import { BrowserModule } from '@angular/platform-browser';
+import { ServerModule, ServerTransferStateModule } from '@angular/platform-server';
 import { ModuleMapLoaderModule } from '@nguniversal/module-map-ngfactory-loader';
 import { AppModule } from './app.module';
 import { AppComponent } from './app.component';
-import { ServerTransferStateModule } from '@angular/platform-server';
-import { BrowserModule } from '@angular/platform-browser';
 
+/**
+ * The root module for the server-side application.  
+ *
+ * Top-level module bits common to both server and browser are imported via the AppModule.
+ */
 @NgModule({
-  imports: [
-    AppModule,
-    BrowserModule.withServerTransition({ appId: 'PDR-LandingPage' }),
-    ServerModule,
-    ModuleMapLoaderModule,
-    ServerTransferStateModule
-  ],
-  providers: [
-    // Add universal-only providers here
-  ],
-  bootstrap: [ AppComponent ],
+    imports: [
+        BrowserModule.withServerTransition({appId: 'PDR-LandingPageService'}),
+        AppModule,
+        ServerModule,
+        ModuleMapLoaderModule,
+        ServerTransferStateModule
+    ],
+    // Since the bootstrapped component is not inherited from your
+    // imported AppModule, it needs to be repeated here.
+    bootstrap: [ AppComponent ],
 })
 export class AppServerModule {}

--- a/angular/src/app/config/README.md
+++ b/angular/src/app/config/README.md
@@ -14,7 +14,7 @@ set a default value if one is not provided in the configuration
 
 An `AppConfig` instance is created via a `ConfigService` instance.  The
 [`ConfigService`](config.service.tst) class itself is abstract, and the
-various implementing sublcasses use different techniques for loading the
+various implementing subclasses use different techniques for loading the
 configuration data, depending on the runtime mode.  A factory function,
 `newConfigService()`, detects the current mode and instantiates the
 appropriate implementation class.  The different modes are intended to support
@@ -39,12 +39,12 @@ the following runtime scenarios:
        rending is working properly.  The application runs both on the server
        and (then) in the browser and is initiated via the command,
        <code>npm run serve:ssr</code>.  In this setup, the server gets its
-       configuration data from the `config` object hard-coded into
+       configuration data from the <code>config</code> object hard-coded into
        <code><a href="../../environments/environment.prod.ts">environments/environment.prod.ts</a></code>
        at build-time (i.e. before running, <code>npm run build:ssr</code>).  This
-       configuration data is delivered to browser-side app via
+       configuration data is delivered to the browser-side app via
        Angular's <code>TransferState</code> mechanism.
-       <p>
+       <br><br>
        Like with the previous scenario, the developer is free to edit
        the <code>environment.prod.ts</code> file (but not check it in); however,
        the developer might find using the <code>PDR_CONFIG_FILE</code>, described
@@ -58,7 +58,7 @@ the following runtime scenarios:
        will first retrieve the configuration from the config service
        and write it to a file on disk.  It sets the location of that
        file into the <code>PDR_CONFIG_FILE</code> environment variable.  This
-       will trigger the `ConfigService` factory function in the
+       will trigger the <code>ConfigService</code> factory function in the
        server-side app to instantiate a <code>ServerFileConfigService</code>
        instance, which loads the configuration from that file.  </dd>
 </dl>

--- a/angular/src/app/config/README.md
+++ b/angular/src/app/config/README.md
@@ -1,0 +1,130 @@
+# ConfigModule
+
+This module provides the application configuratoin infrastructure.
+
+## The Configuration Architecture
+
+Components are provided configuration data via an [`AppConfig`](config.ts)
+class via Angular's dependency injection mechanism.  Configuration values can
+be retrieved directly from the instance's properties
+(e.g. `cfg.locations.distService`) or via its `get()` method
+(e.g. `cfg.get("location.distService")`).  The latter allows for the caller to
+set a default value if one is not provided in the configuration
+(e.g. `cfg.get("location.distService", "/od/ds")`).
+
+An `AppConfig` instance is created via a `ConfigService` instance.  The
+[`ConfigService`](config.service.tst) class itself is abstract, and the
+various implementing sublcasses use different techniques for loading the
+configuration data, depending on the runtime mode.  A factory function,
+`newConfigService()`, detects the current mode and instantiates the
+appropriate implementation class.  The different modes are intended to support
+the following runtime scenarios:
+
+<dl>
+  <dt> Browser-side only for development </dt>
+  <dd> This is intended for rapid-cycle development (e.g. iterating on a
+       component layout).  The application runs completely in the browser
+       (i.e. without the benefit of server-side rending), and it is
+       typically launched by executing <code>npm run start</code>.  Using the
+       <code>AngularEnvironmentConfigService</code> implementation, the
+       configuration data is drawn from the <code>config</code> object hard-coded
+       into the
+       <code><a href="../../environments/environment.ts">environments/environment.ts</a></code>.
+       The developer is free to edit this file for development and
+       testing purposes but normally would not check those changes in.
+       </dd>
+
+  <dt> Server-side rendering for development </dt>
+  <dd> This mode is used with the developer wants to ensure that server-side
+       rending is working properly.  The application runs both on the server
+       and (then) in the browser and is initiated via the command,
+       <code>npm run serve:ssr</code>.  In this setup, the server gets its
+       configuration data from the `config` object hard-coded into
+       <code><a href="../../environments/environment.prod.ts">environments/environment.prod.ts</a></code>
+       at build-time (i.e. before running, <code>npm run build:ssr</code>).  This
+       configuration data is delivered to browser-side app via
+       Angular's <code>TransferState</code> mechanism.
+       <p>
+       Like with the previous scenario, the developer is free to edit
+       the <code>environment.prod.ts</code> file (but not check it in); however,
+       the developer might find using the <code>PDR_CONFIG_FILE</code>, described
+       in the next scenario, just as convenient.  </dd>
+
+  <dt> Production operation (under oar-docker) </dt>
+  <dd> This mode is similar to the previous node where the server-side
+       app delivers the configuration data to the browser via
+       <code>TransferState</code> but with one important difference.  On the
+       server, the docker container that launches the server-side app
+       will first retrieve the configuration from the config service
+       and write it to a file on disk.  It sets the location of that
+       file into the <code>PDR_CONFIG_FILE</code> environment variable.  This
+       will trigger the `ConfigService` factory function in the
+       server-side app to instantiate a <code>ServerFileConfigService</code>
+       instance, which loads the configuration from that file.  </dd>
+</dl>
+
+The factory function, [`newConfigService()`](config.service.ts#L251),
+automatically determines the runtime mode and creates the appropriate
+`ConfigService` implementation.  Three configuration paramters can help the
+developer understand what mode has been engaged and where the configuration
+data came from.  Two are set by the `ConfigService` itself, and one comes only
+from the configuration source file:
+
+<dl>
+   <dt> <code>source</code> </dt>
+   <dd> The value is a label indicating the origin of the configuration data;
+        the value is hard-coded into the <code>ConfigService</code>
+        implementation.  The currently defined labels are:
+        <ul>
+           <li> <code>server-file</code> (from
+                <code>ServerFileConfigService</code>) -- the data was read in
+                from a file on the server's disk.  This only occurs in the
+                server-side app. </li>
+           <li> <code>transfer-state</code> (from
+                <code>TransferStateConfigService</code>) -- the data was read
+                in from the <code>TransferState</code>.  This only occurs in the 
+                browser-side app. </li>
+           <li> <code>angular-env</code> (from
+                <code>AngularEnvironmentConfigService</code>) -- the data was
+                read in from Angular's environment module.  This can occur 
+                either in the server-side or browser-side app, depending on the
+                runtime mode. </li>
+        </ul> </dd>
+
+   <dt> <code>mode</code> </dt>
+   <dd> The value is usually to either "dev" or "prod" by the
+        <code>ConfigService</code>, but the value can be set explicitly in the
+        configuration source file.  The semantics of the possible values is
+        intended to be the same as the the Angular environments labels.
+        Typically, the value will be set to "dev" if the configuration came from
+        <code><a href="../../environments/environment.ts">environments/environment.ts</a></code>.
+        </dd> 
+
+   <dt> <code>status</code> </dt>
+   <dd> This value is <em>not</em> set by the <code>ConfigService</code>;
+        rather, it is set explicitly in the configuration source file.  This
+        value, if set, will be displayed (as a "badge") in the header of the
+        landing page and serves as a further indicator of the runtime context
+        which can be customized by the developer.  The default value set in the
+        <code><a href="../../environments/environment.ts">environement.ts</a></code>
+        file is "Dev Version", reflecting the developer's rapid development-cycle
+        mode.  "Dev-Server Version" indicates a development mode in which the
+        configuration was set on the server and successfully delivered to the
+        browser.  "Misconfigured Version" is intended as a signal that the
+        value was read from the default 
+        <code><a href="../../environments/environment.prod.ts">environement.prod.ts</a></code>
+        file is rather than from, say, the configuration service.  </dd>
+</dl>
+
+## AppConfig
+
+An injectable class for delivering configuration data.  The expected parameter
+names are set by being an extension of the LPSConfig interface where the
+parameters are defined (both syntactically and semantically).
+
+## ConfigService
+
+The abstract base class for implementations that load configuration data from
+different possible sources.
+
+

--- a/angular/src/app/config/README.md
+++ b/angular/src/app/config/README.md
@@ -13,7 +13,7 @@ set a default value if one is not provided in the configuration
 (e.g. `cfg.get("location.distService", "/od/ds")`).
 
 An `AppConfig` instance is created via a `ConfigService` instance.  The
-[`ConfigService`](config.service.tst) class itself is abstract, and the
+[`ConfigService`](config.service.ts) class itself is abstract, and the
 various implementing subclasses use different techniques for loading the
 configuration data, depending on the runtime mode.  A factory function,
 `newConfigService()`, detects the current mode and instantiates the

--- a/angular/src/app/config/config.module.ts
+++ b/angular/src/app/config/config.module.ts
@@ -1,0 +1,25 @@
+import { NgModule, PLATFORM_ID, Optional } from '@angular/core';
+import { BrowserTransferStateModule, TransferState } from '@angular/platform-browser';
+
+import { AppConfig, LPSConfig, WebLocations } from './config'
+import { ConfigService, newConfigService, CFG_DATA } from './config.service'
+
+export function getAppConfig(configService: ConfigService) : AppConfig {
+    let out : AppConfig = configService.getConfig();
+    console.log("App status, according to the configuration: " + out.status);
+    return out;
+}
+
+/**
+ * a service module providing the application configuration infrastructure.  Its 
+ * ultimate purpose is to provide an AppConfig singleton, containing configuration 
+ * data, making available for injection throughout the app.  
+ */
+@NgModule({
+    providers: [
+        { provide: ConfigService, useFactory: newConfigService,
+          deps: [ PLATFORM_ID, TransferState ] },
+        { provide: AppConfig, useFactory: getAppConfig, deps: [ ConfigService ] }
+    ]
+})
+export class ConfigModule { }

--- a/angular/src/app/config/config.service.spec.ts
+++ b/angular/src/app/config/config.service.spec.ts
@@ -1,0 +1,77 @@
+import * as cfg from "./config"
+import * as cfgsvc from "./config.service"
+import { TransferState, StateKey } from '@angular/platform-browser';
+import * as ngenv from '../../environments/environment';
+
+describe("config.service deepcopy", function() {
+
+    let a = { a: 1, b: { bc: "1.3", bd: 1.4, be: [ 1, 2.2, "3G", { z: 25, y: "24" } ] }};
+    let b = cfgsvc.deepCopy(a);
+
+    it("equivalent but independent", function() {
+        expect(b).toEqual(a);
+
+        a.b.be[3]["x"] = "better";
+        expect(b).not.toEqual(a);
+        
+        a.a = 2;
+        a.b.bc = "hey";
+        a.b.be[0] = "you!";
+        expect(b).not.toEqual(a);
+    });    
+});
+
+describe("config.service AngularEnvironmentConfigService", function() {
+    let plid : Object = "browser";
+    let ts : TransferState = new TransferState();
+    let svc = new cfgsvc.AngularEnvironmentConfigService(plid, ts);
+
+    it("getConfig()", function() {
+        let ac : cfg.AppConfig = svc.getConfig() as cfg.AppConfig;
+
+        expect(ac instanceof cfg.AppConfig).toBe(true);
+        expect(ac.status).toBe("Dev Version");
+        expect(ac["mode"]).toBe("dev");
+        expect(ac["source"]).toBe("angular-env");
+    });
+});
+
+describe("config.service newConfigService", function() {
+
+    it("angular-env", function() {
+        let plid : Object = "browser";
+        let ts = new TransferState();
+        let svc = cfgsvc.newConfigService(plid, ts);
+
+        expect(svc instanceof cfgsvc.ConfigService).toBe(true);
+        expect(svc instanceof cfgsvc.AngularEnvironmentConfigService).toBe(true);
+
+        let ac : cfg.AppConfig = svc.getConfig() as cfg.AppConfig;
+        expect(ac instanceof cfg.AppConfig).toBe(true);
+        expect(ac.status).toBe("Dev Version");
+        expect(ac["mode"]).toBe("dev");
+        expect(ac["source"]).toBe("angular-env");
+    });
+
+    it("transfer-state", function() {
+        let plid : Object = "browser";
+        
+        let data : cfg.LPSConfig = cfgsvc.deepCopy(ngenv.config);
+        data["mode"] = "prod";
+        let ts = new TransferState();
+        ts.set(cfgsvc.CONFIG_TS_KEY, data);
+        
+        let svc = cfgsvc.newConfigService(plid, ts);
+
+        expect(svc instanceof cfgsvc.ConfigService).toBe(true);
+        expect(svc instanceof cfgsvc.TransferStateConfigService).toBe(true);
+
+        let ac : cfg.AppConfig = svc.getConfig() as cfg.AppConfig;
+        expect(ac instanceof cfg.AppConfig).toBe(true);
+        expect(ac.status).toBe("Dev Version");
+        expect(ac["mode"]).toBe("prod");
+        expect(ac["source"]).toBe("transfer-state");
+    });
+
+});
+

--- a/angular/src/app/config/config.service.ts
+++ b/angular/src/app/config/config.service.ts
@@ -1,0 +1,271 @@
+import { Inject, InjectionToken } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { TransferState, makeStateKey, StateKey } from '@angular/platform-browser';
+import * as proc from 'process';
+import * as fs from 'fs';
+
+import { AppConfig, LPSConfig } from './config';
+import * as ngenv from '../../environments/environment';
+
+export const CONFIG_KEY_NAME : string = "LPSConfig";
+export const CONFIG_TS_KEY : StateKey<string> = makeStateKey(CONFIG_KEY_NAME);
+export const CFG_DATA : InjectionToken<LPSConfig> = new InjectionToken<LPSConfig>("lpsconfig");
+
+/**
+ * create a deep copy of an object
+ */
+export function deepCopy(obj) {
+    // this implementation comes courtesy of and with thanks to Steve Fenton via
+    // https://stackoverflow.com/questions/28150967/typescript-cloning-object/42758108
+    var copy;
+
+    // Handle the 3 simple types, and null or undefined
+    if (null == obj || "object" != typeof obj) return obj;
+
+    // Handle Date
+    if (obj instanceof Date) {
+        copy = new Date();
+        copy.setTime(obj.getTime());
+        return copy;
+    }
+
+    // Handle Array
+    if (obj instanceof Array) {
+        copy = [];
+        for (var i = 0, len = obj.length; i < len; i++) {
+            copy[i] = deepCopy(obj[i]);
+        }
+        return copy;
+    }
+
+    // Handle Object
+    if (obj instanceof Object) {
+        copy = {};
+        for (var attr in obj) {
+            if (obj.hasOwnProperty(attr)) copy[attr] = deepCopy(obj[attr]);
+        }
+        return copy;
+    }
+ 
+    throw new Error("Unable to copy obj! Its type isn't supported.");
+}
+
+/**
+ * a service that will create an AppConfig instance loaded with values 
+ * approriate for the runtime context.
+ */
+export abstract class ConfigService {
+
+    /**
+     * return an AppConfig instance that is appropriate for the runtime 
+     * context.
+     */
+    abstract getConfig() : AppConfig; 
+    
+}
+
+/**
+ * A ConfigService that pulls it data from the environmental context
+ * that Angular builds into the app.  
+ * 
+ * This service is intended for use in development mode running either as 
+ * client-only in the browser or on the server.  
+ */
+export class AngularEnvironmentConfigService extends ConfigService {
+    private source : string = "angular-env";
+    private defMode : string = "dev";
+    private config : AppConfig|null = null;
+
+    /**
+     * construct the service
+     * @param platid   the PLATFORM_ID value for determining if we are running on the server
+     *                 or in the browser.
+     * @param cache    the TransferState instance for the application.  If we are on the server,
+     *                 getConfig() will cache the configuration to the TransferState object.
+     */
+    constructor(private platid : object, private cache : TransferState) {
+        super();
+    }
+
+    /**
+     * return an AppConfig instance that is appropriate for the runtime 
+     * context.  This will asynchronously return an AppConfig rather than a 
+     * Promise.  
+     */
+    getConfig() : AppConfig {
+        if (! this.config) {
+            console.log("Loading development-mode configuration data from the Angular built-in environment");
+            let data : LPSConfig = deepCopy(ngenv.config);
+            let out : AppConfig = new AppConfig(data);
+            out["source"] = this.source;
+            if (! out["env"]) 
+                out["env"] = this.defMode;
+
+            if (isPlatformServer(this.platid))
+                this.cache.set(CONFIG_TS_KEY, out);
+            this.config = out;
+        }
+        return this.config;
+    }
+}
+
+/**
+ * a ConfigService that reads in its data from a file on local disk.  
+ * 
+ * This will only work on the server.  The data is read in from a given
+ * JSON-formatted file specified at construction.
+ * 
+ * This service is intended for when the LPS is running in a docker container 
+ * from oar-docker.  The container launch script pulls configuration from the
+ * config-server and writes it to a file.
+ */
+export class ServerFileConfigService extends ConfigService {
+
+    private source : string = "server-file";
+    private defMode : string = "prod";       // i.e. in the docker context
+    private config : AppConfig|null = null;
+
+    /**
+     * construct the service.  
+     * 
+     * @param cfgfile   the (full) path to the file to read JSON-encoded data from
+     * @throw Error -- if cfgfile is not set or does not point to an existing file.  
+     */
+    constructor(private cfgfile : string, private cache? : TransferState) {
+        super();
+        if (! cfgfile)
+            throw new Error("Configuration file not provided");
+        if (! fs.existsSync(cfgfile))
+            throw new Error(cfgfile + ": File not found");
+        if (! fs.statSync(cfgfile).isFile())
+            throw new Error(cfgfile + ": Not a file");
+    }
+
+    /**
+     * return an AppConfig instance that is appropriate for the runtime 
+     * context.  This implementation reads the config data from a JSON file. 
+     */
+    getConfig() : AppConfig {
+        if (this.config)
+            return this.config;  // previously created AppConfig
+
+        console.log("Loading configuration data from " + this.cfgfile);
+
+        // synchronous read.  (The file is typically short.)
+        let out : LPSConfig = JSON.parse(fs.readFileSync(this.cfgfile, 'utf8'));
+        out["source"] = this.source;
+        if (! out["mode"])
+            out["mode"] = this.defMode;
+
+        this.config = new AppConfig(out);
+        if (this.cache)
+            this.cache.set(CONFIG_TS_KEY, this.config);
+        return this.config;
+    }
+}
+
+/**
+ * a server-side ConfigService that provides data that was loaded in when the 
+ * server started. 
+ */
+export class ServerLoadedConfigService extends ConfigService {
+    private config : AppConfig|null = null;
+
+    constructor(private cfgdata : LPSConfig, private cache? : TransferState) {
+        super();
+        if (! cfgdata)
+            throw new Error("Server failed to load config data");
+    }
+
+    /**
+     * return an AppConfig instance that is appropriate for the runtime context.  
+     * This implementation loads that that was previously loaded by the server at 
+     * start-up time.  
+     */
+    getConfig() : AppConfig {
+        if (this.config)
+            return this.config;  // previously created AppConfig
+
+        console.log("Loading configuration data previously loaded by server");
+
+        this.config = new AppConfig(this.cfgdata);
+        if (this.cache)
+            this.cache.set(CONFIG_TS_KEY, this.config);
+        return this.config;
+    }
+}
+
+/**
+ * a ConfigService that pulls in data the transfer state
+ */
+export class TransferStateConfigService extends ConfigService {
+
+    private source : string = "transfer-state";
+    private defMode : string = "prod";
+
+    /**
+     * create the service given a TransferState container
+     */
+    constructor(private cache : TransferState) {
+        super();
+        if (! cache.hasKey(CONFIG_TS_KEY))
+            throw new Error("Config key not found in TransferState: " + CONFIG_KEY_NAME);
+    }
+
+    /**
+     * return an AppConfig instance that is appropriate for the runtime 
+     * context.  This implementation extracts the configuration data from 
+     * the transfer state.
+     */
+    getConfig() : AppConfig {
+        console.log("Loading configuration data delivered from the server.");
+
+        let data : LPSConfig|null = this.cache.get(CONFIG_TS_KEY, null) as LPSConfig;
+        if (! data)
+            throw new Error("Missing key from transfer state: " + CONFIG_KEY_NAME)
+        data["source"] = this.source;
+        if (! data["mode"])
+            data["mode"] = this.defMode;
+        return new AppConfig(data);
+    }
+}
+
+/**
+ * return ConfigService appropriate for current runtime context.
+ * 
+ * If the app is running in the user's browser, the service will look for 
+ * the returned service will load configuration data from the app's the 
+ * transfer state.  If it is not there, we can assume that 
+ * we are running in development-client-only mode and 
+ * retrieve the data from the built-in environment.  If the app is running 
+ * on the server, we can retrieve the data from a local file whose path
+ * is set in the OS environment variable (OAR_CONFIG_FILE).  If that is 
+ * not set, we can assume we are running in development-server mode.
+ *
+ * @param platid    the PLATFORM_ID for determining if we are running on the server
+ * @param cache     a TransferState instance to check for config data
+ * @param cfgdata   (optional) LPSConfig object that contains the configuration data loaded 
+ *                    explicitly by some other means.  (This hook is intended for future 
+ *                    ways of loading the configuration data on the server.)
+ */
+export function newConfigService(platid : Object, cache : TransferState, cfgdata? : LPSConfig)
+    : ConfigService
+{
+    if (cache.hasKey(CONFIG_TS_KEY))
+        // this means we're on (should be) on the browser side
+        return new TransferStateConfigService(cache);
+
+    if (isPlatformServer(platid) && cfgdata)
+        // this means we're on the server in production-like mode
+        // this will stash the data into the TransferState
+        return new ServerLoadedConfigService(cfgdata, cache)
+
+    if (isPlatformServer(platid) && proc.env["PDR_CONFIG_FILE"])
+        // this means we're on the server in production-like mode
+        // this will stash the data into the TransferState
+        return new ServerFileConfigService(proc.env["PDR_CONFIG_FILE"], cache)
+
+    // This is the default intended for a development context
+    // this will stash the data into the TransferState
+    return new AngularEnvironmentConfigService(platid, cache);
+}

--- a/angular/src/app/config/config.spec.ts
+++ b/angular/src/app/config/config.spec.ts
@@ -50,6 +50,24 @@ describe("config.AppConfig", function() {
         expect(cfg["locations"].orgHome).toBe("https://nist.gov/");
         expect(cfg.status).toBe(undefined);
         expect(cfg["author"]).toBe("ray");
+
+        // check for default values
+        expect(cfg.editEnabled).toBeDefined();
+        expect(cfg.editEnabled).toBe(false);
+        expect(cfg.locations.pdrHome).toBeDefined();
+        expect(cfg.locations.pdrHome).toBe("https://data.nist.gov/pdr/");
+        expect(cfg.locations.pdrSearch).toBeDefined();
+        expect(cfg.locations.pdrSearch).toBe("https://data.nist.gov/sdp/");
+        expect(cfg.locations.distService).toBeDefined();
+        expect(cfg.locations.distService).toBe("https://data.nist.gov/od/ds/");
+        expect(cfg.locations.mdService).toBeDefined();
+        expect(cfg.locations.mdService).toBe("https://data.nist.gov/rmm/");
+        expect(cfg.locations.landingPageService).toBeDefined();
+        expect(cfg.locations.landingPageService).toBe("https://data.nist.gov/od/id/");
+        expect(cfg.locations.nerdmAbout).toBeDefined();
+        expect(cfg.locations.nerdmAbout).toBe("https://data.nist.gov/od/dm/aboutNerdm.html");
+        expect(cfg.mdAPI).toBeDefined();
+        expect(cfg.mdAPI).toBe("https://data.nist.gov/rmm/");
     });
 
     it("get()", function() {
@@ -80,6 +98,5 @@ describe("config.AppConfig", function() {
         expect(cfg.get("locations.pdrSearch", "nowhere")).toBe("https://data.nist.gov/sdp/");
         expect(cfg.get("locations.hell")).toBe(undefined);
         expect(cfg.get("locations.hell", "nowhere")).toBe("nowhere");
-        
     });
 });

--- a/angular/src/app/config/config.spec.ts
+++ b/angular/src/app/config/config.spec.ts
@@ -1,0 +1,85 @@
+import * as config from "./config";
+
+describe("config.WebLocations", function() {
+
+    it("WebLocations recognizes WebLocations instance data", function() {
+        let data : config.WebLocations = {
+            orgHome: "https://nist.gov/",  portalBase: "https://data.nist.gov/",
+            author: "ray" };
+        expect(data.portalBase).toBe("https://data.nist.gov/");
+        expect(data.pdrHome).toBe(undefined);
+        expect(data["author"]).toBe("ray");
+
+        /*
+        let wrong : config.WebLocations = { portalBase: "https://data.nist.gov/",
+                                            author: "ray" };
+        */
+    });
+});
+
+describe("config.LPSConfig", function() {
+
+    it("LPSConfig recognized LPSConfig instance data", function() {
+        let data : config.LPSConfig = {
+            locations: {
+                orgHome: "https://nist.gov/",  portalBase: "https://data.nist.gov/"
+            },
+            appVersion: "1.1.0",
+            author: "ray"
+        }
+            
+        expect(data.locations.portalBase).toBe("https://data.nist.gov/");
+        expect(data.status).toBe(undefined);
+        expect(data["author"]).toBe("ray");
+    });
+});
+
+describe("config.AppConfig", function() {
+
+    it("Instance initialized from an LPSConfig instance", function() {
+        let data : config.LPSConfig = {
+            locations: {
+                orgHome: "https://nist.gov/",  portalBase: "https://data.nist.gov/"
+            },
+            appVersion: "1.1.0",
+            author: "ray"
+        }
+        let cfg : config.AppConfig = new config.AppConfig(data);
+
+        expect(cfg.locations.portalBase).toBe("https://data.nist.gov/");
+        expect(cfg["locations"].orgHome).toBe("https://nist.gov/");
+        expect(cfg.status).toBe(undefined);
+        expect(cfg["author"]).toBe("ray");
+    });
+
+    it("get()", function() {
+        let data : config.LPSConfig = {
+            locations: {
+                orgHome: "https://nist.gov/",  portalBase: "https://data.nist.gov/"
+            },
+            appVersion: "1.1.0",
+            author: "ray"
+        }
+        let cfg : config.AppConfig = new config.AppConfig(data);
+
+        expect(cfg.get("appVersion")).toBe("1.1.0");
+
+        let author : string = cfg.get("author");
+        expect(author).toBe("ray");
+        author = cfg.get("author", "me!");
+        expect(author).toBe("ray");
+
+        expect(cfg["status"]).toBe(undefined);
+        expect(cfg.get("status", "testing")).toBe("testing");
+        cfg.status = null;
+        expect(cfg.get("status", "testing")).toBe("testing");
+        cfg.status = "review";
+        expect(cfg.get("status", "testing")).toBe("review");
+
+        expect(cfg.get("locations.orgHome", "nowhere")).toBe("https://nist.gov/");
+        expect(cfg.get("locations.pdrSearch", "nowhere")).toBe("https://data.nist.gov/sdp/");
+        expect(cfg.get("locations.hell")).toBe(undefined);
+        expect(cfg.get("locations.hell", "nowhere")).toBe("nowhere");
+        
+    });
+});

--- a/angular/src/app/config/config.ts
+++ b/angular/src/app/config/config.ts
@@ -74,6 +74,13 @@ export interface LPSConfig {
     mdAPI?: string;
 
     /**
+     * True if editing widgets should be made available in the landing page.
+     * This is intended to be true for the internal publishing version of the 
+     * landing page, and false for the external one.  The default will be false.
+     */
+    editEnabled?: boolean;
+
+    /**
      * a label to display (in the head bar) indicating the status of displayed interface.  
      *
      * This is usually populated in production contexts; example values
@@ -102,10 +109,11 @@ export interface LPSConfig {
  */
 export class AppConfig implements LPSConfig {
 
-    locations : WebLocations;
-    mdAPI     : string;
-    status    : string;
-    appVersion: string;
+    locations  : WebLocations;
+    mdAPI      : string;
+    editEnabled: boolean;
+    status     : string;
+    appVersion : string;
 
     /**
      * create an AppConfig directly from an LPSConfig object
@@ -143,6 +151,8 @@ export class AppConfig implements LPSConfig {
             this.locations.nerdmAbout = this.locations.portalBase + "od/dm/aboutNerdm.html";
 
         if (! this.mdAPI) this.mdAPI = this.locations.mdService;
+
+        if (typeof(this.editEnabled) === "undefined") this.editEnabled = false;
     }
 
     /**

--- a/angular/src/app/config/config.ts
+++ b/angular/src/app/config/config.ts
@@ -1,0 +1,181 @@
+/**
+ * Classes used to support the configuration infrastructure.  
+ * 
+ * Configuration parameters used by the application are defined in the form of
+ * interfaces.  The AppConfig is an implementation of the app-level configuration
+ * interface, LPSConfig, that can be injected into Components.  
+ */
+import { Injectable } from '@angular/core';
+
+/**
+ * URLs to remote locations used as links in templates
+ */
+export interface WebLocations {
+
+    /**
+     * the institutional home page (e.g. NIST)
+     */
+    orgHome: string,
+
+    /**
+     * the science portal base URL.  
+     */
+    portalBase?: string,
+
+    /**
+     * the home page for the PDR
+     */
+    pdrHome?: string,
+
+    /**
+     * the PDR search page (i.e. the SDP search page)
+     */
+    pdrSearch?: string,
+
+    /**
+     * the base URL for the distribution service
+     */
+    distService?: string,
+
+    /**
+     * the base URL for the metadata service
+     */
+    mdService?: string
+
+    /**
+     * the NERDm info page
+     */
+    nerdmAbout?: string
+
+    /**
+     * other locations are allowed
+     */
+    [locName: string]: any;
+}
+
+/**
+ * the aggregation of parameters needed to configure the Landing Page Service
+ */
+export interface LPSConfig {
+
+    /**
+     * URLs used in links plugged into templates
+     */
+    locations: WebLocations;
+
+    /**
+     * Base URL for metadata service to use
+     */
+    mdAPI?: string;
+
+    /**
+     * a label to display (in the head bar) indicating the status of displayed interface.  
+     *
+     * This is usually populated in production contexts; example values
+     * include "Review Version", "Dev Version".  
+     */
+    status?: string;
+
+    /**
+     * the interface version to display (in the head bar)
+     */
+    appVersion?: string;
+
+    /**
+     * other parameters are allowed
+     */
+    [propName: string]: any;
+}
+
+/**
+ * a class implementation of the LPSConfig interface.  
+ * 
+ * This adds functions for specialized access to the parameters, such as
+ * specifying a default value.  
+ * 
+ * See {@link LPSConfig} for property documentation.
+ */
+export class AppConfig implements LPSConfig {
+
+    locations : WebLocations;
+    mdAPI     : string;
+    status    : string;
+    appVersion: string;
+
+    /**
+     * create an AppConfig directly from an LPSConfig object
+     * @param params   the input data
+     */
+    constructor(params : LPSConfig) {
+        for (var key in params) 
+            this[key] = params[key];
+        this.inferMissingValues();
+    }
+
+    /*
+     * set some defaults for missing configuration values based on what has been
+     * set.  
+     */
+    private inferMissingValues() : void {
+        if (! this.locations.portalBase) {
+            this.locations.portalBase = this.locations.orgHome;
+            if (! this.locations.portalBase.endsWith('/'))
+                this.locations.portalBase += '/';
+            this.locations.portalBase += 'data/';
+        }
+
+        if (! this.locations.pdrHome)
+            this.locations.pdrHome = this.locations.portalBase + "pdr/";
+        if (! this.locations.pdrSearch)
+            this.locations.pdrSearch = this.locations.portalBase + "sdp/";
+        if (! this.locations.distService)
+            this.locations.distService = this.locations.portalBase + "od/ds/";
+        if (! this.locations.mdService)
+            this.locations.mdService = this.locations.portalBase + "rmm/";
+        if (! this.locations.nerdmAbout)
+            this.locations.nerdmAbout = this.locations.portalBase + "od/dm/aboutNerdm.html";
+
+        if (! this.mdAPI) this.mdAPI = this.locations.mdService;
+    }
+
+    /**
+     * get hierarchical values by name with an option to request a default value.  
+     * 
+     * This function accomplishes two things:  first, it provides a bit of syntactic 
+     * sugar for getting at deep values in the parameter hierarchy.  That is, 
+     * `cfg.get("location.orgHome")` is equivalent to both `cfg.location.orgHome` and
+     * `cfg["location"]["orgHome"]`.  If any of the property names are not one that is 
+     * predefined as a class property, only the latter of the alternatives works.  
+     *
+     * The second bit of functionality is the optional parameter that allows the caller 
+     * to set the default value to return if the value is not set.  If the stored value
+     * is null or undefined, the default value is returned.  
+     * 
+     * @param param   the name of the desired parameter
+     */
+    get<T>(param : string, defval ?: T|null) : T|null|undefined {
+        let names: string[] = param.split(".");
+        let val : any = this;
+        for (var i=0; i < names.length; i++) {
+            if (typeof val != "object")
+                return defval;
+            val = val[names[i]];
+        }
+        return (val != undefined) ? val : defval;
+    }
+
+}
+
+/**
+ * a factory function for creating an AppInfo instance
+ * 
+ * This function's behavior will depend on whether the app is running on the server 
+ * or in the client's browser, and on whether in development mode or production.  
+ * If running on the server in production, the factory will pull in the configuration
+ * data in from the environment.  If running in the browser, it will look for the 
+ * configuration information from the transfer state.  If the data is not available 
+ * in the transfer state (because it is in development mode), ...
+ */
+export let configFactory : () => AppConfig|null = function() {
+    return null;
+}

--- a/angular/src/app/config/config.ts
+++ b/angular/src/app/config/config.ts
@@ -38,9 +38,14 @@ export interface WebLocations {
     distService?: string,
 
     /**
-     * the base URL for the metadata service
+     * the base URL for the (public) metadata service
      */
-    mdService?: string
+    mdService?: string,
+
+    /**
+     * the base URL for the landing page service
+     */
+    landingPageService?: string, 
 
     /**
      * the NERDm info page
@@ -132,6 +137,8 @@ export class AppConfig implements LPSConfig {
             this.locations.distService = this.locations.portalBase + "od/ds/";
         if (! this.locations.mdService)
             this.locations.mdService = this.locations.portalBase + "rmm/";
+        if (! this.locations.landingPageService)
+            this.locations.landingPageService = this.locations.portalBase + "od/id/";
         if (! this.locations.nerdmAbout)
             this.locations.nerdmAbout = this.locations.portalBase + "od/dm/aboutNerdm.html";
 

--- a/angular/src/app/datacart/datacart.component.ts
+++ b/angular/src/app/datacart/datacart.component.ts
@@ -24,7 +24,7 @@ import { CommonVarService } from '../shared/common-var'
 import { DownloadService } from '../shared/download-service/download-service.service';
 import { ZipData } from '../shared/download-service/zipData';
 import { OverlayPanel } from 'primeng/overlaypanel';
-import { AppConfig, Config } from '../shared/config-service/config.service';
+import { AppConfig } from '../config/config';
 import { BootstrapOptions } from '@angular/core/src/application_ref';
 import { AsyncBooleanResultCallback } from 'async';
 import { FileSaverService } from 'ngx-filesaver';
@@ -116,7 +116,6 @@ export class DatacartComponent implements OnInit, OnDestroy {
   noFileDownloaded: boolean; // will be true if any item in data cart is downloaded
   totalDownloaded: number = 0;
   dataArray: string[] = [];
-  confValues: Config;
   distApi: string;
   currentTask: string = '';
   showCurrentTask: boolean = false;
@@ -145,7 +144,7 @@ export class DatacartComponent implements OnInit, OnDestroy {
   constructor(private http: HttpClient,
     private cartService: CartService,
     private downloadService: DownloadService,
-    private appConfig: AppConfig,
+    private cfg : AppConfig,
     private _FileSaverService: FileSaverService,
     private commonVarService: CommonVarService,
     private commonFunctionService: CommonFunctionService,
@@ -163,7 +162,6 @@ export class DatacartComponent implements OnInit, OnDestroy {
       });
     };
 
-    this.confValues = this.appConfig.getConfig();
     this.cartService.watchForceDatacartReload().subscribe(
       value => {
         if (value) {
@@ -180,7 +178,7 @@ export class DatacartComponent implements OnInit, OnDestroy {
     this.commonVarService.setContentReady(false);
     this.isProcessing = true;
     this.ediid = this.commonVarService.getEdiid();
-    this.distApi = this.confValues.DISTAPI;
+    this.distApi = this.cfg.get("distService", "/od/ds/");
     this.routerparams = this.route.params.subscribe(params => {
       this.mode = params['mode'];
     })

--- a/angular/src/app/frame/README.md
+++ b/angular/src/app/frame/README.md
@@ -1,0 +1,17 @@
+# FrameModule
+
+This module provides components that make up the "frame" of the landing
+page--namely, the header and the footer.
+
+## HeadbarComponent
+
+Features:
+ * Set as a black bar at the top of the page
+ * NIST PDR logo that links to the PDR home page (currently the SDP)
+ * PDR-wide links:
+   * About page
+   * Search page (the SDP)
+   * User's Datacart
+ * Labels indicating the version and status of the PDR
+   * this uses the badge style from bootstrap
+

--- a/angular/src/app/frame/footbar.component.css
+++ b/angular/src/app/frame/footbar.component.css
@@ -1,5 +1,5 @@
 #footer {
-    background: #333333;
+    background: #000000;
     /*background-color: white;*/
     color: white;
     position: relative;

--- a/angular/src/app/frame/footbar.component.css
+++ b/angular/src/app/frame/footbar.component.css
@@ -17,6 +17,10 @@
     width: 286px;
 }
 
+.footer__logo {
+  margin-bottom: 1em;
+}
+
 field-items img
 {width:100%;}
 

--- a/angular/src/app/frame/footbar.component.css
+++ b/angular/src/app/frame/footbar.component.css
@@ -1,0 +1,318 @@
+#footer {
+    background: #333333;
+    /*background-color: white;*/
+    color: white;
+    position: relative;
+}
+
+.footer__inner {
+    padding-left:20px;
+    padding-top:20px;
+    padding-right:20px;
+    padding-bottom:10px;
+
+}
+
+#footer .footer__logo img {
+    width: 286px;
+}
+
+field-items img
+{width:100%;}
+
+img {
+    border: 0;
+    max-width: 100%;
+    height: auto;
+}
+
+#footer a {
+    color: white;
+}
+
+.clearfix:after {
+    content: ".";
+    display: block;
+    height: 0;
+    clear: both;
+    visibility: hidden;
+}
+
+#footer .footer__contact {
+    font-size: 15px;
+    line-height: 17px;
+    border-bottom: 1px solid #595959;
+    padding-bottom : .6rem;
+}
+
+.custom-icon:hover {
+  color:#8ac34e;
+}
+
+.item-list li{
+  display:inline;
+  padding:0px 0px 0px 0px;
+  padding:0rem .2rem 0rem 0rem;
+  list-style-type:none;
+  background-image:none;
+  margin-bottom:24px;
+  margin-bottom:1.5rem;
+  margin-left:0;
+}
+
+.menu--footer-main-menu {
+    clear: both;
+    border-top: 1px solid #595959;
+    border-bottom: 1px solid #595959;
+    padding-bottom: 40px;
+    padding-bottom: 2.5rem;
+}
+
+.block {
+    margin-bottom: 1.0rem;
+}
+
+.menu--footer-main-menu ul.menu {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+dl, menu, ol, ul {
+    margin: 0px 0px 20px 16px;
+    margin: 0rem 0rem 1.25rem 1rem;
+    padding: 0px 0px 0px 32px;
+    padding: 0rem 0rem 0rem 2rem;
+}
+
+ul, menu, dir {
+    display: block;
+    list-style-type: disc;
+    -webkit-margin-before: 1em;
+    -webkit-margin-after: 1em;
+    -webkit-margin-start: 0px;
+    -webkit-margin-end: 0px;
+    -webkit-padding-start: 40px;
+}
+
+.menu--footer-main-menu ul.menu li {
+    padding: 0;
+    margin-bottom: 0;
+    vertical-align: top;
+    font-size: 16px;
+    font-size: 1rem;
+    line-height: 20px;
+    line-height: 1.25rem;
+}
+
+#footer .social-links {
+    float: right;
+}
+
+.social-btn--large {
+    height: 40px;
+}
+
+.social-btn {
+    margin-right: 2px;
+    margin-left: 0;
+    padding: 0;
+    height: 34px;
+    color: white;
+}
+
+ul.list-horiz > li, li.list-horiz {
+    list-style: none;
+    display: inline-block;
+    margin: 0;
+}
+
+.social-btn:hover, .social-btn:visited, .social-btn:active {
+    color: white;
+}
+
+a:visited {
+    color: #2d9de7;
+}
+
+.social-btn--large i:before {
+    font-size: 26px;
+    line-height: 40px;
+    height: 40px;
+    width: 40px;
+    text-align: center;
+    display: inline-block;
+}
+
+.social-btn .ext {
+    display: none;
+}
+
+span.ext {
+    display: inline-block;
+    padding-right: 0;
+    text-indent: -99999px;
+    width: 12px;
+}
+
+span.ext {
+    background: url(https://www.nist.gov/sites/all/modules/contrib/extlink/extlink_s.png) 2px center no-repeat;
+    width: 10px;
+    height: 10px;
+    padding-right: 12px;
+    text-decoration: none;
+}
+
+.element-invisible, .element-focusable, #navigation .block-menu .block__title, #navigation .block-menu-block .block__title {
+    position: absolute !important;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px, 1px, 1px, 1px);
+}
+
+.menu--footer-menu {
+    clear: both;
+     margin-bottom: 0.6rem;
+}
+
+
+.menu--footer-menu ul.menu {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    text-align: center;
+}
+
+
+ul, menu, dir {
+    display: block;
+    -webkit-margin-before: 1em;
+    -webkit-margin-after: 1em;
+    -webkit-margin-start: 0px;
+    -webkit-margin-end: 0px;
+    -webkit-padding-start: 40px;
+}
+
+.menu--footer-menu ul.menu li {
+    display: inline-block;
+    font-size: 0.9rem;
+    padding: 0;
+    margin-bottom: 0;
+    margin-left: 0;
+}
+
+.menu--footer-menu ul.menu {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.menu--footer-menu ul.menu li.first:before {
+    content: none;
+}
+.menu--footer-menu ul.menu li:before {
+    content: '|';
+    margin-left: 1.6px;
+    margin-left: 0.1rem;
+    display: inherit;
+    position: static;
+    font: inherit;
+    line-height: inherit;
+    color: inherit;
+}
+
+#footer a {
+    color:  white;
+}
+.menu--footer-menu ul.menu li.first a {
+    margin-left: 0;
+}
+.menu--footer-menu ul.menu li a {
+    font-weight: normal;
+    white-space: nowrap;
+}
+.menu a {
+    text-decoration: none;
+}
+
+.menu--footer-menu ul.menu li {
+    display: inline-block;
+    padding: 0;
+    margin-bottom: 0;
+    margin-left: 0;
+}
+
+.social-btn {
+  margin-right:2px;
+  margin-left:0;
+  padding:0;
+  height:40px;
+  color:gray;
+}
+.social-btn:hover,.social-btn:visited,.social-btn:active{
+  color:gray;
+}
+.social-btn i:before{
+  font-size:22px;
+  line-height:40px;
+  height:40px;
+  width:40px;
+  text-align:center;
+  display:inline-block;
+}
+
+.social-btn i{
+  transition:background-color 300ms ease;
+}
+.social-btn i:hover{
+  color:#fff;
+  background:gray;
+  height: 40px;
+  line-height: 40px;
+  text-align:center;
+  display:inline-block;
+}
+.social-btn i.faa-facebook:hover{
+  background:#3a5897;
+}
+.social-btn i.faa-google-plus:hover{
+  background:#d2412f;
+}
+.social-btn i.faa-twitter:hover{
+  background:#49c9f2;
+}
+.social-btn i.faa-youtube:hover{
+  background:#e52d27;
+}
+
+.social-btn {
+  margin-right: 2px;
+  margin-left: 0;
+  padding: 0;
+  height: 34px;
+  color: white;
+}
+
+.fa, .social-share a {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.menu--footer-menu.first {
+  padding-top: 1.0rem;
+}
+
+ul, menu, dir {
+  display: block;
+  -webkit-margin-before: 1em;
+  -webkit-margin-after: 1em;
+  -webkit-margin-start: 0px;
+  -webkit-margin-end: 0px;
+  -webkit-padding-start: 40px;
+}
+

--- a/angular/src/app/frame/footbar.component.html
+++ b/angular/src/app/frame/footbar.component.html
@@ -1,0 +1,130 @@
+<div id="footer" class="region region-footer ">
+  <div class="footer__inner">
+
+    <div class="social-links">
+      <div class="item-list">
+        <ul>
+          <li> <a href="https://twitter.com/USNISTGOV" target="_blank"
+                  class="social-btn social-btn--large extlink ext"><i class="faa faa-twitter"><span
+                  class="element-invisible">twitter</span></i><span class="ext"><span
+                  class="element-invisible"> (link is external)</span></span></a></li>
+          <li class="field-item service-facebook list-horiz">
+               <a href="https://www.facebook.com/USNISTGOV" target="_blank"
+                  class="social-btn social-btn--large extlink ext"><i class="faa faa-facebook"><span
+                  class="element-invisible">facebook</span></i><span class="ext"><span
+                  class="element-invisible"> (link is external)</span></span></a></li>
+          <li class="field-item service-googleplus list-horiz">
+               <a href="https://plus.google.com/+USNISTGOV" target="_blank"
+                  class="social-btn social-btn--large extlink ext"><i class="faa faa-google-plus"><span
+                  class="element-invisible">google plus</span></i><span class="ext"><span
+                  class="element-invisible"> (link is external)</span></span></a></li>
+          <li class="field-item service-youtube list-horiz">
+               <a href="https://www.youtube.com/user/USNISTGOV" target="_blank"
+                  class="social-btn social-btn--large extlink ext"><i class="faa faa-youtube"><span
+                  class="element-invisible">youtube</span></i><span class="ext"><span
+                  class="element-invisible"> (link is external)</span></span></a></li>
+          <li class="field-item service-rss list-horiz">
+               <a href="https://www2.nist.gov/news-events/nist-rss-feeds" target="_blank"
+                  class="social-btn social-btn--large extlink"><i class="faa faa-rss"><span
+                  class="element-invisible">rss</span></i></a></li>
+          <li class="field-item service-govdelivery list-horiz last">
+               <a href="https://service.govdelivery.com/accounts/USNIST/subscriber/new" target="_blank"
+                  class="social-btn social-btn--large extlink ext"><i class="faa faa-envelope"><span
+                  class="element-invisible">govdelivery</span></i><span class="ext"><span
+                  class="element-invisible"> (link is external)</span></span></a></li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="footer__logo">
+        <a href="https://nist.gov/" title="National Institute of Standards and Technology"
+           class="footer__logo-link" rel="home">
+        <img src="./assets/images/logo_rev.png" alt="National Institute of Standards and Technology"
+             title="National Institute of Standards and Technology">
+      </a>
+    </div>
+
+    <div class="footer__contact">
+      <p>
+        <strong>HEADQUARTERS</strong><br>
+        100 Bureau Drive<br>
+        Gaithersburg, MD 20899
+      </p>
+      <p>
+        <a href="https://www.nist.gov/about-nist/contact-us" target="_blank"><u>Contact Us</u></a> |
+        <a href="https://www.nist.gov/about-nist/our-organization" target="_blank"><u>Our Other
+           Offices</u></a>
+      </p>
+    </div>
+
+    <div id="block-menu-menu-footer-menu"
+         class="block menu--footer-menu first even block--menu block--menu-menu-footer-menu"
+         role="navigation">
+      <ul class="menu">
+        <li class="menu__item is-leaf first leaf menu-depth-1">
+           <a href="https://www.nist.gov/privacy-policy" target="_blank"
+              class="menu__link">Privacy Statement</a></li>
+        <li class="menu__item is-leaf leaf menu-depth-1">
+           <a href="https://www.nist.gov/privacy-policy#privpolicy" target="_blank"
+              class="menu__link"> Privacy Policy</a></li>
+        <li class="menu__item is-leaf leaf menu-depth-1">
+           <a href="https://www.nist.gov/privacy-policy#secnot" target="_blank"
+              class="menu__link"> Security Notice</a></li>
+        <li class="menu__item is-leaf leaf menu-depth-1">
+           <a href="https://www.nist.gov/privacy-policy#accesstate" target="_blank"
+              class="menu__link"> Accessibility Statement</a></li>
+        <li class="menu__item is-leaf leaf menu-depth-1">
+           <a href="https://www.nist.gov/privacy" target="_blank"
+              class="menu__link"> NIST Privacy Program</a></li>
+        <li class="menu__item is-leaf last leaf menu-depth-1">
+           <a href="https://www.nist.gov/no-fear-act-policy" target = "_blank"
+              class="menu__link"> No Fear Act Policy</a></li>
+      </ul>
+    </div>
+    <div id="block-menu-menu-footer-menu-2"
+         class="block menu--footer-menu odd block--menu block--menu-menu-footer-menu-2" role="navigation">
+      <ul class="menu">
+        <li class="menu__item is-leaf first leaf menu-depth-1">
+           <a href="https://www.nist.gov/disclaimer" target="_blank" class="menu__link"> Disclaimer</a></li>
+        <li class="menu__item is-leaf leaf menu-depth-1">
+           <a href="https://www.nist.gov/office-director/freedom-information-act" target="_blank"
+              class="menu__link"> FOIA</a></li>
+        <li class="menu__item is-leaf leaf menu-depth-1">
+           <a href="https://www.nist.gov/environmental-policy-statement" target="_blank"
+              class="menu__link"> Environmental Policy Statement</a></li>
+        <li class="menu__item is-leaf leaf menu-depth-1">
+           <a href="https://www.nist.gov/privacy-policy#cookie" target="_blank"
+              class="menu__link"> Cookie Disclaimer</a></li>
+        <li class="menu__item is-leaf leaf menu-depth-1">
+           <a href="https://www.nist.gov/summary-report-scientific-integrity" target="_blank"
+              class="menu__link"> Scientific Integrity Summary</a></li>
+        <li class="menu__item is-leaf last leaf menu-depth-1">
+           <a href="https://www.nist.gov/nist-information-quality-standards" target="_blank"
+              class="menu__link"> NIST Information Quality Standards</a></li>
+      </ul>
+    </div>
+      
+    <div id="block-menu-menu-footer-menu-3"
+         class="block menu--footer-menu last even block--menu block--menu-menu-footer-menu-3"
+         role="navigation">
+      <ul class="menu">
+        <li class="menu__item is-leaf first leaf menu-depth-1">
+           <a href="http://business.usa.gov/" class="menu__link ext extlink"
+              target="_blank">Business USA<span class="ext"><span
+              class="element-invisible"> (link is external)</span></span></a></li>
+        <li class="menu__item is-leaf leaf menu-depth-1">
+           <a href="https://www.healthcare.gov/" class="menu__link ext extlink"
+              target="_blank"> Healthcare.gov<span class="ext"><span
+              class="element-invisible"> (link is external)</span></span></a></li>
+        <li class="menu__item is-leaf leaf menu-depth-1">
+           <a href="http://www.science.gov/" class="menu__link ext extlink"
+              target="_blank"> Science.gov<span class="ext"><span
+              class="element-invisible"> (link is external)</span></span></a></li>
+        <li class="menu__item is-leaf last leaf menu-depth-1">
+           <a href="http://www.usa.gov/" class="menu__link ext extlink"
+              target="_blank"> USA.gov<span class="ext"><span
+              class="element-invisible"> (link is external)</span></span></a></li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/angular/src/app/frame/footbar.component.html
+++ b/angular/src/app/frame/footbar.component.html
@@ -13,11 +13,14 @@
                   class="social-btn social-btn--large extlink ext"><i class="faa faa-facebook"><span
                   class="element-invisible">facebook</span></i><span class="ext"><span
                   class="element-invisible"> (link is external)</span></span></a></li>
-          <li class="field-item service-googleplus list-horiz">
-               <a href="https://plus.google.com/+USNISTGOV" target="_blank"
-                  class="social-btn social-btn--large extlink ext"><i class="faa faa-google-plus"><span
-                  class="element-invisible">google plus</span></i><span class="ext"><span
+          <li><a href="https://www.linkedin.com/company/nist" target="_blank"
+                  class="social-btn social-btn--large extlink ext"><i class="faa faa-linkedin"><span
+                  class="element-invisible">linkedin</span></i><span class="ext"><span
                   class="element-invisible"> (link is external)</span></span></a></li>
+          <li><a href="https://www.instagram.com/usnistgov/" target="_blank"
+               class="social-btn social-btn--large extlink ext"><i class="faa faa-instagram"><span
+               class="element-invisible">Instagram</span></i><span
+               class="ext" aria-label="(link is external)"></span></a></li>
           <li class="field-item service-youtube list-horiz">
                <a href="https://www.youtube.com/user/USNISTGOV" target="_blank"
                   class="social-btn social-btn--large extlink ext"><i class="faa faa-youtube"><span

--- a/angular/src/app/frame/footbar.component.spec.ts
+++ b/angular/src/app/frame/footbar.component.spec.ts
@@ -1,0 +1,31 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FootbarComponent } from './footbar.component';
+
+describe('FootbarComponent', () => {
+    let component : FootbarComponent;
+    let fixture : ComponentFixture<FootbarComponent>;
+
+    it('should contain expected content', () => {
+        TestBed.configureTestingModule({
+            declarations: [ FootbarComponent ]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(FootbarComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+
+        expect(component).toBeDefined();
+
+        let cmpel = fixture.nativeElement;
+        let aels = cmpel.querySelectorAll("a");
+        expect(aels.length).toBeGreaterThan(3);
+        let links = [];
+        for (let i = 0; i < aels.length; i++)
+            links.push(aels[i].getAttribute("href"));
+        expect(links.includes("https://twitter.com/USNISTGOV")).toBe(true);
+        expect(links.includes("https://www.facebook.com/USNISTGOV")).toBe(true);
+        expect(links.includes("https://www.youtube.com/user/USNISTGOV")).toBe(true);
+        expect(links.includes("https://nist.gov/")).toBe(true);
+    });
+});

--- a/angular/src/app/frame/footbar.component.ts
+++ b/angular/src/app/frame/footbar.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+
+/**
+ * A Component that serves as the footer of the landing page.  
+ * 
+ * Features include:
+ * * Set as black bar at the bottom of the page
+ */
+@Component({
+  moduleId: module.id,
+  selector: 'pdr-footbar',
+  templateUrl: 'footbar.component.html',
+  styleUrls: ['footbar.component.css']
+})
+export class FootbarComponent { }

--- a/angular/src/app/frame/frame.module.ts
+++ b/angular/src/app/frame/frame.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
+import { RouterModule } from '@angular/router';
 import { HeadbarComponent } from "./headbar.component";
 import { FootbarComponent } from "./footbar.component";
 
@@ -13,7 +14,8 @@ import { FootbarComponent } from "./footbar.component";
         FootbarComponent
     ],
     imports: [
-        CommonModule       // provides template directives
+        CommonModule,       // provides template directives
+        RouterModule        // allow use of [routerLink]
     ],
     exports: [ HeadbarComponent, FootbarComponent ]
 })

--- a/angular/src/app/frame/frame.module.ts
+++ b/angular/src/app/frame/frame.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { HeadbarComponent } from "./headbar.component";
+import { FootbarComponent } from "./footbar.component";
+
+/**
+ * A module that provides components that make up the "frame" of the landing 
+ * page--namely, the header and the footer.
+ */
+@NgModule({
+    declarations: [
+        HeadbarComponent,
+        FootbarComponent
+    ],
+    imports: [
+        CommonModule       // provides template directives
+    ],
+    exports: [ HeadbarComponent, FootbarComponent ]
+})
+export class FrameModule {
+
+}
+

--- a/angular/src/app/frame/headbar.component.css
+++ b/angular/src/app/frame/headbar.component.css
@@ -1,0 +1,63 @@
+
+
+.header__logo-link {
+    /* display: block; */
+}
+.background-black
+{
+    background-color: #000000;
+}
+.header-background {
+    background-color: #333333;
+}
+.header-div {
+    /*vertical-align: middle;*/
+    padding-top: 1%;
+    /*margin-bottom: 10px;*/
+    padding-bottom: 1%;
+    padding-left: 1%;
+    color: white;
+}
+
+.header-links {
+    margin-right: 0px;
+    margin-top: 0px;
+    color:white;
+    padding-right: 2%;
+}
+
+
+.textlinks {
+    color:white;
+}
+
+
+.badgesm {
+    font-size: 12px;
+    font-weight: bold;
+    color: #fff;
+    padding: 3px 7px; 
+    vertical-align: 50%;
+/*    margin-top: -3.0em;
+    margin-right: -2.0em; */
+    height:20px;
+    width:20px;
+    min-width: 10px;
+    z-index: 10;
+    line-height: 1;
+    text-align: center;
+    white-space: nowrap;
+    background-color: #777;
+    border-radius: 10px;
+}
+
+.badge-notify {
+    background-color: green;
+    position:relative;
+    top: -20px;
+    left: -5px;
+    font-size: 9px;
+    height:20px;
+    width:20px;
+    padding:5px 3px 3px 3px ;
+}

--- a/angular/src/app/frame/headbar.component.css
+++ b/angular/src/app/frame/headbar.component.css
@@ -12,10 +12,10 @@
 }
 .header-div {
     /*vertical-align: middle;*/
-    padding-top: 1%;
+    padding-top: 0.7em;
     /*margin-bottom: 10px;*/
-    padding-bottom: 1%;
-    padding-left: 1%;
+    padding-bottom: 0.6em;
+    padding-left: 0.7em;
     color: white;
 }
 
@@ -53,11 +53,12 @@
 
 .badge-notify {
     background-color: green;
-    position:relative;
-    top: -20px;
+    color: white;
+    position: relative;
+    top: -10px;
     left: -5px;
     font-size: 9px;
-    height:20px;
-    width:20px;
-    padding:5px 3px 3px 3px ;
+    height: 20px;
+    width: 20px;
+    padding: 5px 3px 3px 3px ;
 }

--- a/angular/src/app/frame/headbar.component.css
+++ b/angular/src/app/frame/headbar.component.css
@@ -8,7 +8,7 @@
     background-color: #000000;
 }
 .header-background {
-    background-color: #333333;
+    background-color: #000000;
 }
 .header-div {
     /*vertical-align: middle;*/

--- a/angular/src/app/frame/headbar.component.html
+++ b/angular/src/app/frame/headbar.component.html
@@ -1,0 +1,25 @@
+<div [ngClass]="{ 'layout-wrapper': true, 'layout-compact': layoutCompact }">
+<div [ngClass]="{ 'layout-container': false,
+                  'menu-layout-static': (layoutMode=='static' || layoutMode=='horizontal'),
+                  'menu-layout-overlay': (layoutMode=='overlay'),
+                  'menu-layout-horizontal': (layoutMode=='horizontal') }">
+  <div class="topbar clearfix header-background">
+    <div class="header-div">
+      <a href="/" title="NIST Public Data Repository"
+         class="header__logo-link" rel="home">
+        <img class="Fleft" src="./assets/images/nist-pdr-rev.png"
+             alt="NIST Public Data Repository" title="NIST Public Data Repository" />
+      </a>
+
+      <span *ngIf="status" class="badge" id="appVersion" style="background-color:#8f3919">{{ appVersion }}</span>
+         &nbsp;&nbsp;
+      <span *ngIf="status" class="badge" id="appStatus" style="background-color:darkcyan">{{ status }}</span>
+      <div align="right" class="header-links">
+        <a href="/pdr/about" target="_blank"><span class="textlinks"><b>About</b></span></a> | 
+        <a href="{{ searchLink }}" target="_blank"><span class="textlinks"><b>Search</b></span></a>
+      </div>
+    </div>
+  </div>
+</div>
+</div>
+  

--- a/angular/src/app/frame/headbar.component.html
+++ b/angular/src/app/frame/headbar.component.html
@@ -7,16 +7,25 @@
     <div class="header-div">
       <a href="/" title="NIST Public Data Repository"
          class="header__logo-link" rel="home">
-        <img class="Fleft" src="./assets/images/nist-pdr-rev.png"
-             alt="NIST Public Data Repository" title="NIST Public Data Repository" />
+         <img class="Fleft top_bar" src="./assets/images/nist_logo_reverse.png"
+           alt="NIST Public Data Repository"
+           title="NIST Public Data Repository">
+         <span class="Fleft"
+           style="font-weight:bold;line-height: 16.5px;display: table-cell;vertical-align: text-top;color: #FFFFFF;font-size:14px;padding-left: 0.5em">PUBLIC
+           <br> DATA REPOSITORY </span>
       </a>
 
-      <span *ngIf="status" class="badge" id="appVersion" style="background-color:#8f3919">{{ appVersion }}</span>
+      <span *ngIf="appVersion" class="badge" id="appVersion" style="background-color:#f0f0f0; margin-left: 0.5em; color: black;">{{ appVersion }}</span>
          &nbsp;&nbsp;
       <span *ngIf="status" class="badge" id="appStatus" style="background-color:darkcyan">{{ status }}</span>
       <div align="right" class="header-links">
-        <a href="/pdr/about" target="_blank"><span class="textlinks"><b>About</b></span></a> | 
-        <a href="{{ searchLink }}" target="_blank"><span class="textlinks"><b>Search</b></span></a>
+        <a href="/about" target="_blank"><span class="textlinks"><b>About</b></span></a> | 
+        <a href="{{ searchLink }}" target="_blank"><span class="textlinks"><b>Search</b></span></a> |
+        <a [routerLink]="['/datacart', 'normal']" routerLinkActive="active" target="_blank"
+            (click)="updateCartStatus()"><span class="textlinks"><b>Cart </b></span>
+            <i class="faa faa-shopping-cart faa-1x icon-white" style="color: #fff;"></i>
+            <span class="w3-badge badge-pill badge-notify">&nbsp;{{cartLength}}&nbsp;</span></a>
+        
       </div>
     </div>
   </div>

--- a/angular/src/app/frame/headbar.component.spec.ts
+++ b/angular/src/app/frame/headbar.component.spec.ts
@@ -1,0 +1,72 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TransferState } from '@angular/platform-browser';
+
+import { HeadbarComponent } from './headbar.component';
+import { AngularEnvironmentConfigService } from '../config/config.service';
+import { AppConfig } from '../config/config'
+
+describe('HeadbarComponent', () => {
+    let component : HeadbarComponent;
+    let fixture : ComponentFixture<HeadbarComponent>;
+    let cfg : AppConfig;
+    let plid : Object = "browser";
+    let ts : TransferState = new TransferState();
+
+    it('should display configured information', () => {
+        cfg = (new AngularEnvironmentConfigService(plid, ts)).getConfig() as AppConfig;
+        cfg.locations.pdrSearch = "https://goob.nist.gov/search";
+        cfg.status = "Unit Testing";
+        cfg.appVersion = "2.test";
+        
+        TestBed.configureTestingModule({
+            declarations: [ HeadbarComponent ],
+            providers: [{ provide: AppConfig, useValue: cfg }]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(HeadbarComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+
+        expect(component).toBeDefined();
+        expect(component.searchLink).toBe("https://goob.nist.gov/search");
+        expect(component.status).toBe("Unit Testing");
+        expect(component.appVersion).toBe("2.test");
+
+        let cmpel = fixture.nativeElement;
+        let el = cmpel.querySelector("#appVersion"); 
+        expect(el.textContent).toBe(component.appVersion);
+        el = cmpel.querySelector("#appStatus");
+        expect(el.textContent).toBe(component.status);
+
+        let aels = cmpel.querySelectorAll(".header-links a")
+        expect(aels.length).toBeGreaterThan(1);
+        expect(aels[0].getAttribute('href')).toBe("/pdr/about");
+        expect(aels[1].getAttribute('href')).toBe("https://goob.nist.gov/search");
+    });
+
+    it('badges are optional', () => {
+        cfg = (new AngularEnvironmentConfigService(plid, ts)).getConfig() as AppConfig;
+        cfg.locations.pdrSearch = "https://goob.nist.gov/search";
+        cfg.status = undefined;
+        cfg.appVersion = undefined;
+        
+        TestBed.configureTestingModule({
+            declarations: [ HeadbarComponent ],
+            providers: [{ provide: AppConfig, useValue: cfg }]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(HeadbarComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+
+        expect(component).toBeDefined();
+        expect(component.appVersion).toBe('');
+        expect(component.status).toBe('');
+
+        let cmpel = fixture.nativeElement;
+        let el = cmpel.querySelector("#appVersion"); 
+        expect(el).toBeNull();
+        el = cmpel.querySelector("#appStatus");
+        expect(el).toBeNull();
+    });
+});

--- a/angular/src/app/frame/headbar.component.spec.ts
+++ b/angular/src/app/frame/headbar.component.spec.ts
@@ -1,14 +1,24 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { TransferState } from '@angular/platform-browser';
+import { RouterModule } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Component } from '@angular/core';
+import { HttpClientModule, HttpClient } from '@angular/common/http';
 
 import { HeadbarComponent } from './headbar.component';
 import { AngularEnvironmentConfigService } from '../config/config.service';
 import { AppConfig } from '../config/config'
+import { CartService } from '../datacart/cart.service';
+import { Data } from '../datacart/data';
+
+@Component({ template: '' })
+class DummyComponent {}
 
 describe('HeadbarComponent', () => {
     let component : HeadbarComponent;
     let fixture : ComponentFixture<HeadbarComponent>;
     let cfg : AppConfig;
+    let cart : CartService;
     let plid : Object = "browser";
     let ts : TransferState = new TransferState();
 
@@ -19,8 +29,17 @@ describe('HeadbarComponent', () => {
         cfg.appVersion = "2.test";
         
         TestBed.configureTestingModule({
-            declarations: [ HeadbarComponent ],
-            providers: [{ provide: AppConfig, useValue: cfg }]
+            imports: [
+                RouterTestingModule.withRoutes([
+                    { path: 'datacart', component: DummyComponent }
+                ]),
+                HttpClientModule
+            ],
+            declarations: [ HeadbarComponent, DummyComponent ],
+            providers: [
+                { provide: AppConfig, useValue: cfg  },
+                CartService
+            ]
         }).compileComponents();
 
         fixture = TestBed.createComponent(HeadbarComponent);
@@ -40,7 +59,7 @@ describe('HeadbarComponent', () => {
 
         let aels = cmpel.querySelectorAll(".header-links a")
         expect(aels.length).toBeGreaterThan(1);
-        expect(aels[0].getAttribute('href')).toBe("/pdr/about");
+        expect(aels[0].getAttribute('href')).toBe("/about");
         expect(aels[1].getAttribute('href')).toBe("https://goob.nist.gov/search");
     });
 
@@ -51,8 +70,17 @@ describe('HeadbarComponent', () => {
         cfg.appVersion = undefined;
         
         TestBed.configureTestingModule({
-            declarations: [ HeadbarComponent ],
-            providers: [{ provide: AppConfig, useValue: cfg }]
+            imports: [
+                RouterTestingModule.withRoutes([
+                    { path: 'datacart', component: DummyComponent }
+                ]),
+                HttpClientModule
+            ],
+            declarations: [ HeadbarComponent, DummyComponent ],
+            providers: [
+                { provide: AppConfig, useValue: cfg  },
+                CartService
+            ]
         }).compileComponents();
 
         fixture = TestBed.createComponent(HeadbarComponent);
@@ -68,5 +96,45 @@ describe('HeadbarComponent', () => {
         expect(el).toBeNull();
         el = cmpel.querySelector("#appStatus");
         expect(el).toBeNull();
+    });
+
+    it('displays active cart size', () => {
+        cfg = (new AngularEnvironmentConfigService(plid, ts)).getConfig() as AppConfig;
+        cfg.locations.pdrSearch = "https://goob.nist.gov/search";
+        cfg.status = undefined;
+        cfg.appVersion = undefined;
+        
+        TestBed.configureTestingModule({
+            imports: [
+                RouterTestingModule.withRoutes([
+                    { path: 'datacart', component: DummyComponent }
+                ]),
+                HttpClientModule
+            ],
+            declarations: [ HeadbarComponent, DummyComponent ],
+            providers: [
+                { provide: AppConfig, useValue: cfg  },
+                CartService
+            ]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(HeadbarComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+
+        expect(component).toBeDefined();
+        expect(component.cartLength).toBe(0);
+
+        let data : Data = {
+            cartId: "cart", ediid: "YYZ", id: "urn:YYZ", downloadUrl: "http://goob/YYZ", 
+            resId: null, resTitle: "Booya!", resFilePath: "YYZ", filePath: "YYZ", fileName: "YYZ", 
+            fileSize: null, filetype: "text/plain", downloadStatus: "burnt", mediatype: "text/plain",
+            description: null, isSelected: false, message: "hello world"
+        };
+        component.cartService.addDataToCart(data);
+        expect(component.cartLength).toBe(1);
+
+        // consequence of a click on the datacart
+        component.updateCartStatus();
     });
 });

--- a/angular/src/app/frame/headbar.component.ts
+++ b/angular/src/app/frame/headbar.component.ts
@@ -1,0 +1,39 @@
+import { Component, ElementRef } from '@angular/core';
+import { AppConfig } from '../config/config';
+
+/**
+ * A Component that serves as the header of the landing page.  
+ * 
+ * Features include:
+ * * Set as black bar at the top of the page
+ * * NIST PDR logo that links to the PDR home page (currently the SDP)
+ * * PDR-wide links:
+ *   * About page
+ *   * Search page (the SDP)
+ *   * User's Datacart
+ * * Labels indicating the version and status of the PDR
+ *   * this uses the badge style from bootstrap
+ */
+@Component({
+    moduleId: module.id,
+    selector: 'pdr-headbar',
+    templateUrl: 'headbar.component.html',
+    styleUrls: ['headbar.component.css']
+})
+export class HeadbarComponent {
+
+    layoutCompact : boolean = true;
+    layoutMode : string = 'horizontal';
+    searchLink : string = "";
+    status : string = "";
+    appVersion : string = "";
+
+    constructor(private el: ElementRef, private cfg : AppConfig) {
+        if (! (cfg instanceof AppConfig))
+            throw new Error("HeadbarComponent: Wrong config type provided: "+cfg);
+        this.searchLink = cfg.get("locations.pdrSearch", "/sdp/");
+        this.status = cfg.get("status", "");
+        this.appVersion = cfg.get("appVersion","");
+    }
+  
+}

--- a/angular/src/app/frame/headbar.component.ts
+++ b/angular/src/app/frame/headbar.component.ts
@@ -1,5 +1,7 @@
 import { Component, ElementRef } from '@angular/core';
 import { AppConfig } from '../config/config';
+import { CartService } from '../datacart/cart.service';
+import { CartEntity } from '../datacart/cart.entity';
 
 /**
  * A Component that serves as the header of the landing page.  
@@ -27,13 +29,43 @@ export class HeadbarComponent {
     searchLink : string = "";
     status : string = "";
     appVersion : string = "";
+    cartLength : number = 0;
+    cartEntities : CartEntity[] = [] as CartEntity[];  // is this needed here?
 
-    constructor(private el: ElementRef, private cfg : AppConfig) {
+    constructor(private el: ElementRef, private cfg : AppConfig,
+                public cartService : CartService)
+    {
         if (! (cfg instanceof AppConfig))
             throw new Error("HeadbarComponent: Wrong config type provided: "+cfg);
         this.searchLink = cfg.get("locations.pdrSearch", "/sdp/");
         this.status = cfg.get("status", "");
         this.appVersion = cfg.get("appVersion","");
+
+        this.cartService.watchStorage().subscribe( value => {
+            this.cartLength = value;
+        });
     }
-  
+
+    // Is this needed?
+    getDataCartList() {
+        this.cartService.getAllCartEntities().then(function (result) {
+            this.cartEntities = result;
+            this.cartLength = this.cartEntities.length;
+            return this.cartLength;
+        }.bind(this), function (err) {
+            console.error("Headbar: failure while fetching data cart size");
+            console.error(err);
+            // alert("something went wrong while fetching the products");
+        });
+        return null;
+    }
+
+    /**
+     * ensure that the data cart display is up to date
+     */
+    updateCartStatus() {
+        this.cartService.updateCartDisplayStatus(true);
+        this.cartService.setCurrentCart('cart');
+    }
+
 }

--- a/angular/src/app/landing/description/description.component.html
+++ b/angular/src/app/landing/description/description.component.html
@@ -52,6 +52,7 @@
     </span>
 
     <div *ngIf="files.length  > 0">
+    <div *ngIf="inBrowser; else filesLoading">
       <div class="flex-container" style="margin-top: 2em;">
         <div style="flex: 0 0 110px; text-align: left; padding-bottom: 0em;">
           <span><b>Files </b> </span>
@@ -188,6 +189,15 @@
           </tr>
         </ng-template>
       </p-treeTable>
+    </div>
+    <ng-template #filesLoading>
+      <div>
+        <b>Files </b>
+      </div>
+      <p>
+        <i>Loading file list...</i>
+      </p>
+    </ng-template>
     </div>
   </div>
 </div>

--- a/angular/src/app/landing/description/description.component.ts
+++ b/angular/src/app/landing/description/description.component.ts
@@ -84,8 +84,8 @@ export class DescriptionComponent {
   confValues: Config;
   isLocalProcessing: boolean;
   showDownloadProgress: boolean = false;
-  mobWidth: number;
-  mobHeight: number;
+  mobWidth: number = 800;   // default value used in server context
+  mobHeight: number = 900;  // default value used in server context
   fontSize: string;
 
   /* Function to Return Keys object properties */
@@ -109,18 +109,20 @@ export class DescriptionComponent {
         { field: 'mediatype', header: 'Media Type', width: 'auto' },
         { field: 'size', header: 'Size', width: 'auto' },
         { field: 'download', header: 'Status', width: 'auto' }];
-        
-      this.mobHeight = (window.innerHeight);
-      this.mobWidth = (window.innerWidth);
-      this.setWidth(this.mobWidth);
+
+      if (typeof(window) !== 'undefined') {
+        this.mobHeight = (window.innerHeight);
+        this.mobWidth = (window.innerWidth);
+        this.setWidth(this.mobWidth);
   
-      window.onresize = (e) => {
-        ngZone.run(() => {
-          this.mobWidth = window.innerWidth;
-          this.mobHeight = window.innerHeight;
-          this.setWidth(this.mobWidth);
-        });
-    };
+        window.onresize = (e) => {
+          ngZone.run(() => {
+            this.mobWidth = window.innerWidth;
+            this.mobHeight = window.innerHeight;
+            this.setWidth(this.mobWidth);
+          });
+        };
+      }
 
     this.cartService.watchAddAllFilesCart().subscribe(value => {
       this.addAllFileSpinner = value;

--- a/angular/src/app/landing/description/description.component.ts
+++ b/angular/src/app/landing/description/description.component.ts
@@ -37,6 +37,7 @@ export class DescriptionComponent {
   @Input() editContent: boolean;
   @Input() filescount: number;
   @Input() metadata: boolean;
+  @Input() inBrowser : boolean;   // false if running server-side
 
   addAllFileSpinner: boolean = false;
   fileDetails: string = '';

--- a/angular/src/app/landing/description/description.component.ts
+++ b/angular/src/app/landing/description/description.component.ts
@@ -12,7 +12,7 @@ import { CommonVarService } from '../../shared/common-var';
 import { environment } from '../../../environments/environment';
 import { HttpClientModule, HttpClient, HttpHeaders, HttpRequest, HttpEventType, HttpResponse, HttpEvent } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
-import { AppConfig, Config } from '../../shared/config-service/config.service';
+import { AppConfig } from '../../config/config';
 import { THIS_EXPR } from '@angular/compiler/src/output/output_ast';
 import { FileSaverService } from 'ngx-filesaver';
 import { Router } from '@angular/router';
@@ -81,7 +81,6 @@ export class DescriptionComponent {
   messageColor: any;
   noFileDownloaded: boolean; // will be true if any item in data cart is downloaded
   distApi: string;
-  confValues: Config;
   isLocalProcessing: boolean;
   showDownloadProgress: boolean = false;
   mobWidth: number = 800;   // default value used in server context
@@ -98,7 +97,7 @@ export class DescriptionComponent {
     private downloadService: DownloadService,
     private commonVarService: CommonVarService,
     private http: HttpClient,
-    private appConfig: AppConfig,
+    private cfg : AppConfig,
     private _FileSaverService: FileSaverService,
     private confirmationService: ConfirmationService,
     private commonFunctionService: CommonFunctionService,
@@ -137,11 +136,10 @@ export class DescriptionComponent {
         this.cartLength = this.cartService.getCartSize();
       }
     });
-    this.confValues = this.appConfig.getConfig();
   }
 
   ngOnInit() {
-    this.distApi = this.confValues.DISTAPI;
+    this.distApi = this.cfg.get("distService", "/od/ds/");
 
     if (this.files.length != 0)
       this.files = <TreeNode[]>this.files[0].data;

--- a/angular/src/app/landing/landing.component.html
+++ b/angular/src/app/landing/landing.component.html
@@ -101,7 +101,7 @@
               <span *ngIf="isDOI"><i> <a class="font14"
                     href="https://doi.org/{{record.doi.split(':')[1]}}">{{record.doi}}</a></i></span>
               <span *ngIf="!isDOI"><i> <a class="font14"
-                    href="{{ confValues.PDRAPI }}{{record['@id']}}">{{record["@id"]}}</a></i>
+                    href="{{ cfg.get('landingPageService','/od/id/') }}{{record['@id']}}">{{record["@id"]}}</a></i>
               </span>
               <span *ngIf="checkReferences()"><br>
                 <span>Described in article: </span>

--- a/angular/src/app/landing/landing.component.html
+++ b/angular/src/app/landing/landing.component.html
@@ -158,7 +158,8 @@
               <description-resources [record]="record" [files]="files" [distdownload]="distdownload"
                                      [isInternal]="isInternal" [filescount]="filescount" [inBrowser]="inBrowser"
                                      [metadata]="metadata"></description-resources>
-              <metadata-detail [record]="record" [serviceApi]="serviceApi" [metadata]="metadata"></metadata-detail>
+              <metadata-detail [record]="record" [serviceApi]="serviceApi" [inBrowser]="inBrowser"
+                               [metadata]="metadata"></metadata-detail>
               <!-- <data-cart></data-cart>   -->
             </div>
             <div *ngIf="record.length !== 0 && inBrowser">

--- a/angular/src/app/landing/landing.component.html
+++ b/angular/src/app/landing/landing.component.html
@@ -38,7 +38,8 @@
                 <b *ngSwitchCase="'nrdp:PublicDataResource'">Public Data Resource</b>
                 <b *ngSwitchDefault></b>
               </span>
-              <div *ngIf="record.length !== 0" class="ui-sm-1 d-none d-sm-block d-md-none ">
+              <div *ngIf="record.length !== 0 && inBrowser"
+                   class="ui-sm-1 d-none d-sm-block d-md-none ">
                 <button style="float: right" type="button" pButton icon="faa faa-list"
                   class="ui-button ui-button-icon-only" (click)="menu3.toggle($event)"></button>
                 <p-menu #menu3 class="rightMenuStylePop" popup="popup" [model]="rightmenu"></p-menu>
@@ -144,8 +145,10 @@
             <div class="ui-g-4 ui-md-4 ui-lg-4 ui-sm-12">
               <span *ngIf="HomePageLink">
                 <a [(href)]="record.landingPage" target="_blank" style="float: right;">
-                  <button pButton type="button" class="homePageLink" icon="faa faa-external-link"
-                    label="Visit Home Page"></button>
+                  <span *ngIf="inBrowser; else visitHomeOnServer">
+                    <button pButton type="button" class="homePageLink" icon="faa faa-external-link" label="Visit Home Page"></button>
+                  </span>
+                  <ng-template #visitHomeOnServer>Visit Home Page</ng-template>
                 </a>
               </span>
             </div>
@@ -153,11 +156,12 @@
           <div class="ui-g">
             <div class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-12">
               <description-resources [record]="record" [files]="files" [distdownload]="distdownload"
-                [isInternal]="isInternal" [filescount]="filescount" [metadata]="metadata"></description-resources>
+                                     [isInternal]="isInternal" [filescount]="filescount" [inBrowser]="inBrowser"
+                                     [metadata]="metadata"></description-resources>
               <metadata-detail [record]="record" [serviceApi]="serviceApi" [metadata]="metadata"></metadata-detail>
               <!-- <data-cart></data-cart>   -->
             </div>
-            <div *ngIf="record.length !== 0">
+            <div *ngIf="record.length !== 0 && inBrowser">
               <p-dialog class="citationDialog" [closable]="false" [(visible)]="display" modal="modal" width="550"
                 height="330" responsive="true" #citeDialog>
                 <p-header> Citation

--- a/angular/src/app/landing/landing.component.ts
+++ b/angular/src/app/landing/landing.component.ts
@@ -7,7 +7,7 @@ import { Observable, of } from 'rxjs';
 import * as _ from 'lodash';
 import 'rxjs/add/operator/map';
 import { Subscription } from 'rxjs/Subscription';
-import { AppConfig, Config } from '../shared/config-service/config.service';
+import { AppConfig } from '../config/config';
 import { PLATFORM_ID, APP_ID, Inject } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { CartService } from '../datacart/cart.service';
@@ -123,7 +123,6 @@ export class LandingComponent implements OnInit {
   private newer: reference = {};
   navigationSubscription: any;
   ediid: any;
-  confValues: Config;
   displayDatacart: boolean = false;
   isLocalProcessing: boolean = false;
   isLoading: boolean = true;
@@ -133,13 +132,13 @@ export class LandingComponent implements OnInit {
    *
    */
   constructor(private route: ActivatedRoute, private el: ElementRef,
-    private titleService: Title, private appConfig: AppConfig, private router: Router
-    , @Inject(PLATFORM_ID) private platformId: Object,
-    @Inject(APP_ID) private appId: string,
-    private transferState: TransferState,
-    private searchService: SearchService,
-    private commonVarService: CommonVarService) {
-    this.confValues = this.appConfig.getConfig();
+              private titleService: Title, private cfg : AppConfig, private router: Router,
+              @Inject(PLATFORM_ID) private platformId: Object,
+              @Inject(APP_ID) private appId: string,
+              private transferState: TransferState,
+              private searchService: SearchService,
+              private commonVarService: CommonVarService)
+  {
   }
 
   /**
@@ -259,10 +258,11 @@ export class LandingComponent implements OnInit {
    * Update menu on landing page
    */
   updateMenu() {
-    this.serviceApi = this.confValues.LANDING + "records?@id=" + this.record['@id'];
-    if (!_.includes(this.confValues.LANDING, "rmm"))
-      this.serviceApi = this.confValues.LANDING + this.record['ediid'];
-    this.distdownload = this.confValues.DISTAPI + "ds/zip?id=" + this.record['@id'];
+    let mdapi = this.cfg.get("mdAPI", "/unconfigured");
+    this.serviceApi = mdapi + "records?@id=" + this.record['@id'];
+    if (!_.includes(mdapi, "/rmm/"))
+      this.serviceApi = mdapi + this.record['ediid'];
+    this.distdownload = this.cfg.get("distService","/od/ds/") + "zip?id=" + this.record['@id'];
 
     var itemsMenu: MenuItem[] = [];
     var metadata = this.createMenuItem("Export JSON", "faa faa-file-o", (event) => { this.turnSpinnerOff(); }, this.serviceApi);
@@ -272,9 +272,9 @@ export class LandingComponent implements OnInit {
     }
 
     var resourcesByAuthor = this.createMenuItem('Resources by Authors', "faa faa-external-link", "",
-      this.confValues.SDPAPI + "/#/search?q=authors.familyName=" + authlist + "&key=&queryAdvSearch=yes");
+      this.cfg.get("locations.pdrSearch","/sdp/") + "/#/search?q=authors.familyName=" + authlist + "&key=&queryAdvSearch=yes");
     var similarRes = this.createMenuItem("Similar Resources", "faa faa-external-link", "",
-      this.confValues.SDPAPI + "/#/search?q=" + this.record['keyword'] + "&key=&queryAdvSearch=yes");
+      this.cfg.get("locations.pdrSearch","/sdp/") + "/#/search?q=" + this.record['keyword'] + "&key=&queryAdvSearch=yes");
     var license = this.createMenuItem("Fair Use Statement", "faa faa-external-link", "", this.record['license']);
     var citation = this.createMenuItem('Citation', "faa faa-angle-double-right",
       (event) => { this.getCitation(); this.showDialog(); }, '');

--- a/angular/src/app/landing/landing.component.ts
+++ b/angular/src/app/landing/landing.component.ts
@@ -127,6 +127,7 @@ export class LandingComponent implements OnInit {
   isLocalProcessing: boolean = false;
   isLoading: boolean = true;
   HomePageLink: boolean = false;
+  inBrowser : boolean = false;  
 
   /**
    * Creates an instance of the SearchPanel
@@ -140,6 +141,7 @@ export class LandingComponent implements OnInit {
               private searchService: SearchService,
               private commonVarService: CommonVarService)
   {
+    this.inBrowser = isPlatformBrowser(platformId);
   }
 
   /**

--- a/angular/src/app/landing/metadata/metadata.component.ts
+++ b/angular/src/app/landing/metadata/metadata.component.ts
@@ -4,17 +4,19 @@ import { Component, Input, Pipe,PipeTransform } from '@angular/core';
   selector: 'metadata-detail',
   template: `
     <div class="ui-g">
-     <div [hidden]="!metadata" class = "ui-g-12 ui-md-12 ui-lg-12 ui-sm-12" >
-       <h3><b>Metadata</b></h3>
-        <span style="">
-          For more information about the metadata consult the <a href="/od/dm/nerdm/">NERDm documentation</a>. 
-        </span>
-        <button style="position:relative; float:right; background-color: #1371AE;" type="button" pButton icon="faa faa-file-code-o"
-                title="Get Metadata in JSON format." label="json" (click)="onjson()"></button>
-        <br>
-        <span style="font-size:8pt;color:grey;" >* item[number] indicates an array not a key name</span>
-        <br><br>
-       <fieldset-view [entry]="record"></fieldset-view>
+     <div *ngIf="inBrowser">
+       <div [hidden]="!metadata" class = "ui-g-12 ui-md-12 ui-lg-12 ui-sm-12" >
+         <h3><b>Metadata</b></h3>
+          <span style="">
+            For more information about the metadata, consult the <a href="/od/dm/nerdm/">NERDm documentation</a>. 
+          </span>
+          <button style="position:relative; float:right; background-color: #1371AE;" type="button" pButton icon="faa faa-file-code-o"
+                    title="Get Metadata in JSON format." label="json" (click)="onjson()"></button>
+          <br>
+          <span style="font-size:8pt;color:grey;" >* item[number] indicates an array not a key name</span>
+          <br><br>
+         <div *ngIf="inBrowser"><fieldset-view [entry]="record"></fieldset-view></div>
+        </div>
       </div>
     </div>
   `
@@ -25,6 +27,7 @@ export class MetadataComponent {
   @Input() record: any[];
   @Input() serviceApi : string;
   @Input() metadata : boolean;
+  @Input() inBrowser : boolean;
   ngOnInit() {
       delete this.record["_id"];
   }

--- a/angular/src/app/shared/footbar/footbar.component.ts
+++ b/angular/src/app/shared/footbar/footbar.component.ts
@@ -5,7 +5,7 @@ import { Component } from '@angular/core';
  */
 @Component({
   moduleId: module.id,
-  selector: 'pdr-footbar',
+  selector: 'pdr-dep-footbar',
   templateUrl: 'footbar.component.html',
   styleUrls: ['footbar.component.css']
 })

--- a/angular/src/app/shared/headbar/headbar.component.ts
+++ b/angular/src/app/shared/headbar/headbar.component.ts
@@ -12,7 +12,7 @@ declare var Ultima: any;
 
 @Component({
   moduleId: module.id,
-  selector: 'pdr-headbar',
+  selector: 'pdr-dep-headbar',
   templateUrl: 'headbar.component.html',
   styleUrls: ['headbar.component.css']
 })

--- a/angular/src/app/shared/search-service/search-service.service.ts
+++ b/angular/src/app/shared/search-service/search-service.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/observable/throw';
-import { AppConfig } from '../config-service/config.service';
+import { AppConfig } from '../../config/config';
 import * as _ from 'lodash';
 /**
  * This class provides the Search service with methods to search for records from tha rmm.
@@ -19,9 +19,10 @@ export class SearchService {
    * @param {Http} http - The injected Http.
    * @constructor
    */
-  constructor(private http: HttpClient,
-    private appConfig : AppConfig) {
-    this.landingBackend = this.appConfig.getConfig().LANDING;
+  constructor(private http: HttpClient, private cfg : AppConfig) {
+      this.landingBackend = cfg.get("mdAPI", "/unconfigured");
+      if (this.landingBackend == "/unconfigured")
+          throw new Error("Metadata service endpoint not configured!");
   }
 
   /**

--- a/angular/src/app/shared/search-service/search-service.service.ts
+++ b/angular/src/app/shared/search-service/search-service.service.ts
@@ -49,6 +49,7 @@ export class SearchService {
       backend = this.landingBackend+'records/'; 
     }else
       backend =  this.landingBackend;
+    console.log("Sending query: "+backend+searchValue);
     return this.http.get(backend + searchValue, { headers: new HttpHeaders({ timeout: '${10000}' }) });
   }
 }

--- a/angular/src/app/shared/shared.module.ts
+++ b/angular/src/app/shared/shared.module.ts
@@ -3,8 +3,8 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { SearchService } from './search-service/index';
-// import { FootbarComponent } from './footbar/index';
-// import { HeadbarComponent } from './headbar/index';
+import { FootbarComponent as DepFootbarComponent } from './footbar/index';
+import { HeadbarComponent as DepHeadbarComponent } from './headbar/index';
 
 /**
  * Do not specify providers for modules that might be imported by a lazy loaded module.
@@ -12,8 +12,8 @@ import { SearchService } from './search-service/index';
 
 @NgModule({
   imports: [CommonModule, RouterModule],
-/*  declarations: [ HeadbarComponent, FootbarComponent], */
-  exports: [ /* HeadbarComponent, FootbarComponent, */
+  declarations: [ DepHeadbarComponent, DepFootbarComponent], 
+  exports: [ DepHeadbarComponent, DepFootbarComponent, 
     CommonModule, FormsModule, RouterModule]
 })
 export class SharedModule {

--- a/angular/src/app/shared/shared.module.ts
+++ b/angular/src/app/shared/shared.module.ts
@@ -3,8 +3,8 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { SearchService } from './search-service/index';
-import { FootbarComponent } from './footbar/index';
-import { HeadbarComponent } from './headbar/index';
+// import { FootbarComponent } from './footbar/index';
+// import { HeadbarComponent } from './headbar/index';
 
 /**
  * Do not specify providers for modules that might be imported by a lazy loaded module.
@@ -12,8 +12,8 @@ import { HeadbarComponent } from './headbar/index';
 
 @NgModule({
   imports: [CommonModule, RouterModule],
-  declarations: [ HeadbarComponent, FootbarComponent],
-  exports: [ HeadbarComponent, FootbarComponent, 
+/*  declarations: [ HeadbarComponent, FootbarComponent], */
+  exports: [ /* HeadbarComponent, FootbarComponent, */
     CommonModule, FormsModule, RouterModule]
 })
 export class SharedModule {

--- a/angular/src/environments/environment.prod.ts
+++ b/angular/src/environments/environment.prod.ts
@@ -7,3 +7,22 @@ export const environment = {
   METAPI:  'http://localhost/metaurl/',
   LANDING: 'http://testdata.nist.gov/rmm/'
 };
+
+import { LPSConfig } from '../app/config/config';
+
+export const context = {
+    production: true
+};
+
+export const config : LPSConfig = {
+    locations: {
+        orgHome:     "https://nist.gov/",
+        portalBase:  "https://data.nist.gov/",
+        pdrHome:     "https://data.nist.gov/pdr/",
+        pdrSearch:   "https://data.nist.gov/sdp/"
+    },
+    mode:        "dev",
+    status:      "Dev Version",
+    appVersion:  "v1.1.0",
+    production:  context.production
+}

--- a/angular/src/environments/environment.spec.ts
+++ b/angular/src/environments/environment.spec.ts
@@ -1,0 +1,10 @@
+import * as ngenv from "./environment";
+
+describe("environments.environment", function() {
+
+    it("config", function() {
+        expect(ngenv.config.locations.orgHome).toBeTruthy();
+        expect(ngenv.config.mode).toBe("dev");
+        expect(ngenv.config.production).toBeFalsy();
+    });
+});

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -1,5 +1,9 @@
-
-
+/*
+ * The following is the deprecated environment using the old configuration framework.
+ * It is included here keep the application working using the old framework while 
+ * the new one is being integrated.  It will be removed when the migration is 
+ * complete.
+ */
 export const environment = {
   production: false,
   RMMAPI: 'http://testdata.nist.gov/rmm/',
@@ -9,3 +13,34 @@ export const environment = {
     METAPI:  'http://localhost/metaurl/',
     LANDING: 'http://testdata.nist.gov/rmm/'
 };
+
+/*
+ * Angular build-time environments data.
+ * 
+ * Environment Label: dev (default)
+ *
+ * When building under the dev environment mode, the contents of this file will get built into 
+ * the application.  
+ *
+ * This is the default version of this file.  When the app is built via `ng build --env=label`,
+ * the contents of ./environment.label.ts will be used instead.  
+ */
+import { LPSConfig } from '../app/config/config';
+
+export const context = {
+    production: false
+};
+
+export const config : LPSConfig = {
+    locations: {
+        orgHome:     "https://nist.gov/",
+        portalBase:  "https://data.nist.gov/",
+        pdrHome:     "https://data.nist.gov/pdr/",
+        pdrSearch:   "https://data.nist.gov/sdp/"
+    },
+    mode:        "dev",
+    status:      "Dev Version",
+    appVersion:  "v1.1.0",
+    production:  context.production
+}
+

--- a/angular/src/main.ts
+++ b/angular/src/main.ts
@@ -1,16 +1,10 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
 import { AppBrowserModule } from './app/app.browser.module';
-// import { environment } from './environments/environment';
+import {context} from './environments/environment';
 
-// if (environment.production) {
-//   enableProdMode();
-// }
-
-// platformBrowserDynamic().bootstrapModule(AppBrowserModule)
-//   .catch(err => console.log(err));
 document.addEventListener("DOMContentLoaded", () => {
-  platformBrowserDynamic()
-    .bootstrapModule(AppBrowserModule)
-    .catch(err => console.log(err));
+  platformBrowserDynamic().bootstrapModule(AppBrowserModule)
+                          .catch(err => console.error(err));
 });


### PR DESCRIPTION
This PR is part of a larger effort to fix server-side rendering.  Currently, exceptions occurring on the server-side are causing rendering to stop soon after encoding the NERDm JSON data into the landing page (via Angular's TransferState).  This larger effort is aimed at eliminating those errors as well as at making it simpler to make robust improvements going forward.  

In this step, this PR establishes a new framework for handling and using configuration information.  It takes into account the different runtime contexts (local development vs testing vs. production operation) and is described in the README.md file in [angular/src/app/config](/usnistgov/oar-pdr/tree/feature/newconfig/angular/src/app/config).  In particular, during development and testing, one will want to set the configuration via a local file; in production, the data must come from the configuration service, be used by the server but also transmitted to the browser to configure the browser-side application.

The new framework is implemented via a new (sub-) module in [app/config](/usnistgov/oar-pdr/tree/feature/newconfig/angular/src/app/config) (replacing the `config-service` in [app/shared](/usnistgov/oar-pdr/tree/feature/newconfig/angular/src/app/shared)).  When running the application in development (either as a browser-only app or with server-side rendering), the configuration is set via [src/enivronments/envirtonment.ts](/usnistgov/oar-pdr/tree/feature/newconfig/angular/src/environments/environment.ts).  When running under oar-docker, the server-side application reads the configuration from a file whose location is set by an environment variable.  (This is file is written and the environment variable set by the docker container that hosts the landing page service.)  The service side then transmits the configuration along with the rendered page using the Angular TransferState mechanism.  

The new framework introduces a new schema for the landing page service.  It will be retrieved from the config server via the name `pdr-lps`.  It adds some additional configuration parameters and renames others.  Documentation for the schema can be found in-line in [app/config/config.ts](/usnistgov/oar-pdr/tree/feature/newconfig/angular/src/app/config/config.ts).  