### PR TITLE
Fix docker build: install python module, funcsigs

### DIFF
--- a/docker/pdrtest/Dockerfile
+++ b/docker/pdrtest/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y python-yaml nginx curl wget less sudo \
                                          uwsgi uwsgi-plugin-python zip \
                                          p7zip-full git
 RUN pip install --upgrade setuptools
-RUN pip install 'bagit>=1.6.3,<2.0' 'fs>=2.0.21'
+RUN pip install funcsigs 'bagit>=1.6.3,<2.0' 'fs>=2.0.21'
 
 # install multibag from source
 RUN curl -L -o multibag-py.zip \


### PR DESCRIPTION
Something appears to have change in the python module dependency chain (probably related to [oar-metadata PR#31](https://github.com/usnistgov/oar-metadata/pull/31)), and now the python module, funcsigs, is an explicit dependency for the [NIST mulibag module](https://github.com/usnistgov/multibag-py).  In this PR, this module is now explicitly pip-installed in the `docker/pdrtest/Dockerfile`.  Without this change, the python tests fail.  
