### PR TITLE
Changed GA for page view only. 

### DIFF
--- a/angular/e2e/about/about.component.e2e-spec.ts
+++ b/angular/e2e/about/about.component.e2e-spec.ts
@@ -4,7 +4,7 @@ describe('About Page', function() {
 
   beforeEach(async () => {
     //browser.waitForAngular();
-    return await browser.get('/about');
+    return await browser.get('/pdr/about');
   });
 
   it('should display title of about page', async() => {

--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -2334,6 +2334,11 @@
         }
       }
     },
+    "classlist.js": {
+      "version": "1.1.20150312",
+      "resolved": "https://registry.npmjs.org/classlist.js/-/classlist.js-1.1.20150312.tgz",
+      "integrity": "sha1-HXCEL3Ai8I2awIbOaeWyUPLFd4k="
+    },
     "clean-css": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",

--- a/angular/package.json
+++ b/angular/package.json
@@ -7,8 +7,8 @@
   },
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
-    "build": "ng build",
+    "start": "ng serve --aot",
+    "build": "ng build --aot",
     "test": "ng test --browsers=ChromeHeadless",
     "e2e": "ng e2e",
     "lint": "ng lint oar-lps",

--- a/angular/src/app/app-routing.module.ts
+++ b/angular/src/app/app-routing.module.ts
@@ -9,9 +9,9 @@ import { ErrorComponent, UserErrorComponent } from './landing/error.component';
 import { DatacartComponent} from './datacart/datacart.component';
 
 const routes: Routes = [
-  { path: '', redirectTo: '/about', pathMatch: 'full' },
+  { path: '', redirectTo: '/pdr/about', pathMatch: 'full' },
 
-  { path: 'about',  children: [
+  { path: 'pdr/about',  children: [
     {
       path: '',
      component: LandingAboutComponent

--- a/angular/src/app/frame/headbar.component.html
+++ b/angular/src/app/frame/headbar.component.html
@@ -19,7 +19,7 @@
          &nbsp;&nbsp;
       <span *ngIf="status" class="badge" id="appStatus" style="background-color:darkcyan">{{ status }}</span>
       <div align="right" class="header-links">
-        <a href="/about" target="_blank"><span class="textlinks"><b>About</b></span></a> | 
+        <a href="/pdr/about" target="_blank"><span class="textlinks"><b>About</b></span></a> | 
         <a href="{{ searchLink }}" target="_blank"><span class="textlinks"><b>Search</b></span></a> |
         <a [routerLink]="['/datacart', 'normal']" routerLinkActive="active" target="_blank"
             (click)="updateCartStatus()"><span class="textlinks"><b>Cart </b></span>

--- a/angular/src/app/frame/headbar.component.spec.ts
+++ b/angular/src/app/frame/headbar.component.spec.ts
@@ -59,7 +59,7 @@ describe('HeadbarComponent', () => {
 
         let aels = cmpel.querySelectorAll(".header-links a")
         expect(aels.length).toBeGreaterThan(1);
-        expect(aels[0].getAttribute('href')).toBe("/about");
+        expect(aels[0].getAttribute('href')).toBe("/pdr/about");
         expect(aels[1].getAttribute('href')).toBe("https://goob.nist.gov/search");
     });
 

--- a/angular/src/app/shared/ga-service/google-analytics.service.mock.ts
+++ b/angular/src/app/shared/ga-service/google-analytics.service.mock.ts
@@ -5,13 +5,6 @@ declare var gas:Function;
 
 @Injectable()
 export class GoogleAnalyticsServiceMock {
-  constructor() {
-  }
-
-  /*
-  *   Append Google Analytics script to a page
-  */
-  public appendGaTrackingCode() {
-
+  constructor(router: Router) {
   }
 }

--- a/angular/src/app/shared/ga-service/google-analytics.service.ts
+++ b/angular/src/app/shared/ga-service/google-analytics.service.ts
@@ -5,23 +5,14 @@ declare var gas:Function;
 
 @Injectable()
 export class GoogleAnalyticsService {
-  constructor() {
+  constructor(router: Router) {
+    router.events.subscribe(event => {
+      if (event instanceof NavigationEnd) {
+        setTimeout(() => {
+          gas('send', 'pageview', event.url, 'pageview');
+        }, 1000);
+      }
+    })
   }
 
-  /*
-  *   Append Google Analytics script to a page
-  */
-  public appendGaTrackingCode() {
-    try {
-      console.log("phone home...");
-      const script = document.createElement('script');
-      script.async = true;
-      script.src = "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=UA-66610693-14&yt=true&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c";
-      document.head.appendChild(script);
-    } catch (ex) {
-      console.error('Error appending google analytics');
-      console.error(ex);
-    }
-
-  }
 }


### PR DESCRIPTION

I am using the same JIRA tracker 773.

As mentioned in the email, the tracking code on outbound event was not working correctly. So I am using the previous approach for now - using router event to track page view only.

There are only landing page, datacard page and about page in pdr. Make sure when click on those pages you see "collect" events in the Network tab in developer Tools.



