### PR TITLE
Fixed dup page views

### DIFF
--- a/angular/src/app/app-routing.module.ts
+++ b/angular/src/app/app-routing.module.ts
@@ -9,9 +9,9 @@ import { ErrorComponent, UserErrorComponent } from './landing/error.component';
 import { DatacartComponent} from './datacart/datacart.component';
 
 const routes: Routes = [
-  { path: '', redirectTo: '/pdr/about', pathMatch: 'full' },
+  { path: '', redirectTo: '/about', pathMatch: 'full' },
 
-  { path: 'pdr/about',  children: [
+  { path: 'about',  children: [
     {
       path: '',
      component: LandingAboutComponent

--- a/angular/src/app/shared/ga-service/google-analytics.service.ts
+++ b/angular/src/app/shared/ga-service/google-analytics.service.ts
@@ -1,18 +1,24 @@
+// Google Analytics (GA) script was handled differently from traditional web pages. Angular 2+ is a SPA
+// which was considered only one page.
+// But if a page is launched in a new tab, it was consider a new page and the GA script will be triggered.
+// In PDR, we have only landing page and datacart page. Landing page open datacart page in a new tab. 
+// So we don't need to fire gas() function here.
+
 import { Injectable } from '@angular/core';
 import {Router, NavigationEnd} from '@angular/router';
-import { environment } from '../../../environments/environment';
 declare var gas:Function; 
 
 @Injectable()
 export class GoogleAnalyticsService {
-  constructor(router: Router) {
-    router.events.subscribe(event => {
-      if (event instanceof NavigationEnd) {
-        setTimeout(() => {
-          gas('send', 'pageview', event.url, 'pageview');
-        }, 1000);
-      }
-    })
-  }
+  // constructor(router: Router) {
+  //   router.events.subscribe(event => {
+  //     if ((event instanceof NavigationEnd) && event.url != '/') {
+  //       console.log("event", event);
+  //       setTimeout(() => {
+  //         gas('send', 'pageview', event.url, 'pageview');
+  //       }, 1000);
+  //     }
+  //   })
+  // }
 
 }


### PR DESCRIPTION
whenever user visits PDR landing page or datacart page, GA generates two page views instead of one. This was because we always start datacart in the separated page which was considered a new page by the browser. So the page view was sent to GA server by both original script in index.html and the router event. Since PDR only has "landing", "about" and "datacart" pages and those are all "new page", no extra GA code is necessary in the router event.

So in this fix, I just simply remove the function in GA service. But I left the structure there because we need to track other events such as outbound click, download, etc. 