### PR TITLE
Fix ID validation failure in pre-pub metadata server

### DIFF
--- a/python/nistoar/pdr/preserv/bagger/prepupd.py
+++ b/python/nistoar/pdr/preserv/bagger/prepupd.py
@@ -371,8 +371,8 @@ class UpdatePrepper(object):
         if not nerdm.get('@id'):
             raise StateException("Bag {0}: missing @id"
                                  .format(os.path.basename(mdbag)))
-        bag = BagBuilder(parent, os.path.basename(mdbag), {}, nerdm.get('@id'),
-                         logger=deflog)
+        bag = BagBuilder(parent, os.path.basename(mdbag), {'validate_id': False},
+                         nerdm.get('@id'), logger=deflog)
         bag.add_res_nerd(nerdm, savefilemd=True)
 
         # finally set the version to a value appropriate for an update in
@@ -408,7 +408,8 @@ class UpdatePrepper(object):
         # (this assumes forward compatibility).
         bagutils.update_nerdm_schema(nerd)
         
-        bldr = BagBuilder(parent, bagname, {}, nerd['@id'], logger=deflog)
+        bldr = BagBuilder(parent, bagname, {'validate_id': False},
+                          nerd['@id'], logger=deflog)
         bldr.add_res_nerd(nerd, savefilemd=True)
 
         # update the version appropriate for edit mode

--- a/python/nistoar/pdr/preserv/bagit/builder.py
+++ b/python/nistoar/pdr/preserv/bagit/builder.py
@@ -89,9 +89,10 @@ class BagBuilder(PreservationSystem):
     :prop merge_convention str ("dev"): the merge convention name to 
                                  use to merge annotation data into the primary
                                  NERDm metadata.
-    :prop validate_id bool (True):  If True, an identifier provided to the 
+    :prop validate_id bool (False):  If True, an identifier provided to the 
                               constructor will be checked for transcription
-                              error.
+                              error (assuming the identifier contains a "check
+                              character")
     :prop copy_on_link_failure bool (True):  If True, then when moving datafiles 
                               to output bag via a hardlink, then the file 
                               will get copied if the linking fails.  
@@ -447,7 +448,7 @@ class BagBuilder(PreservationSystem):
             if not re.match(r"^ark:/\d+/\w", id):
                 raise ValueError("Invalid ARK identifier provided: "+id)
 
-            validate = self.cfg.get('validate_id', True)
+            validate = self.cfg.get('validate_id', False)
             if isinstance(validate, (unicode, str)):
                 # assume that this is a RE of matching shoulders to validate
                 try:


### PR DESCRIPTION
In oar-pdr [v1.2.2](https://github.com/usnistgov/oar-pdr/releases/tag/1.2.2) (deployed as part of  v1.20 of oar-docker), the landing page service was failing to serve up pre-publication previews of the landing page; this was because the metadata server was still attempting to validate the ARK id for its check character, even though the service was configured not to for the new ARK ID format.  This error was traced to a use of the `BagBuilder` class within `nistoar.pdr.preserv.bagger.prepupd` where a `BagBuilder` instance was being instantiated without any configuration.  The default value of the `validate_id` config parameter is currently set to `True`; so the check was being erroneously applied.  This PR fixes this by providing an explicit configuration with this parameter set to `False`.