### PR TITLE
Fix preservation failure when updating a submission having an ARK SIP identifier

### DIFF
--- a/python/nistoar/pdr/preserv/service/service.py
+++ b/python/nistoar/pdr/preserv/service/service.py
@@ -25,7 +25,7 @@ submit the metadata to the PDR metadata database.
 """
 from copy import deepcopy
 from abc import ABCMeta, abstractmethod, abstractproperty
-import os, logging, threading, time, errno
+import os, logging, threading, time, errno, re
 
 from detach import Detach
 
@@ -143,6 +143,7 @@ class PreservationService(object):
         # create a Handler object that will be launched asynchronously
         try:
             hdlr = self._make_handler(sipid, siptype, asupdate=False)
+            log.info("Initial preservation requested for SIP=%s", sipid)
         except (IDNotFound, SIPDirectoryNotFound) as ex:
             return self._not_found_state(sipid, siptype)
         except Exception as ex:
@@ -151,7 +152,8 @@ class PreservationService(object):
         # check for the existence of an AIP corresponding to the input SIP ID:
         # if one exists, fail because the user should have called update()
         if self._prepsvc:
-            if self._prepsvc.prepper_for(sipid, log=log).aip_exists():
+            aipid = re.sub(r'^ark:/\d+/','', sipid)
+            if self._prepsvc.prepper_for(aipid, log=log).aip_exists():
                 hdlr.set_state(status.CONFLICT,
                                "requested initial preservation of existing AIP")
                 msg = "AIP with ID already exists (need to request update?): "
@@ -221,6 +223,7 @@ class PreservationService(object):
         # create a Handler object that will be launched asynchronously
         try:
             hdlr = self._make_handler(sipid, siptype, asupdate=True)
+            log.info("Preservation update requested for SIP=%s", sipid)
         except (IDNotFound, SIPDirectoryNotFound) as ex:
             return self._not_found_state(sipid, siptype)
         except Exception as ex:
@@ -230,7 +233,8 @@ class PreservationService(object):
         # if one does not exists, fail because the user should have called
         # preserve()
         if self._prepsvc:
-            if not self._prepsvc.prepper_for(sipid, log=log).aip_exists():
+            aipid = re.sub(r'^ark:/\d+/','', sipid)
+            if not self._prepsvc.prepper_for(aipid, log=log).aip_exists():
                 hdlr.set_state(status.CONFLICT,
                                "requested update to non-existing AIP")
                 msg = "AIP with ID does not exist (unable to update): "

--- a/python/nistoar/pdr/preserv/service/wsgi.py
+++ b/python/nistoar/pdr/preserv/service/wsgi.py
@@ -306,8 +306,8 @@ class Handler(object):
                 "message": str(ex),
                 "history": []
             }
-            self.set_response(409, "Already preserved (need to request update "+
-                                   "via PATCH?)")
+            self.set_response(409, "Not previously preserved (need to issue "+
+                                   "PUT?)")
 
         except Exception as ex:
             log.exception("preservation request failure for sip=%s: %s",


### PR DESCRIPTION
In oar-pdr [v1.2.2](https://github.com/usnistgov/oar-pdr/releases/tag/1.2.2), the preservation service would fail to preserve an update when the SIP uses an ARK-based identifier.  This was because the service was trying to cache a copy of the published NERDm record in a cache directory with the name `ark:/xxxxx/mds2-yyyy.json`  This PR corrects this problem, allowing such updates to be supported.  