### PR TITLE
Remove some manual GA tracking code

### DIFF
--- a/angular/src/app/landing/contact/contact.component.html
+++ b/angular/src/app/landing/contact/contact.component.html
@@ -11,8 +11,7 @@
                 Contact:
                 <strong>
                     <a class="font14" *ngIf="isEmail"
-                        href="{{record.contactPoint.hasEmail}}" target="_top"
-                        (click)="gaService.gaTrackEvent('Email', $event, 'Resource title: ' + record.title, record.contactPoint.hasEmail)">
+                        href="{{record.contactPoint.hasEmail}}" target="_top">
                         {{record.contactPoint.fn}}</a>
                     <span *ngIf="!isEmail">{{record.contactPoint.fn}}</span>
                 </strong>..
@@ -27,8 +26,7 @@
                     <span class="font14" *ngIf="isEmail">
                         <br><strong>Email:</strong>
                         <a *ngIf="isEmail" href="{{record.contactPoint.hasEmail}}"
-                            target="_top"
-                            (click)="gaService.gaTrackEvent('Email', $event, 'Resource title: ' + record.title, record.contactPoint.hasEmail)">
+                            target="_top">
                             {{record.contactPoint.hasEmail.split(":")[1]}}</a>
                     </span>
                     <div class="font14" *ngIf="record.contactPoint.address">

--- a/angular/src/app/landing/data-files/data-files.component.html
+++ b/angular/src/app/landing/data-files/data-files.component.html
@@ -195,8 +195,7 @@
                     <span *ngIf="refs['refType'] == 'IsReferencedBy'">
                         <br>
                         <i class="faa faa-external-link"> </i>
-                        <a style="margin-left:0.3em;" href={{refs.location}} target="blank"
-                            (click)="gaService.gaTrackEvent('outbound', $event, 'Resource title: '+record.title, refs.location)">
+                        <a style="margin-left:0.3em;" href={{refs.location}} target="blank">
                             {{ refs.location }}</a>
                     </span>
 

--- a/angular/src/app/landing/data-files/data-files.component.ts
+++ b/angular/src/app/landing/data-files/data-files.component.ts
@@ -633,9 +633,6 @@ export class DataFilesComponent {
     * Function to set status when a file was downloaded
     **/
     setFileDownloaded(rowData: any) {
-        // Google Analytics code to track download event
-        this.gaService.gaTrackEvent('download', undefined, 'Resource title: ' + this.record['title'], rowData.downloadUrl);
-
         rowData.downloadStatus = 'downloaded';
         this.cartService.updateCartItemDownloadStatus(rowData.cartId, 'downloaded');
         this.downloadStatus = this.updateDownloadStatus(this.files) ? "downloaded" : null;


### PR DESCRIPTION
I removed GA tracking function from contact, home page and direct download links so they won't be double tracked. I was unable to recreate the problem locally. So can only test the result in testdata for now.

The code is based on integration13.