### PR TITLE
ODD844: Display access URLs

### DIFF
--- a/angular/src/app/landing/data-files/data-files.component.html
+++ b/angular/src/app/landing/data-files/data-files.component.html
@@ -31,7 +31,7 @@
             <br>
             <span style="padding-left:2.00em" *ngFor="let apage of accessPages">
                 <i class="faa faa-external-link"> <span style="margin-left:0.3em;">
-                    <span *ngIf="apage['description']" else #noAccessTitle>
+                    <span *ngIf="apage['description']" else noAccessTitle>
                         <a href="{{apage['accessURL']}}" title="{{apage['description']}}"
                            (click)="gaService.gaTrackEvent('homepage', $event, 
                                                            'Resource title: ' + record.title,

--- a/angular/src/app/landing/data-files/data-files.component.html
+++ b/angular/src/app/landing/data-files/data-files.component.html
@@ -25,13 +25,25 @@
                 page</a>.
         </span>
 
-        <span style="margin-left:0em" *ngIf="isAccessPage">
-            <br>Data is available via the following locations:
+        <!-- Access Pages -->
+        <span style="margin-left:0em" *ngIf="accessPages.length > 0">
+            <br>Data and related material can be found at the following locations:
             <br>
-            <span style="padding-left:2.00em" *ngFor="let title of accessTitles; let i =index">
-                <i class="faa faa-external-link"> <span style="margin-left:0.3em;"> <a href="{{accessUrls[i]}}"
-                            (click)="gaService.gaTrackEvent('homepage', $event,'Resource title: ' + record.title, accessUrls[i])">{{title}}</a></span>
-                </i><br>
+            <span style="padding-left:2.00em" *ngFor="let apage of accessPages">
+                <i class="faa faa-external-link"> <span style="margin-left:0.3em;">
+                    <span *ngIf="apage['description']" else #noAccessTitle>
+                        <a href="{{apage['accessURL']}}" title="{{apage['description']}}"
+                           (click)="gaService.gaTrackEvent('homepage', $event, 
+                                                           'Resource title: ' + record.title,
+                                                           apage['accessURL'])">{{apage['title']}}</a>
+                    </span>
+                    <ng-template #noAccessTitle>
+                        <a href="{{apage['accessURL']}}" 
+                           (click)="gaService.gaTrackEvent('homepage', $event, 
+                                                           'Resource title: ' + record.title,
+                                                           apage['accessURL'])">{{apage['title']}}</a>
+                    </ng-template>
+                </span></i><br>
             </span>
         </span>
 

--- a/angular/src/app/landing/data-files/data-files.component.html
+++ b/angular/src/app/landing/data-files/data-files.component.html
@@ -31,7 +31,7 @@
             <br>
             <span style="padding-left:2.00em" *ngFor="let apage of accessPages">
                 <i class="faa faa-external-link"> <span style="margin-left:0.3em;">
-                    <span *ngIf="apage['description']" else noAccessTitle>
+                    <span *ngIf="apage['description']; else noAccessTitle">
                         <a href="{{apage['accessURL']}}" title="{{apage['description']}}"
                            (click)="gaService.gaTrackEvent('homepage', $event, 
                                                            'Resource title: ' + record.title,

--- a/angular/src/app/landing/data-files/data-files.component.ts
+++ b/angular/src/app/landing/data-files/data-files.component.ts
@@ -302,8 +302,13 @@ export class DataFilesComponent {
      * return an array of AccessPage components from the given input components array
      */
     selectAccessPages(comps : NerdmComp[]) : NerdmComp[] {
-        return comps.filter(cmp => cmp['@type'].includes("nrdp:AccessPage") &&
-                                   ! cmp['@type'].includes("nrd:Hidden"));
+        let use : NerdmComp[] = comps.filter(cmp => cmp['@type'].includes("nrdp:AccessPage") &&
+                                       ! cmp['@type'].includes("nrd:Hidden"));
+        use = (JSON.parse(JSON.stringify(use))) as NerdmComp[];
+        return use.map((cmp) => {
+            if (! cmp['title']) cmp['title'] = cmp['accessURL']
+            return cmp;
+        });
     }
 
     /**

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -13,8 +13,8 @@ import { LPSConfig } from '../app/config/config';
 
 export const context = {
     production: false,
-    useMetadataService: true,
-    useCustomizationService: true
+    useMetadataService: false,
+    useCustomizationService: false
 };
 
 export const config: LPSConfig = {
@@ -51,6 +51,7 @@ export const testdata: {} = {
         ],
         "@id": "ark:/88434/mds0000fbk",
         "title": "Multiple Encounter Dataset (MEDS-I) - NIST Special Database 32",
+        "doi": "doi:10.18434/mds0000fbk",
         "contactPoint": {
             "hasEmail": "mailto:patricia.flanagan@nist.gov",
             "fn": "Patricia Flanagan"
@@ -101,12 +102,12 @@ export const testdata: {} = {
                 "downloadURL": "http://nigos.nist.gov:8080/nist/sd/32/NIST_SD32_MEDS-I_face.zip",
                 "filepath": "NIST_SD32_MEDS-I_face.zip",
                 "@type": [
-                    "nrdp:DataFile",
+                    "nrdp:AccessPage",
                     "dcat:Distribution"
                 ],
                 "@id": "cmps/NIST_SD32_MEDS-I_face.zip",
                 "_extensionSchemas": [
-                    "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                    "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/AccessPage"
                 ]
             },
             {
@@ -126,6 +127,19 @@ export const testdata: {} = {
                 "@id": "cmps/NIST_SD32_MEDS-I_html.zip",
                 "_extensionSchemas": [
                     "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                ]
+            },
+            {
+                "accessURL": "https://doi.org/10.18434/mds0000fbk",
+                "description": "DOI Access to landing page",
+                "title": "DOI Access to \"Multiple Encounter Dataset (MEDS-I)\"",
+                "@type": [
+                    "nrd:Hidden",
+                    "dcat:Distribution"
+                ],
+                "@id": "#doi:10.18434/mds0000fbk",
+                "_extensionSchemas": [
+                    "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/"
                 ]
             }
         ],


### PR DESCRIPTION
This PR address [ODD-844 ("LPS: Access URLs no longer showing up on Landing Page")](http://mml.nist.gov:8080/browse/ODD-844) that observed that the accessURL rendering was based on the deprecated `inventory` NERDm property, causing them not to appear in new records.  This fix replaces the management of accessURL data in the `data-files` component.  
