### PR TITLE
LPS Restructuring Con't:  New Tools Component

### DIFF
--- a/angular/src/app/landing/citation/citation.component.spec.ts
+++ b/angular/src/app/landing/citation/citation.component.spec.ts
@@ -1,0 +1,82 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CitationModule } from './citation.module';
+import { CitationDescriptionComponent, CitationPopupComponent } from './citation.component';
+
+describe('CitationDescriptionComponent', () => {
+    let component : CitationDescriptionComponent;
+    let fixture : ComponentFixture<CitationDescriptionComponent>;
+
+    let setupComponent = function(citetext : string) {
+        component = null;
+        TestBed.configureTestingModule({
+            imports: [ CitationModule ],
+            declarations: [  ],
+            providers: [
+            ]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(CitationDescriptionComponent);
+        component = fixture.componentInstance;
+        component.citetext = citetext
+        fixture.detectChanges();
+    }
+
+    it("layout", () => {
+        setupComponent("It's all about me!");
+        expect(component).toBeDefined();
+
+        let cmpel = fixture.nativeElement;
+        let pels = cmpel.querySelectorAll(".citation");
+        expect(pels.length).toEqual(1);
+        expect(pels[0].textContent).toEqual("It's all about me!");
+
+        pels = cmpel.querySelectorAll("a");
+        expect(pels.length).toEqual(1);
+        expect(pels[0].textContent).toContain("Recommendations");
+    });
+});
+
+describe('CitationPopupComponent', () => {
+    let component : CitationPopupComponent;
+    let fixture : ComponentFixture<CitationPopupComponent>;
+
+    let setupComponent = function(citetext : string) {
+        component = null;
+        TestBed.configureTestingModule({
+            imports: [ CitationModule ],
+            declarations: [ ],
+            providers: [
+            ]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(CitationPopupComponent);
+        component = fixture.componentInstance;
+        component.citetext = citetext
+        component.visible = true;
+        fixture.detectChanges();
+    }
+
+    it("layout", () => {
+        setupComponent("It's all about me!");
+        expect(component).toBeDefined();
+
+        let cmpel = fixture.nativeElement;
+        let pels = cmpel.querySelectorAll("citation-display");
+        expect(pels.length).toEqual(1);
+
+        pels = cmpel.querySelectorAll("p-dialog");
+        expect(pels.length).toEqual(1);
+
+        pels = cmpel.querySelectorAll("button");
+        expect(pels.length).toEqual(1);
+
+        pels = cmpel.querySelectorAll(".citation");
+        expect(pels.length).toEqual(1);
+        expect(pels[0].textContent).toEqual("It's all about me!");
+
+        pels = cmpel.querySelectorAll("a");
+        expect(pels.length).toEqual(1);
+        expect(pels[0].textContent).toContain("Recommendations");
+    });
+});

--- a/angular/src/app/landing/citation/citation.component.ts
+++ b/angular/src/app/landing/citation/citation.component.ts
@@ -1,0 +1,82 @@
+/*
+ * This file defines two components:
+ *
+ * Two components are provided for displaying this information:
+ *  * CitationDescriptionComponent -- a component that display the information in a panel
+ *  * CitationPopupComponent -- a component that wraps the description in a pop-up widget
+ */
+import { Component, Input, Output, OnChanges, EventEmitter } from '@angular/core';
+
+/**
+ * A component for displaying information about how to cite a data resource described 
+ * by a NERDm metadata record
+ */
+@Component({
+    selector: 'citation-display',
+    template: `
+<span><b>Copy the recommended text to cite this resource </b></span> <br><br>
+<p contenteditable="false" class="citation">{{ citetext }}</p>
+<br>
+<a target="citationsRecommendation"
+   href="https://www.nist.gov/director/copyright-fair-use-and-licensing-statements-srd-data-and-software#citations">See also the NIST Citation Recommendations.</a>
+`,
+    styles: [
+        ".citation { font-size: 14px; }"
+    ]
+})
+export class CitationDescriptionComponent {
+    /** the recommended citation string */
+    @Input() citetext : string;
+}
+    
+/**
+ * a component for displaying citation information in a pop-up window
+ */
+@Component({
+    selector: 'citation-popup',
+    template: `
+<p-dialog #citepopup class="citationDialog" [closable]="false" [(visible)]="visible" 
+                     [modal]="false" width="550">
+  <p-header> Citation
+    <button style="position:relative; float:right; background-color:#1E6BA1; " type="button" 
+            pButton icon="faa faa-close" (click)="hide()"></button>
+  </p-header>
+  <citation-display [citetext]="citetext"></citation-display>
+</p-dialog>
+`,
+    styles: [
+        `
+:host /deep/ citationDialog > button.ui-button-icon-only{  
+  border-radius: 50%;
+  width: 1.5em;
+  height: 1.5em;
+}
+
+:host /deep/  .ui-dialog .ui-dialog-titlebar{
+  background-color: #f1f1f1;
+  color: #212121;
+  font-family: sans-serif;
+  font-size: 16px;
+}
+`
+    ],
+})
+export class CitationPopupComponent {
+    @Input() citetext : string;
+    @Input() visible : boolean;
+    @Output() visibleChange = new EventEmitter<boolean>();
+
+    _setVisible(yesno : boolean) : void {
+        this.visible = yesno;
+        this.visibleChange.emit(this.visible);
+    }        
+
+    /** display the pop-up */
+    show() : void { this._setVisible(true); }
+
+    /** dismiss the pop-up */
+    hide() : void { this._setVisible(false); }
+
+    /** dismiss the pop-up */
+    toggle() : void { this._setVisible(!this.visible); }
+}

--- a/angular/src/app/landing/citation/citation.module.ts
+++ b/angular/src/app/landing/citation/citation.module.ts
@@ -1,0 +1,30 @@
+import { NgModule }     from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { SharedModule, ButtonModule, DialogModule } from 'primeng/primeng';
+// import { ButtonModule } from 'primeng/button';
+// import { DialogModule } from 'primeng/dialog';
+
+import { CitationDescriptionComponent, CitationPopupComponent } from './citation.component'
+
+/**
+ * A module providing components for display citation information for a data resource
+ *
+ * Two components are provided for displaying this information:
+ *  * CitationDescriptionComponent -- a component that display the information in a panel
+ *  * CitationPopupComponent -- a component that wraps the description in a pop-up widget
+ */
+@NgModule({
+    imports: [
+        CommonModule, ButtonModule, DialogModule, SharedModule, BrowserAnimationsModule
+    ],
+    declarations: [
+        CitationDescriptionComponent, CitationPopupComponent
+    ],
+    exports: [
+        CitationDescriptionComponent, CitationPopupComponent
+    ]
+})
+export class CitationModule { }
+

--- a/angular/src/app/landing/landing.component.html
+++ b/angular/src/app/landing/landing.component.html
@@ -1,5 +1,5 @@
 <div class="ui-grid ui-grid-responsive ui-grid-pad center" style="border: 0px solid white;">
-    <div class="card landingcard">
+    <div class="card landing-body">
         <div *ngIf="recordLoaded()">
             <div class="ui-g">
                 <div class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-12">

--- a/angular/src/app/landing/landing.component.html
+++ b/angular/src/app/landing/landing.component.html
@@ -1,135 +1,118 @@
-<pdr-edit-control *ngIf="editEnabled && inBrowser" [inBrowser]="inBrowser"
-                  [(mdrec)]="record" [requestID]="requestId"></pdr-edit-control>
-
 <div class="ui-grid ui-grid-responsive ui-grid-pad center" style="border: 0px solid white;">
     <div class="card landingcard">
         <div *ngIf="recordLoaded()">
             <div class="ui-g">
-                <div class="ui-g-10 ui-md-10 ui-lg-10 ui-sm-12">
-                    <div class="ui-g">
-                        <div class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-12">
-                            <span class="recordType">
-                                <b>{{recordType}}</b>
-                            </span>
-                            <div *ngIf="record.length !== 0 && inBrowser"
-                                class="ui-sm-1 d-none d-block d-sm-block d-md-none ">
-                                <button style="float: right" type="button" pButton icon="faa faa-list"
-                                    class="ui-button ui-button-icon-only" (click)="menu3.toggle($event)"></button>
-                                <p-menu #menu3 class="rightMenuStylePop" popup="popup" [model]="rightmenu"></p-menu>
-                            </div>
-                            <br>
-                            <app-title [record]="record" [inBrowser]="inBrowser"></app-title>
-                            <app-author [record]="record" [inBrowser]="inBrowser"></app-author>
-                        </div>
-                        <div class="ui-g-8 ui-md-8 ui-lg-8 ui-sm-12">
-                            <app-contact [record]="record" [inBrowser]="inBrowser"></app-contact>
-
-                            <span>Identifier: </span>
-                            <span *ngIf="doiUrl"><i> <a class="font14" href="{{doiUrl}}"
-                                        >{{record.doi}}</a></i></span>
-                            <span *ngIf="!doiUrl"><i> <a class="font14"
-                                        href="{{ cfg.get('landingPageService','/od/id/') }}{{record['@id']}}">{{record["@id"]}}</a></i>
-                            </span>
-                            <span *ngIf="checkReferences()"><br>
-                                <span>Described in article: </span>
-                                <small *ngFor="let refs of record['references']; let i =index">
-                                    <span style="padding-left:2.75em" *ngIf="refs.refType == 'IsDocumentedBy'">
-                                        <br><i class="faa faa-external-link">
-                                            <a class="font14" href={{refs.location}} target="blank"
-                                                (click)="gaService.gaTrackEvent('outbound', $event, 'Resource title: ' + record.title, refs.location)">{{ refs.label }}</a></i>
-                                        <span *ngIf="i < record.references.length-1 ">,</span>
-                                    </span>
-                                </small>
-                            </span><br>
-                            <span class="" *ngIf="record.version"> Version: <strong>{{record.version}}</strong></span>
-                            <span class="" *ngIf="record.versionHistory" style="padding-right: 15pt;">...
-                                <i style="cursor: pointer;" class="faa" aria-hidden="true"
-                                    [ngClass]="{'faa-plus-square-o': !clickHistory, 'faa-minus-square-o': clickHistory}"
-                                    (click)="closeHistory = !closeHistory; clickHistory = expandHistory();"></i>
-                            </span>
-                            <span class="" *ngIf="record.issued" style="padding-right: 10pt;"> Released:
-                                <strong>{{record.issued}}</strong></span>
-                            <span class="" *ngIf="record.modified" style="padding-right: 10pt;"> Last modified:
-                                <strong>{{record.modified}}</strong></span>
-                            <div class="card customcard" [collapse]="!closeHistory">
-                                <b>Version History:</b>
-                                <span *ngFor="let release of record.versionHistory">
-                                    <br> <b [innerHTML]="renderRelVer(release, record.version)"></b> &nbsp;&nbsp;
-                                    <span *ngIf="release.issued">Released: {{release.issued}}</span>
-                                    <span *ngIf="release.location || release.refid"> &nbsp;&nbsp;
-                                        <i [innerHTML]="renderRelId(release, record.version)"></i>
-                                    </span>
-                                    <span *ngIf="release.description"> <br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-                                        <i>{{release.description}}</i>
-                                    </span>
-                                </span>
-                            </div>
-                            <p style="margin-top: 10px;" *ngIf="newer.location">
-                                <b>There is a more recent release of this resource available: &nbsp;&nbsp;
-                                    <a href="{{newer.location}}"
-                                        (click)="gaService.gaTrackEvent('outbound', $event, 'Resource title: ' + record.title, newer.label)">{{newer.label}}</a></b>
-                            </p>
-                        </div>
-
-                        <div class="ui-g-4 ui-md-4 ui-lg-4 ui-sm-12">
-                            <span *ngIf="HomePageLink" style="float: right;">
-                                <span *ngIf="inBrowser; else visitHomeOnServer">
-                                    <button type="button"
-                                        (click)="visitHomePage(record.landingPage, $event, 'Resource title: '+record.title)"
-                                        pButton type="submit"
-                                        style="float:right;margin:.5em 1em .5em 0em;width:200px; height:2em; background-color:#1471AE;color:white;padding-right: 1em;"
-                                        [disabled]="mdupdsvc.editMode">
-                                        <i class="faa faa-external-link"
-                                            style="color: #fff;padding-left: .5em;padding-right: .5em;"></i>
-                                        Visit Home Page
-                                    </button>
-                                </span>
-                                <ng-template #visitHomeOnServer>Visit Home Page</ng-template>
-                            </span>
-                        </div>
+                <div class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-12">
+                    <span class="recordType">
+                        <b>{{recordType}}</b>
+                    </span>
+                    <div *ngIf="record.length !== 0 && inBrowser"
+                        class="ui-sm-1 d-none d-block d-sm-block d-md-none ">
+                        <button style="float: right" type="button" pButton icon="faa faa-list"
+                            class="ui-button ui-button-icon-only" (click)="menu3.toggle($event)"></button>
+                        <p-menu #menu3 class="rightMenuStylePop" popup="popup" [model]="rightmenu"></p-menu>
                     </div>
+                    <br>
+                    <app-title [record]="record" [inBrowser]="inBrowser"></app-title>
+                    <app-author [record]="record" [inBrowser]="inBrowser"></app-author>
+                </div>
+                <div class="ui-g-8 ui-md-8 ui-lg-8 ui-sm-12">
+                    <app-contact [record]="record" [inBrowser]="inBrowser"></app-contact>
 
-                    <div class="ui-g">
-                        <div class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-12">
-                            <div [hidden]="metadata">
-                                <app-description [record]="record" [inBrowser]="inBrowser"></app-description>
-                            </div>
-                            <app-topic [record]="record" [inBrowser]="inBrowser"></app-topic>
-                            <app-keyword [record]="record" [inBrowser]="inBrowser"></app-keyword>
-                            <p></p>
-                            <description-resources [record]="record" [files]="files"
-                                [metadata]="metadata" [inBrowser]="inBrowser" [ediid]="ediid" [editEnabled]="editEnabled"></description-resources>
-                            <metadata-detail [record]="record" [serviceApi]="serviceApi" [inBrowser]="inBrowser"
-                                [metadata]="metadata">
-                            </metadata-detail>
-                        </div>
-                        <div *ngIf="record.length !== 0 && inBrowser">
-                            <p-dialog class="citationDialog" [closable]="false" [(visible)]="display" modal="modal"
-                                width="550" height="330" responsive="true" #citeDialog>
-                                <p-header> Citation
-                                    <button style="position:relative; float:right; background-color:#1E6BA1; "
-                                        type="button" pButton icon="faa faa-close" (click)="closeDialog()"></button>
-                                </p-header>
-                                <span><b>Copy the recommended text to cite this resource </b></span> <br><br>
-                                <p contenteditable="false" style="font-size: 14px;">{{ citeString }}</p>
-                                <br>
-                                <a target="citationsRecommendation"
-                                    href="https://www.nist.gov/director/copyright-fair-use-and-licensing-statements-srd-data-and-software#citations"
-                                    (click)="gaService.gaTrackEvent('outbound', $event, 'Resource title: ' + record.title)">See
-                                    also NIST Citation Recommendations</a>
-                            </p-dialog>
-                        </div>
+                    <span>Identifier: </span>
+                    <span *ngIf="doiUrl"><i> <a class="font14" href="{{doiUrl}}"
+                                >{{record.doi}}</a></i></span>
+                    <span *ngIf="!doiUrl"><i> <a class="font14"
+                                href="{{ cfg.get('landingPageService','/od/id/') }}{{record['@id']}}">{{record["@id"]}}</a></i>
+                    </span>
+                    <span *ngIf="checkReferences()"><br>
+                        <span>Described in article: </span>
+                        <small *ngFor="let refs of record['references']; let i =index">
+                            <span style="padding-left:2.75em" *ngIf="refs.refType == 'IsDocumentedBy'">
+                                <br><i class="faa faa-external-link">
+                                    <a class="font14" href={{refs.location}} target="blank"
+                                        (click)="gaService.gaTrackEvent('outbound', $event, 'Resource title: ' + record.title, refs.location)">{{ refs.label }}</a></i>
+                                <span *ngIf="i < record.references.length-1 ">,</span>
+                            </span>
+                        </small>
+                    </span><br>
+                    <span class="" *ngIf="record.version"> Version: <strong>{{record.version}}</strong></span>
+                    <span class="" *ngIf="record.versionHistory" style="padding-right: 15pt;">...
+                        <i style="cursor: pointer;" class="faa" aria-hidden="true"
+                            [ngClass]="{'faa-plus-square-o': !clickHistory, 'faa-minus-square-o': clickHistory}"
+                            (click)="closeHistory = !closeHistory; clickHistory = expandHistory();"></i>
+                    </span>
+                    <span class="" *ngIf="record.issued" style="padding-right: 10pt;"> Released:
+                        <strong>{{record.issued}}</strong></span>
+                    <span class="" *ngIf="record.modified" style="padding-right: 10pt;"> Last modified:
+                        <strong>{{record.modified}}</strong></span>
+                    <div class="card customcard" [collapse]="!closeHistory">
+                        <b>Version History:</b>
+                        <span *ngFor="let release of record.versionHistory">
+                            <br> <b [innerHTML]="renderRelVer(release, record.version)"></b> &nbsp;&nbsp;
+                            <span *ngIf="release.issued">Released: {{release.issued}}</span>
+                            <span *ngIf="release.location || release.refid"> &nbsp;&nbsp;
+                                <i [innerHTML]="renderRelId(release, record.version)"></i>
+                            </span>
+                            <span *ngIf="release.description"> <br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                                <i>{{release.description}}</i>
+                            </span>
+                        </span>
                     </div>
+                    <p style="margin-top: 10px;" *ngIf="newer.location">
+                        <b>There is a more recent release of this resource available: &nbsp;&nbsp;
+                            <a href="{{newer.location}}"
+                                (click)="gaService.gaTrackEvent('outbound', $event, 'Resource title: ' + record.title, newer.label)">{{newer.label}}</a></b>
+                    </p>
                 </div>
 
-                <div *ngIf="inBrowser" class="ui-g-2 ui-md-2 ui-lg-2 ui-sm-12">
-                    <div class="ui-g" style="position:sticky; top:0; ">
-                        <div class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-12">
-                            <div class="d-none d-md-block d-lg-block d-xl-block ">
-                                <p-menu class="rightMenuStyle" [model]="rightmenu"></p-menu>
-                            </div>
-                        </div>
+                <div class="ui-g-4 ui-md-4 ui-lg-4 ui-sm-12">
+                    <span *ngIf="HomePageLink" style="float: right;">
+                        <span *ngIf="inBrowser; else visitHomeOnServer">
+                            <button type="button"
+                                (click)="visitHomePage(record.landingPage, $event, 'Resource title: '+record.title)"
+                                pButton type="submit"
+                                style="float:right;margin:.5em 1em .5em 0em;width:200px; height:2em; background-color:#1471AE;color:white;padding-right: 1em;"
+                                [disabled]="mdupdsvc.editMode">
+                                <i class="faa faa-external-link"
+                                    style="color: #fff;padding-left: .5em;padding-right: .5em;"></i>
+                                Visit Home Page
+                            </button>
+                        </span>
+                        <ng-template #visitHomeOnServer>Visit Home Page</ng-template>
+                    </span>
+                </div>
+            </div>
+
+            <div class="ui-g">
+                <div class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-12">
+                    <div [hidden]="metadata">
+                        <app-description [record]="record" [inBrowser]="inBrowser"></app-description>
                     </div>
+                    <app-topic [record]="record" [inBrowser]="inBrowser"></app-topic>
+                    <app-keyword [record]="record" [inBrowser]="inBrowser"></app-keyword>
+                    <p></p>
+                    <description-resources [record]="record" [files]="files"
+                        [metadata]="metadata" [inBrowser]="inBrowser" [ediid]="ediid" [editEnabled]="editEnabled"></description-resources>
+                    <metadata-detail [record]="record" [serviceApi]="serviceApi" [inBrowser]="inBrowser"
+                        [metadata]="metadata">
+                    </metadata-detail>
+                </div>
+                <div *ngIf="record.length !== 0 && inBrowser">
+                    <p-dialog class="citationDialog" [closable]="false" [(visible)]="display" modal="modal"
+                        width="550" height="330" responsive="true" #citeDialog>
+                        <p-header> Citation
+                            <button style="position:relative; float:right; background-color:#1E6BA1; "
+                                type="button" pButton icon="faa faa-close" (click)="closeDialog()"></button>
+                        </p-header>
+                        <span><b>Copy the recommended text to cite this resource </b></span> <br><br>
+                        <p contenteditable="false" style="font-size: 14px;">{{ citeString }}</p>
+                        <br>
+                        <a target="citationsRecommendation"
+                            href="https://www.nist.gov/director/copyright-fair-use-and-licensing-statements-srd-data-and-software#citations"
+                            (click)="gaService.gaTrackEvent('outbound', $event, 'Resource title: ' + record.title)">See
+                            also NIST Citation Recommendations</a>
+                    </p-dialog>
                 </div>
             </div>
         </div>

--- a/angular/src/app/landing/landing.component.html
+++ b/angular/src/app/landing/landing.component.html
@@ -6,12 +6,6 @@
                     <span class="recordType">
                         <b>{{recordType}}</b>
                     </span>
-                    <div *ngIf="record.length !== 0 && inBrowser"
-                        class="ui-sm-1 d-none d-block d-sm-block d-md-none ">
-                        <button style="float: right" type="button" pButton icon="faa faa-list"
-                            class="ui-button ui-button-icon-only" (click)="menu3.toggle($event)"></button>
-                        <p-menu #menu3 class="rightMenuStylePop" popup="popup" [model]="rightmenu"></p-menu>
-                    </div>
                     <br>
                     <app-title [record]="record" [inBrowser]="inBrowser"></app-title>
                     <app-author [record]="record" [inBrowser]="inBrowser"></app-author>

--- a/angular/src/app/landing/landing.component.spec.ts
+++ b/angular/src/app/landing/landing.component.spec.ts
@@ -20,6 +20,10 @@ import { TestDataService } from '../shared/testdata-service/testDataService';
 import { GoogleAnalyticsService } from '../shared/ga-service/google-analytics.service';
 import * as mock from '../testing/mock.services';
 import {RouterTestingModule} from "@angular/router/testing";
+import { DatePipe } from '@angular/common';
+import { MetadataUpdateService } from './editcontrol/metadataupdate.service';
+import { AuthService, WebAuthService, MockAuthService } from './editcontrol/auth.service';
+
 import { testdata } from '../../environments/environment';
 
 describe('LandingComponent', () => {
@@ -32,6 +36,7 @@ describe('LandingComponent', () => {
     let route : ActivatedRoute;
     let router : Router;
     let routes : Routes = [ ];
+    let authsvc : AuthService = new MockAuthService(undefined);
 
     beforeEach(() => {
         cfg = (new AngularEnvironmentConfigService(plid, ts)).getConfig() as AppConfig;
@@ -66,8 +71,10 @@ describe('LandingComponent', () => {
                 { provide: ActivatedRoute,  useValue: route },
                 { provide: ElementRef,      useValue: null },
                 { provide: AppConfig,       useValue: cfg },
+                { provide: AuthService,     useValue: authsvc },
                 UserMessageService,
-                CartService, DownloadService, TestDataService, GoogleAnalyticsService, ModalService
+                CartService, DownloadService, TestDataService, GoogleAnalyticsService, ModalService,
+                MetadataUpdateService, DatePipe
             ]
         }).compileComponents();
 

--- a/angular/src/app/landing/landing.module.ts
+++ b/angular/src/app/landing/landing.module.ts
@@ -4,9 +4,6 @@ import { SharedModule } from '../shared/shared.module';
 import { TreeModule, FieldsetModule, DialogModule, OverlayPanelModule,
          ConfirmDialogModule, MenuModule } from 'primeng/primeng';
 import { TreeTableModule } from 'primeng/treetable';
-import { DatePipe } from '@angular/common';
-import { EditControlModule } from './editcontrol/editcontrol.module';
-import { MetadataUpdateService } from './editcontrol/metadataupdate.service';
 
 import { LandingComponent } from './landing.component';
 import { DataFilesComponent } from './data-files/data-files.component';
@@ -32,10 +29,7 @@ import { MetadataView } from './metadata/metadataview.component';
   ],
   imports: [
     CommonModule,SharedModule,TreeModule,FieldsetModule, DialogModule, OverlayPanelModule,
-      ConfirmDialogModule, MenuModule,TreeTableModule, EditControlModule
-  ],
-  providers: [
-      MetadataUpdateService, DatePipe
+      ConfirmDialogModule, MenuModule,TreeTableModule
   ],
   exports:[
     LandingComponent, DataFilesComponent, TitleComponent, AuthorComponent, ContactComponent,

--- a/angular/src/app/landing/landingpage.component.css
+++ b/angular/src/app/landing/landingpage.component.css
@@ -1,1 +1,16 @@
+.landingcard {
+    padding: 2.5rem 2.5rem 2.5rem 2.5rem;
+    margin-bottom: 0rem;
+    border: 0px;
+}
+
+.landingcard h3 {
+    font-size: 1.25em;
+    font-weight: 400;
+}
+
+.landingcard h2 {
+    font-size: 1.375em;
+    font-weight: 400;
+}
 

--- a/angular/src/app/landing/landingpage.component.css
+++ b/angular/src/app/landing/landingpage.component.css
@@ -4,12 +4,16 @@
     border: 0px;
 }
 
-.landingcard h3 {
+.landing-body {
+    border: 0px;
+}
+
+.landing-body h3 {
     font-size: 1.25em;
     font-weight: 400;
 }
 
-.landingcard h2 {
+.landing-body h2 {
     font-size: 1.375em;
     font-weight: 400;
 }

--- a/angular/src/app/landing/landingpage.component.html
+++ b/angular/src/app/landing/landingpage.component.html
@@ -1,2 +1,57 @@
+<!-- edit control panel (visible when editing is enabled) -->
+<pdr-edit-control *ngIf="editEnabled" [inBrowser]="inBrowser"
+                  [(mdrec)]="md" [requestID]="requestId"></pdr-edit-control>
+
 <!-- landing page panel -->
-<app-landing [record]="md" [requestId]="reqId" [inBrowser]="inBrowser"></app-landing>
+<div class="ui-grid ui-grid-responsive ui-grid-pad center">
+  <div class="card landingcard">
+
+    <div *ngIf="md === null">
+      <div class="ui-g-10 ui-md-10 ui-lg-10 ui-sm-12" style="padding-left: 1%">
+        <b>Landing page is loading...</b>
+      </div>
+    </div>
+
+    <!-- Pop-up tool menu (for small-width devices) -->
+    <div *ngIf="md !== null && inBrowser"
+         class="ui-sm-1 d-none d-block d-sm-block d-md-none ">
+      <button style="position: absolute; top: 1.0rem; left: 1.5rem" type="button"
+              pButton icon="faa faa-list" class="ui-button ui-button-icon-only" 
+              (click)="menu3.togglePopup($event)"></button>
+      <tools-menu #menu3 [record]="md" [isPopup]="true" (toggle_citation)="toggleCitation()"
+                         (scroll)="goToSection($event)"></tools-menu>
+    </div>
+
+    <div *ngIf="md">
+      <div class="ui-g">
+
+        <!-- landing page content -->
+        <div class="ui-g-10 ui-md-10 ui-lg-10 ui-sm-12">
+
+          <app-landing [record]="md" [inBrowser]="inBrowser" [requestId]="reqId"></app-landing>
+
+        </div>
+
+        <!-- citation pop-up -->
+        <div *ngIf="inBrowser">
+          <citation-popup [citetext]="getCitation()"
+                          [(visible)]="citationVisible"></citation-popup>
+        </div>
+
+        <!-- side tool menu (for tablets and desktop displays  -->
+        <div class="ui-g-2 ui-md-2 ui-lg-2 ui-sm-12">
+          <div class="ui-g" style="position: sticky; top: 0;">
+            <div class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-12">
+              <div *ngIf="inBrowser" class="d-none d-md-block d-lg-block d-xl-block ">
+
+                <tools-menu #menu2 [record]="md" [isPopup]="false"
+                                   (toggle_citation)="toggleCitation()"
+                                   (scroll)="goToSection($event)"></tools-menu>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/angular/src/app/landing/landingpage.component.spec.ts
+++ b/angular/src/app/landing/landingpage.component.spec.ts
@@ -10,6 +10,8 @@ import { ToastrModule } from 'ngx-toastr';
 
 import { LandingPageModule } from './landingpage.module';
 import { LandingPageComponent } from './landingpage.component';
+import { ToolsModule } from './tools/tools.module';
+import { CitationModule } from './citation/citation.module';
 import { AngularEnvironmentConfigService } from '../config/config.service';
 import { AppConfig } from '../config/config'
 import { MetadataTransfer, NerdmRes } from '../nerdm/nerdm'
@@ -67,7 +69,7 @@ describe('LandingPageComponent', () => {
     let setupComponent = function() {
         TestBed.configureTestingModule({
             imports: [
-                HttpClientModule, BrowserAnimationsModule, LandingPageModule,
+                HttpClientModule, BrowserAnimationsModule, LandingPageModule, ToolsModule, CitationModule,
                 RouterTestingModule.withRoutes(routes),
                 ToastrModule.forRoot({
                     toastClass: 'toast toast-bootstrap-compatibility-fix'
@@ -79,7 +81,7 @@ describe('LandingPageComponent', () => {
                 { provide: AppConfig,       useValue: cfg },
                 { provide: MetadataService, useValue: mds },
                 UserMessageService,
-                CartService, DownloadService, TestDataService, GoogleAnalyticsService, ModalService,
+                CartService, DownloadService, TestDataService, GoogleAnalyticsService, ModalService
             ]
         }).compileComponents();
 

--- a/angular/src/app/landing/landingpage.module.ts
+++ b/angular/src/app/landing/landingpage.module.ts
@@ -1,9 +1,15 @@
 import { NgModule }     from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { DatePipe }     from '@angular/common';
+import { ButtonModule } from 'primeng/button';
 
 import { NerdmModule } from '../nerdm/nerdm.module';
 import { LandingPageComponent } from './landingpage.component';
 import { LandingModule } from '../landing/landing.module';
+import { MetadataUpdateService } from './editcontrol/metadataupdate.service';
+import { EditControlModule } from './editcontrol/editcontrol.module';
+import { ToolsModule } from './tools/tools.module';
+import { CitationModule } from './citation/citation.module';
 
 /**
  * A module supporting the complete display of landing page content associated with 
@@ -12,13 +18,18 @@ import { LandingModule } from '../landing/landing.module';
 @NgModule({
     imports: [
         CommonModule,
+        ButtonModule,
         NerdmModule,    // provider for MetadataService (which depends on AppConfig)
-        LandingModule
+        LandingModule,
+        EditControlModule,
+        ToolsModule,
+        CitationModule
     ],
     declarations: [
         LandingPageComponent,
     ],
     providers: [
+        MetadataUpdateService, DatePipe
     ],
     exports: [
         LandingPageComponent

--- a/angular/src/app/landing/tools/toolmenu.component.css
+++ b/angular/src/app/landing/tools/toolmenu.component.css
@@ -1,0 +1,99 @@
+:host /deep/ .rightMenuStyle > .ui-menu .ui-submenu-header{
+  /* background-color: #B8D4E6; */
+  /* background-color:rgb(65, 68, 69); */
+  background-color:#2C8034;
+  padding: 2%;
+  padding-left: 5%;
+  font-family: sans-serif;
+  font-size: 16px;
+  font-weight: bold;
+  color: white;
+ 
+}
+
+:host /deep/ .rightMenuStyle > .ui-menu  .ui-menuitem-link  .ui-state-hover{
+  line-height: 1em;
+  min-height: 1em;
+  background-color: #e7f0f6;
+  word-wrap: break-word;
+  font-family: 'Sans-Serif';
+  font-size: 14px;
+}
+
+:host /deep/ .rightMenuStyle > .ui-menu  .ui-menuitem{
+  line-height: 1em;
+  min-height: 1em;
+  /* background-color:  #e7f0f6; */
+  background-color: #F0FAF1;
+  word-wrap: break-word;
+  font-family: sans-serif;
+  font-size: 14px;
+  padding: 0;
+}
+
+:host /deep/ .rightMenuStyle > .ui-menu .ui-menuitem-link{
+  padding: 0.5em 0.2em 0.5em 0.5em;
+  font-family:  sans-serif;
+  font-size: 14px;
+}
+:host /deep/ .rightMenuStyle > .ui-menu{
+  width: 100%;
+}
+
+:host /deep/ .rightMenuStyle > .ui-menu  .ui-menuitem-link:hover {
+  background-color: #ffffff;
+  color: #000000;
+}
+
+:host /deep/ .rightMenuStylePop  > .ui-menu {
+  position: absolute;
+  width: 12em;
+  word-wrap: break-word;
+  font-family: sans-serif;
+  
+}
+:host /deep/ .rightMenuStylePop > .ui-menu .ui-menuitem-link{
+  padding: 0.5em 0.2em 0.5em 0.5em;
+  font-size: 14px;
+}
+
+:host /deep/ .rightMenuStylePop > .ui-menu  .ui-menuitem{
+  line-height: 1em;
+  min-height: 1em;
+  /* background-color:  #e7f0f6; */
+  background-color: #F0FAF1;
+  word-wrap: break-word;
+  font-family: sans-serif;
+  font-size: 14px;
+  padding: 0;
+}
+
+:host /deep/ .rightMenuStylePop > .ui-menu  .ui-menuitem-link  .ui-state-hover{
+  line-height: 1em;
+  min-height: 1em;
+  background-color: #e7f0f6;
+  word-wrap: break-word;
+  font-family: 'Sans-Serif';
+  font-size: 14px;
+}
+:host /deep/ .rightMenuStylePop > .ui-menu .ui-submenu-header {
+  background-color:#2C8034;
+  padding: 2%;
+  padding-left: 5%;
+  font-family: sans-serif;
+  font-size: 16px;
+  font-weight: bold;
+  color: white;
+ 
+}
+
+:host /deep/ .rightMenuStylePop > .ui-menu .ui-submenu-header{
+  padding: 0.5em 0.2em 0.5em 0.5em;
+  font-size: 14px;
+}
+
+:host /deep/ .ui-menu{
+  padding: 0;
+  border:0;
+}
+

--- a/angular/src/app/landing/tools/toolmenu.component.spec.ts
+++ b/angular/src/app/landing/tools/toolmenu.component.spec.ts
@@ -1,0 +1,54 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { TransferState } from '@angular/platform-browser';
+
+import { MenuModule } from 'primeng/menu';
+
+import { ToolMenuComponent } from './toolmenu.component';
+import { AngularEnvironmentConfigService } from '../../config/config.service';
+import { AppConfig } from '../../config/config'
+import { NerdmRes } from '../../nerdm/nerdm';
+import { testdata } from '../../../environments/environment';
+
+describe('ToolMenuComponent', () => {
+    let component : ToolMenuComponent;
+    let fixture : ComponentFixture<ToolMenuComponent>;
+    let cfg : AppConfig;
+    let plid : Object = "browser";
+    let ts : TransferState = new TransferState();
+
+    let setupComponent = function(popup : boolean, md : NerdmRes) {
+        cfg = (new AngularEnvironmentConfigService(plid, ts)).getConfig() as AppConfig;
+        cfg.locations.pdrSearch = "https://goob.nist.gov/search";
+        
+        component = null;
+        TestBed.configureTestingModule({
+            imports: [ CommonModule, MenuModule, BrowserAnimationsModule ],
+            declarations: [ ToolMenuComponent ],
+            providers: [
+                { provide: AppConfig,  useValue: cfg },
+            ]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(ToolMenuComponent);
+        component = fixture.componentInstance;
+        component.record = md;
+        component.isPopup = popup;
+        fixture.detectChanges();
+    }
+
+    it('displays the submenus', () => {
+        let md = testdata['test1'];
+        setupComponent(false, md);
+
+        expect(component).toBeDefined();
+        expect(component.record['@id']).toBe('ark:/88434/mds0000fbk');
+        expect(component.isPopup).toBe(false);
+
+        let cmpel = fixture.nativeElement;
+        let pels = cmpel.querySelectorAll("p-menu");
+        expect(pels.length).toBeGreaterThan(0);
+        
+    });
+});

--- a/angular/src/app/landing/tools/toolmenu.component.ts
+++ b/angular/src/app/landing/tools/toolmenu.component.ts
@@ -1,0 +1,197 @@
+import { Component, Input, Output, OnChanges, ViewChild, EventEmitter } from '@angular/core';
+
+import { MenuItem } from 'primeng/api';
+import { Menu } from 'primeng/menu';
+
+import { AppConfig } from '../../config/config';
+import { NerdmRes } from '../../nerdm/nerdm';
+
+/**
+ * A component for displaying access to landing page tools in a menu.
+ * 
+ * Items include:
+ * * links to the different sections of the landing page
+ * * links to view or export metadata
+ * * information about usage (like Citation information in a pop-up)
+ * * links for searching for similar resources
+ */
+@Component({
+    selector: 'tools-menu',
+    template: `
+<p-menu #tmenu [ngClass]="{'rightMenuStyle': !isPopup, 'rightMenuStylePop': isPopup}" 
+               [popup]="isPopup" [model]="items"></p-menu>
+`,
+    styleUrls: ['./toolmenu.component.css']
+})
+export class ToolMenuComponent implements OnChanges {
+
+    // the resource record metadata that the tool menu data is drawn from
+    @Input() record : NerdmRes|null = null;
+
+    // true if this menu should appear as a popup
+    @Input() isPopup : boolean = false;
+
+    // signal for triggering display of the citation information
+    @Output() toggle_citation = new EventEmitter<boolean>();
+
+    // signal for scrolling to a section within the page
+    @Output() scroll = new EventEmitter<string>();
+
+    // reference to the child menu (needed to toggle display when isPopup = true)
+    @ViewChild('tmenu')
+    private menu : Menu;
+
+    // the menu item configuration
+    items: MenuItem[] = [];
+
+    /**
+     * create the component.
+     * @param cfg   the app configuration data
+     */
+    constructor(private cfg : AppConfig) {  }
+
+    /**
+     * toggle the appearance of a popup menu
+     */
+    togglePopup(click) {
+        if (this.isPopup)
+            this.menu.toggle(click);
+    }
+
+    /**
+     * update the component state when the record metadata is updated
+     */
+    ngOnChanges() {
+        if (this.record) 
+            this.updateMenu();
+    }
+
+    /**
+     * configure the menu using data from the record metadata
+     */
+    updateMenu() {
+        var mitems : MenuItem[] = [];
+        var subitems : MenuItem[] = [];
+
+        let mdapi = this.cfg.get("locations.mdService", "/unconfigured");
+        if (mdapi.slice(-1) != '/') mdapi += '/';
+        if (mdapi.search("/rmm/") < 0)
+            mdapi += this.record['ediid'];
+        else
+            mdapi += "records?@id=" + this.record['@id'];
+
+        // Go To...
+        // top of the page
+        subitems.push(
+            this.createMenuItem("Top", "faa faa-arrow-circle-right",
+                                (event) => { this.goToSection(null); }, null)
+        );
+
+        // Go To...
+        subitems.push(
+            this.createMenuItem("Description", "faa faa-arrow-circle-right",
+                                (event) => { this.goToSection('description'); }, null)
+        );
+
+        // is it possible to not have a data access section?
+        subitems.push(
+            this.createMenuItem("Data Access", "faa faa-arrow-circle-right",
+                                (event) => { this.goToSection('dataAccess'); }, null)
+        );
+        
+        if (this.record['references'])
+            subitems.push(
+                this.createMenuItem("References", "faa faa-arrow-circle-right ",
+                                    (event) => { this.goToSection('reference'); }, null)
+            );
+        mitems.push({ label: 'Go To...', items: subitems });
+
+        // Record Details
+        subitems = [
+            this.createMenuItem("View Metadata", "faa faa-bars",
+                                (event) => { this.goToSection('metadata'); },null),
+            this.createMenuItem("Export JSON", "faa faa-file-o", null, mdapi)
+        ];
+        mitems.push({ label: "Record Details", items: subitems });
+
+        // Use
+        subitems = [
+            this.createMenuItem('Citation', "faa faa-angle-double-right",
+                                (event) => { this.toggleCitation(); }, null),
+            this.createMenuItem("Fair Use Statement", "faa faa-external-link", null,
+                                this.record['license'])
+        ];
+        mitems.push({ label: "Use", items: subitems });
+
+        // Find
+        let searchbase = this.cfg.get("locations.pdrSearch","/sdp/")
+        if (searchbase.slice(-1) != '/') searchbase += "/"
+        let authlist = "";
+        if (this.record['authors']) {
+            for (let a of this.record['authors']) {
+                if (a['familyName'])
+                    authlist += ","+a.familyName
+            }
+            if (authlist.length > 0) authlist = authlist.slice(1);
+        }
+        subitems = [
+            this.createMenuItem("Similar Resources", "faa faa-external-link", null,
+                                searchbase + "#/search?q=" + this.record['keyword'] +
+                                "&key=&queryAdvSearch=yes"),
+            this.createMenuItem('Resources by Authors', "faa faa-external-link", null,
+                                searchbase + "#/search?q=authors.familyName=" + authlist +
+                                "&key=&queryAdvSearch=yes")
+        ];
+        mitems.push({ label: "Find", items: subitems });
+
+        this.items = mitems;
+    }
+
+    /**
+     * create an entry for a menu
+     * @param label     the label that should appear on the menu entry
+     * @param icon      the class labels that define the icon to display next to the menu label
+     * @param command   a function that should be executed when the menu item is selected.
+     *                    The function should take a single argument representing the selection
+     *                    event object
+     * @param url       a URL that should be navigated to when the menu item is selected.
+     */
+    createMenuItem(label: string, icon: string, command: any, url: string) {
+        let item : MenuItem = {
+            label: label,
+            icon: icon
+        };
+        if (command)
+            item.command = command;
+        if (url) {
+            item.url = url;
+            item.target = "_blank";
+        }
+
+        return item;
+    }
+
+    /**
+     * switch the display of the Citation information:  if it is currently showing,
+     * it should be hidden; if it is not visible, it should be shown.  This method
+     * is trigger by clicking on the "Citation" link in the menu; clicking 
+     * alternatively both shows and hides the display.
+     *
+     * The LandingPageComponent handles the actual display of the information
+     * (currently implemented as a pop-up).  
+     */
+    toggleCitation() {
+        this.toggle_citation.emit(true);
+    }
+    
+    /**
+     * scroll to the specified section of the landing page
+     */
+    goToSection(sectname : string) {
+        if (sectname) 
+            console.info("scrolling to #"+sectname+"...");
+        else
+            console.info("scrolling to top of document");
+        this.scroll.emit(sectname);
+    }
+}

--- a/angular/src/app/landing/tools/tools.module.ts
+++ b/angular/src/app/landing/tools/tools.module.ts
@@ -1,0 +1,27 @@
+import { NgModule }     from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { MenuModule } from 'primeng/menu';
+
+import { ToolMenuComponent } from './toolmenu.component';
+
+/**
+ * A module providing tools for interacting with the landing page's record metadata.  
+ *
+ * This includes the right-hand menu for navigating the record, displaying citation information, 
+ * and searching for related records.
+ */
+@NgModule({
+    imports: [
+        CommonModule,
+        MenuModule
+    ],
+    declarations: [
+        ToolMenuComponent
+    ],
+    exports: [
+        ToolMenuComponent
+    ]
+})
+export class ToolsModule { }
+

--- a/angular/src/app/nerdm/nerdm.spec.ts
+++ b/angular/src/app/nerdm/nerdm.spec.ts
@@ -1,4 +1,155 @@
 import * as nerdm from './nerdm';
+import { testdata } from '../../environments/environment';
+
+import * as _ from 'lodash';
+
+describe('NERDResource', function() {
+
+    it("constructor", function() {
+        let nrd = new nerdm.NERDResource(testdata['test1']);
+        expect(nrd.data).toBeDefined();
+        expect(nrd.data['@id']).toBe("ark:/88434/mds0000fbk");
+    });
+
+    it("_isstring", function() {
+        expect(nerdm.NERDResource._isstring("")).toBe(true);
+        expect(nerdm.NERDResource._isstring("goob")).toBe(true);
+        expect(nerdm.NERDResource._isstring(new String("goob"))).toBe(true);
+
+        expect(nerdm.NERDResource._isstring(14)).toBe(false);
+        expect(nerdm.NERDResource._isstring(["goob"])).toBe(false);
+        expect(nerdm.NERDResource._isstring({"goob": "gurn"})).toBe(false);
+    });
+
+    it("_stripns", function() {
+        expect(nerdm.NERDResource._stripns("")).toBe("");
+        expect(nerdm.NERDResource._stripns("hank")).toBe("hank");
+        expect(nerdm.NERDResource._stripns("nrd:hank")).toBe("hank");
+        expect(nerdm.NERDResource._stripns("nrd:hank:gaherd")).toBe("hank:gaherd");
+    });
+
+    it("_striptypes", function() {
+        let nrd = testdata['test1']
+        expect(nerdm.NERDResource._striptypes(nrd)).toEqual(["PublicDataResource"]);
+        expect(nerdm.NERDResource._striptypes(nrd['components'][1])).toEqual(["DataFile","Distribution"]);
+        expect(nerdm.NERDResource._striptypes({'@type': "goob"})).toEqual(["goob"]);
+        expect(nerdm.NERDResource._striptypes({'@type': ["ns:gurn", "goob"]})).toEqual(["goob","gurn"]);
+    });
+
+    it("_typesintersect", function() {
+        let nrd = testdata['test1']
+        expect(nerdm.NERDResource._typesintersect(nrd, ["PublicDataResource"])).toBe(true);
+        expect(nerdm.NERDResource._typesintersect(nrd, ["SRD"])).toBe(false);
+        let cmp = nrd['components'][1];
+        expect(nerdm.NERDResource._typesintersect(cmp, ["SRD"])).toBe(false);
+        expect(nerdm.NERDResource._typesintersect(cmp, ["DataFile","Gurn","SRD"])).toBe(true);
+        expect(nerdm.NERDResource._typesintersect(cmp, ["DataFile","Distribution"])).toBe(true);
+        expect(nerdm.NERDResource._typesintersect(cmp, ["Hank","Gurn","SRD"])).toBe(false);
+        cmp = nrd['components'][0];
+        expect(nerdm.NERDResource._typesintersect(cmp, ["AKA","Hidden","Distribution"])).toBe(true);
+        cmp = nrd['components'][2];
+        expect(nerdm.NERDResource._typesintersect(cmp, ["AKA","Hidden","ZZZ"])).toBe(false);
+    });
+
+    it("objectMatchesType", function() {
+        let nrd = testdata['test1']
+        expect(nerdm.NERDResource.objectMatchesTypes(nrd, ["PublicDataResource"])).toBe(true);
+        expect(nerdm.NERDResource.objectMatchesTypes(nrd, ["SRD"])).toBe(false);
+        let cmp = nrd['components'][1];
+        expect(nerdm.NERDResource.objectMatchesTypes(cmp, ["SRD"])).toBe(false);
+        expect(nerdm.NERDResource.objectMatchesTypes(cmp, ["DataFile","Gurn","SRD"])).toBe(true);
+        expect(nerdm.NERDResource.objectMatchesTypes(cmp, ["Gurn","SRD","DataFile"])).toBe(true);
+        expect(nerdm.NERDResource.objectMatchesTypes(cmp, ["SRD","Gurn","DataFile"])).toBe(true);
+        expect(nerdm.NERDResource.objectMatchesTypes(cmp, ["DataFile","Distribution"])).toBe(true);
+        expect(nerdm.NERDResource.objectMatchesTypes(cmp, ["Distribution","DataFile"])).toBe(true);
+        expect(nerdm.NERDResource.objectMatchesTypes(cmp, ["Hank","Gurn","SRD"])).toBe(false);
+        cmp = nrd['components'][0];
+        expect(nerdm.NERDResource.objectMatchesTypes(cmp, ["AKA","Hidden","Distribution"])).toBe(true);
+        expect(nerdm.NERDResource.objectMatchesTypes(cmp, "Hidden")).toBe(true);
+        expect(nerdm.NERDResource.objectMatchesTypes(cmp, "ZZZ")).toBe(false);
+        expect(nerdm.NERDResource.objectMatchesTypes(nrd['contactPoint'], ["ZZZ"])).toBe(false);
+        cmp = nrd['components'][2];
+        expect(nerdm.NERDResource.objectMatchesTypes(cmp, ["ZZZ","AKA","Hidden"])).toBe(false);
+
+        expect(nerdm.NERDResource.objectMatchesTypes(cmp, ["ZZZ","AKA","Hidden"])).toBe(false);
+    });
+
+    it("getComponentsByType", () => {
+        let nrd = new nerdm.NERDResource(testdata['test1']);
+        let cmps : any[] = nrd.getComponentsByType("DataFile");
+        expect(cmps.length).toEqual(2);
+        expect(cmps[0]['@type']).toEqual(["nrdp:DataFile", "dcat:Distribution"]);
+        expect(cmps[1]['@type']).toEqual(["nrdp:DataFile", "dcat:Distribution"]);
+
+        cmps = nrd.getComponentsByType("nrdm:Hidden");
+        expect(cmps.length).toEqual(1);
+        expect(cmps[0]['@type']).toEqual(["nrdp:Hidden", "nrdp:AccessPage", "dcat:Distribution"]);
+
+        cmps = nrd.getComponentsByType(["Hidden", "nrdm:DataFile"]);
+        expect(cmps.length).toEqual(3);
+        expect(cmps[0]['@type']).toEqual(["nrdp:Hidden", "nrdp:AccessPage", "dcat:Distribution"]);
+        expect(cmps[1]['@type']).toEqual(["nrdp:DataFile", "dcat:Distribution"]);
+        expect(cmps[2]['@type']).toEqual(["nrdp:DataFile", "dcat:Distribution"]);
+
+        cmps = nrd.getComponentsByType(["Distribution"]);
+        expect(cmps.length).toEqual(3);
+        expect(cmps[0]['@type']).toEqual(["nrdp:Hidden", "nrdp:AccessPage", "dcat:Distribution"]);
+        expect(cmps[1]['@type']).toEqual(["nrdp:DataFile", "dcat:Distribution"]);
+        expect(cmps[2]['@type']).toEqual(["nrdp:DataFile", "dcat:Distribution"]);
+
+        cmps = nrd.getComponentsByType("Goob");
+        expect(cmps.length).toEqual(0);
+
+        let nrdd = _.cloneDeep(testdata['test1']);
+        nrdd['components'] = []
+        nrd = new nerdm.NERDResource(nrdd);
+        cmps = nrd.getComponentsByType(["Distribution"]);
+        expect(cmps.length).toEqual(0);
+        delete nrd.data['components'];
+        expect(nrd.data['components']).not.toBeDefined()
+        cmps = nrd.getComponentsByType(["Distribution"]);
+        expect(cmps.length).toEqual(0);
+    });
+
+    it("countComponentsByType", () => {
+        let nrd = new nerdm.NERDResource(testdata['test1']);
+        expect(nrd.countComponentsByType("DataFile")).toEqual(2);
+    });
+
+    it("getFilecListComponents", () => {
+        let nrd = new nerdm.NERDResource(testdata['test2']);
+        expect(nrd.data['components'].length).toEqual(5);
+
+        let cmps : any[] = nrd.getFileListComponents();
+        expect(cmps.length).toEqual(3);
+        expect(cmps[0]['filepath']).toEqual("README.txt");
+        expect(cmps[1]['filepath']).toEqual("data");
+        expect(cmps[2]['filepath']).toEqual("data/file.csv");
+    });
+
+    it("countFilecListComponents", () => {
+        let nrd = new nerdm.NERDResource(testdata['test2']);
+        expect(nrd.data['components'].length).toEqual(5);
+        expect(nrd.countFileListComponents()).toEqual(3);
+    });
+
+    it("getCitation", () => {
+        let nrd = new nerdm.NERDResource(testdata['test2']);
+        let cstr = nrd.getCitation();
+        expect(cstr.startsWith("Doe, John, Plant, Robert (2011), Test2, National Institute of Standards and Technology, https://doi.org/XXXXX/MMMMM (Accessed ")).toBe(true);
+        // expect(cstr).toEqual("Doe, John, Plant, Robert (2011) Test2, National Institute of Standards and Technology, https://doi.org/XXXXX/MMMMM (Accessed ");
+
+        nrd = new nerdm.NERDResource(testdata['test1']);
+        cstr = nrd.getCitation();
+//        expect(cstr).toBe("Patricia Flanagan (2011), Multiple Encounter Dataset (MEDS-I) - NIST Special Database 32, National Institute of Standards and Technology, https://www.nist.gov/itl/iad/image-group/special-database-32-multiple-encounter-dataset-meds (Accessed ");
+        expect(cstr).toContain("Patricia Flanagan (2011), Multiple Encounter Dataset (MEDS-I) - NIST Special Database 32, National Institute of Standards and Technology, https://www.nist.gov/itl/iad/image-group/special-database-32-multiple-encounter-dataset-meds (Accessed ");
+
+        nrd = new nerdm.NERDResource(_.cloneDeep(testdata['test1']));
+        delete nrd.data['contactPoint']['fn'];
+        cstr = nrd.getCitation();
+        expect(cstr).toContain("National Institute of Standards and Technology (2011), Multiple Encounter Dataset (MEDS-I) - NIST Special Database 32, National Institute of Standards and Technology, https://www.nist.gov/itl/iad/image-group/special-database-32-multiple-encounter-dataset-meds (Accessed ");
+    });
+});
 
 describe('MetadataTransfer', function() {
 

--- a/angular/src/app/nerdm/nerdm.ts
+++ b/angular/src/app/nerdm/nerdm.ts
@@ -3,6 +3,8 @@
  */
 import { Injectable, InjectionToken } from '@angular/core';
 
+import * as _ from 'lodash';
+
 /**
  * a representation of a NERDm Component
  */
@@ -59,6 +61,170 @@ export interface NerdmRes {
      * other parameters are expected
      */
     [propName: string]: any;
+}
+
+/**
+ * a class interpreting a NerdmRes record.  This class wraps a NerdmRes object in an 
+ * interface that provides functions that generate views on that information useful to 
+ * displaying it.
+ */
+export class NERDResource {
+
+    /**
+     * wrap a NerdRes record (the data that describes a data resource)
+     */
+    constructor(public data : NerdmRes) { }
+
+    /**
+     * return the recommend text for citing this resource
+     */
+    getCitation() : string {
+        if (this.data['citation'])
+            return this.data.citation;
+
+        let out = ""
+        if (this.data['authors']) {
+            for (let i = 0; i < this.data['authors'].length; i++) {
+                let author = this.data['authors'][i];
+                if (author.familyName !== null && author.familyName !== undefined)
+                    out += author.familyName + ', ';
+                if (author.givenName !== null && author.givenName !== undefined)
+                    out += author.givenName;
+                if (author.middleName !== null && author.middleName !== undefined)
+                    out += ' ' + author.middleName;
+                if (i != this.data['authors'].length - 1)
+                    out += ', ';
+            }
+        }
+        else if (this.data['contactPoint'] && this.data['contactPoint']['fn']) {
+            out += this.data['contactPoint']['fn'];
+        }
+        else if (this.data['publisher'] && this.data['publisher']['name']) {
+            out += this.data['publisher']['name'];
+        }
+        else {
+            out += "National Institute of Standards and Technology";
+        }
+
+        let date = this.data['issued'];
+        if (! date)
+            date = this.data['modified'];
+        if (date)
+            out += ' (' + date.split('-')[0] + ')';
+
+        if (this.data['title'])
+            out += ', ' + this.data['title'];
+        if (this.data['publisher'] && this.data['publisher']['name']) 
+            out += ', ' + this.data['publisher']['name'];
+
+        if (this.data['doi']) {
+            let doi = this.data['doi'];
+            if (doi.startsWith("doi:"))
+                doi = "https://doi.org/" + doi.split(':').slice(1).join(':')
+            out += ', ' + doi;
+        }
+        else if (this.data['landingPage']) {
+            out += ', ' + this.data['landingPage'];
+        }
+
+        date = new Date();
+        out += " (Accessed " + date.getFullYear() + '-'
+        let n = date.getMonth() + 1;
+        n = (n < 10) ? "0" + n.toString() : n.toString();
+        out += n + '-';
+        n = date.getDate();
+        n = (n < 10) ? "0" + n.toString() : n.toString();
+        out += n + ')';
+        
+        return out
+    }
+
+    static _isstring(v : any, i?, a?) : boolean {
+        return typeof v === 'string' || v instanceof String;
+    }
+    static _stripns(t : string, i?, a?) : string {
+        return t.substr(t.indexOf(':')+1);
+    }
+    static _striptypes(cmp : {}) : string[] {
+        if (! cmp['@type']) return [];
+
+        let out = cmp['@type']
+        if (this._isstring(out)) out = [ out ];
+        if (! Array.isArray(out)) return []
+
+        return out.filter(this._isstring).map(this._stripns).sort()
+    }
+    static _typesintersect(obj : {}, types : string[]) : boolean {
+        // we will assume that types is strictly an ordered array of strings
+        let ctypes : string[] = this._striptypes(obj).sort();
+
+        for(var c of ctypes) {
+            for(var t of types) {
+                if (t == c) return true;  // found a matching type!
+                if (t > c) break;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * return true if there is an intersection between a given set of types
+     * and the values in the "@type" property of a given object
+     * @param obj    an object with the "@type" property; false will be returned 
+     *               if the property does not exist or if it is not of type string 
+     *               or array.
+     * @param types  a string or an array of string type labels.  Any prepended 
+     *               namespace prefixes will be ignored.  
+     */
+    static objectMatchesTypes(obj : {}, types : string|string[]) : boolean {
+        if (this._isstring(types)) types = [types as string]
+        if (! Array.isArray(types)) return false;
+        types = types.filter(this._isstring).map(this._stripns).sort();
+
+        return this._typesintersect(obj, types);
+    }
+
+    /**
+     * return an array of the component objects that match any of the given @type labels.
+     * The labels should not include namespace qualifiers
+     */
+    getComponentsByType(types : string|string[]) : any[] {
+        if (! this.data['components'] || !Array.isArray(this.data['components']))
+            return [];
+
+        if (NERDResource._isstring(types)) types = [types as string]
+        if (! Array.isArray(types)) return [];
+        types = types.filter(NERDResource._isstring).map(NERDResource._stripns).sort();
+
+        return this.data['components'].filter((c,i?,a?) => {
+            return NERDResource._typesintersect(c, types as string[]);
+        });
+    }
+
+    /**
+     * return the number resource components that match any of the given @type labels.  
+     * The labels should not include namespace qualifiers
+     */
+    countComponentsByType(types : string|string[]) {
+        return this.getComponentsByType(types).length;
+    }
+
+    /**
+     * return the components that should appear in the file listing display
+     */
+    getFileListComponents() {
+        let listable = ["DataFile", "Subcollection", "ChecksumFile"];
+        let hidden = ["Hidden"];
+        return this.getComponentsByType(listable)
+            .filter((c) => { return ! NERDResource.objectMatchesTypes(c, hidden); });
+    }
+
+    /**
+     * return the number of components that should appear in the file listing display
+     */
+    countFileListComponents() {
+        return this.getFileListComponents().length;
+    }
 }
 
 /**

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -51,7 +51,6 @@ export const testdata: {} = {
         ],
         "@id": "ark:/88434/mds0000fbk",
         "title": "Multiple Encounter Dataset (MEDS-I) - NIST Special Database 32",
-        "doi": "doi:10.18434/mds0000fbk",
         "contactPoint": {
             "hasEmail": "mailto:patricia.flanagan@nist.gov",
             "fn": "Patricia Flanagan"
@@ -102,6 +101,7 @@ export const testdata: {} = {
                 "downloadURL": "http://nigos.nist.gov:8080/nist/sd/32/NIST_SD32_MEDS-I_face.zip",
                 "filepath": "NIST_SD32_MEDS-I_face.zip",
                 "@type": [
+                    "nrdp:Hidden",
                     "nrdp:AccessPage",
                     "dcat:Distribution"
                 ],
@@ -134,7 +134,7 @@ export const testdata: {} = {
                 "description": "DOI Access to landing page",
                 "title": "DOI Access to \"Multiple Encounter Dataset (MEDS-I)\"",
                 "@type": [
-                    "nrd:Hidden",
+                    "nrdp:DataFile",
                     "dcat:Distribution"
                 ],
                 "@id": "#doi:10.18434/mds0000fbk",
@@ -166,6 +166,76 @@ export const testdata: {} = {
         }
         ]
 
+    },
+
+    
+    "test2": {
+        "@context": [
+            "https://www.nist.gov/od/dm/nerdm-pub-context.jsonld",
+            {
+                "@base": "ark:/88434/mds0000fbk"
+            }
+        ],
+        "_schema": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#",
+        "_extensionSchemas": [
+            "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataPublication"
+        ],
+        "@type": [
+            "nrdp:PublicDataResource"
+        ],
+        "@id": "ark:/88434/mds0000fbk",
+        "ediid": "ark:/88434/mds0000fbk",
+        "doi": "doi:XXXXX/MMMMM",
+        "title": "Test2",
+        "version": "12.1",
+        "authors": [
+            {
+                "familyName": "Doe",
+                "givenName": "John",
+                "fn": "John Doe"
+            },
+            {
+                "familyName": "Plant",
+                "givenName": "Robert",
+                "fn": "R. Plant"
+            }
+        ],
+        "contactPoint": {
+            "hasEmail": "mailto:patricia.flanagan@nist.gov",
+            "fn": "Patricia Flanagan"
+        },
+        "modified": "2011-07-11",
+        "landingPage": "https://www.nist.gov/itl/iad/image-group/special-database-32-multiple-encounter-dataset-meds",
+        "description": [ "para1", "para2" ],
+        "publisher": {
+            "@type": "org:Organization",
+            "name": "National Institute of Standards and Technology"
+        },
+        "components": [
+            {
+                "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
+                "filepath": "README.txt",
+                "downloadURL": "https://data.nist.gov/od/ds/mds0000fbk/README.txt"
+            },
+            {
+                "@type": [ "nrdp:Subcollection" ],
+                "filepath": "data",
+            },
+            {
+                "@type": [ "nrdp:Subcollection", "nrd:Hidden" ],
+                "filepath": "secret",
+            },
+            {
+                "@type": [ "nrdp:DataFile", "dcat:Distribution" ],
+                "filepath": "data/file.csv",
+                "downloadURL": "https://data.nist.gov/od/ds/mds0000fbk/data/file.csv"
+            },
+            {
+                "@type": [ "nrdp:DataFile", "nrd:Hidden" ],
+                "filepath": "data/secret.csv",
+                "downloadURL": "https://data.nist.gov/od/ds/mds0000fbk/data/file.csv"
+            }
+        ]
     }
 };
 


### PR DESCRIPTION
This PR is part of an ongoing effort at restructuring the angular Landing Page Service (LPS) app in an effort to improve maintainability and ease further evolution of the presentation.  Its overall goal is to distribute the current `LandingComponent` into several smaller apps that are aggregated together.  This PR, in particular, breaks out the right-hand tools menu into is own component, leaving the `LandingComponent` to handle just the main body of the landing page content.  While implementation of the menu is largely unchanged, it is a helpful precursor to replacing the tool bar with an implementation that is primeng-free (as the primeng components don't work with the server-side rendering).  

The change provided by the PR is summarized in the following diagrams.  
![toolmenu-extraction](https://user-images.githubusercontent.com/1027700/74261691-9e86e700-4cc9-11ea-9fd9-151f84b5d4a3.png)

In particular, the changes include:
 * a new tools module (`ToolsModule`) containing a new `ToolMenuComponent` that encapsulates the current right-hand menu (also used as the pop-up menu while in mobile mode).
 * re-org of citation component, including 
    * placing it in its own `CitationModule`
    * splitting the layout into `CitationDescriptionComponent`, which handles the pop-up content, and `CitationPopupComponent`, which presents the content into a pop-up window.
 * the tool menu and citation component are now part of the `LandingPageComponent` composition, and removed from `LandingComponent`.  The latter now just handles the body content of the landing page.  
 * added the `NERDMResource` class to `app/nerdm/nerdm.ts` which handles more metadata transformations, including generating citation text.

(As a preview, the next restructuring PR will split the `LandingComponent` into the different navigable sections.)

To review, please:
 1. review this PR description
 2. scan the code differences as needed for any obvious issues
 3. run standalone with editing turned on and off to ensure proper layout
 4. run under oar-docker/apps to ensure proper integrated behavior



