### PR TITLE
python: fix tests that rely on data.nist.gov

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -57,11 +57,11 @@ def find_oar_metadata(submoddir='oar-metadata'):
     outpy = os.path.join(out, "python", "nistoar")
     if not os.path.exists(out):
         msg = "oar-metadata submodule not found in {0} subdirectory" 
-        raise RuntimeError(msg.format(dirname))
+        raise RuntimeError(msg.format(out))
     if not os.path.exists(outpy):
         msg = "{0} subdirectory does apparently does not contain oar-metadata " \
               "submodule"
-        raise RuntimeError(msg.format(dirname))
+        raise RuntimeError(msg.format(out))
     return out
 
 def build_oar_metadata(pkgdir, buildlib, buildscrp):


### PR DESCRIPTION
This PR fixes some unit tests that sometimes fail or hang because they rely on accessing the production distribution service on data.nist.gov.  Instead, these unit tests now use a simulated distribution service running locally.  

This PR leverages the [PR#34 from oar-metadata](https://github.com/usnistgov/oar-metadata/pull/34) that modifies the conversion of POD records to NERDm which previously was too specific to data.nist.gov.  Conversion will now recognize distribution service URLs from any server, including a locally running one.  