### PR TITLE
angular: landing page: fix detection of PDR landing pages

### DIFF
--- a/angular/src/app/landing/landing.component.html
+++ b/angular/src/app/landing/landing.component.html
@@ -73,7 +73,7 @@
                                 Visit Home Page
                             </button>
                         </span>
-                        <ng-template #visitHomeOnServer>Visit Home Page</ng-template>
+                        <ng-template #visitHomeOnServer><a href="{{record.landingPage}}">Visit Home Page</a></ng-template>
                     </span>
                 </div>
             </div>

--- a/angular/src/app/landing/landing.component.spec.ts
+++ b/angular/src/app/landing/landing.component.spec.ts
@@ -26,7 +26,7 @@ import { AuthService, WebAuthService, MockAuthService } from './editcontrol/auth
 
 import { testdata } from '../../environments/environment';
 
-describe('LandingComponent', () => {
+fdescribe('LandingComponent', () => {
     let component : LandingComponent;
     let fixture : ComponentFixture<LandingComponent>;
     let cfg : AppConfig;
@@ -92,5 +92,20 @@ describe('LandingComponent', () => {
         let cmpel = fixture.nativeElement;
         let el = cmpel.querySelector("h2"); 
         expect(el.textContent).toContain(nrd.title);
+    });
+
+    it("can detect PDR landing pages", function() {
+        setupComponent();
+        expect(component.displayHomePageLink()).toBeTruthy();
+        component.record.landingPage = "https://data.nist.gov/od/id/mds2-111";
+        expect(component.displayHomePageLink()).toBeFalsy();
+        component.record.landingPage = "https://testdata.nist.gov/od/id/EBC9DB05EDEA5B0EE043065706812DF81";
+        expect(component.displayHomePageLink()).toBeFalsy();
+        component.record.landingPage = "https://oardev.nist.gov/od/id/EBC9DB05EDEA5B0EE043065706812DF81";
+        expect(component.displayHomePageLink()).toBeFalsy();
+        component.record.landingPage = "https://localhost/od/id/EBC9DB05EDEA5B0EE043065706812DF81";
+        expect(component.displayHomePageLink()).toBeFalsy();
+        component.record.landingPage = "https://www.nist.gov/data"
+        expect(component.displayHomePageLink()).toBeTruthy();
     });
 });

--- a/angular/src/app/landing/landing.component.spec.ts
+++ b/angular/src/app/landing/landing.component.spec.ts
@@ -26,7 +26,7 @@ import { AuthService, WebAuthService, MockAuthService } from './editcontrol/auth
 
 import { testdata } from '../../environments/environment';
 
-fdescribe('LandingComponent', () => {
+describe('LandingComponent', () => {
     let component : LandingComponent;
     let fixture : ComponentFixture<LandingComponent>;
     let cfg : AppConfig;

--- a/angular/src/app/landing/landing.component.ts
+++ b/angular/src/app/landing/landing.component.ts
@@ -458,12 +458,7 @@ export class LandingComponent implements OnInit, OnChanges {
         if (this.record.landingPage == null || this.record.landingPage == undefined) {
             return false;
         }
-        var url = 'od/id/' + this.ediid;
-        if (this.record.landingPage.search(url) > -1) {
-            return false;
-        } else {
-            return true;
-        }
+        return (this.record.landingPage.search(/^https?:\/\/[\w\.\-]+\/od\/id\//) < 0)
     }
 
     visitHomePage(url: string, event, title) {


### PR DESCRIPTION
When the `landingPage` metadata property points to an external web site, a button should appear at the top of the landing page that links to the landing page; if it's a PDR landing page URL, the button should not appear.  The code that detects an external URL was not properly recognizing PDR URLs using the new identifier pattern and the corresponding convention for the PDR landing page URL.  This PR updates to the implementation to recognize these URLs.

I also include a minor change that renders button as a traditional link when rendering on the server.  