### PR TITLE
Restore "View Metadata" function

### DIFF
--- a/angular/src/app/landing/landing.component.html
+++ b/angular/src/app/landing/landing.component.html
@@ -80,16 +80,16 @@
 
             <div class="ui-g">
                 <div class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-12">
-                    <div [hidden]="metadata">
+                    <div [hidden]="showMetadata">
                         <app-description [record]="record" [inBrowser]="inBrowser"></app-description>
                     </div>
                     <app-topic [record]="record" [inBrowser]="inBrowser"></app-topic>
                     <app-keyword [record]="record" [inBrowser]="inBrowser"></app-keyword>
                     <p></p>
                     <description-resources [record]="record" [files]="files"
-                        [metadata]="metadata" [inBrowser]="inBrowser" [ediid]="ediid" [editEnabled]="editEnabled"></description-resources>
+                        [metadata]="showMetadata" [inBrowser]="inBrowser" [ediid]="ediid" [editEnabled]="editEnabled"></description-resources>
                     <metadata-detail [record]="record" [serviceApi]="serviceApi" [inBrowser]="inBrowser"
-                        [metadata]="metadata">
+                        [metadata]="showMetadata">
                     </metadata-detail>
                 </div>
                 <div *ngIf="record.length !== 0 && inBrowser">

--- a/angular/src/app/landing/landing.component.ts
+++ b/angular/src/app/landing/landing.component.ts
@@ -111,7 +111,6 @@ export class LandingComponent implements OnInit, OnChanges {
     isCopied: boolean = false;
     distdownload: string = '';
     serviceApi: string = '';
-    metadata: boolean = false;
     private files: TreeNode[] = [];
     pdrApi: string = '';
     isResultAvailable: boolean = true;
@@ -133,6 +132,9 @@ export class LandingComponent implements OnInit, OnChanges {
     @Input() record: NerdmRes = null;
     @Input() requestId: string = null;     // the ID used in the URL to access this page
     @Input() inBrowser: boolean = false;
+
+    // this will be removed in the next restructure iteration
+    @Input() showMetadata: boolean = false;
 
     ediid: string = null;
 
@@ -204,7 +206,7 @@ export class LandingComponent implements OnInit, OnChanges {
     }
 
     viewmetadata() {
-        this.metadata = true;
+        this.showMetadata = true;
         this.similarResources = false;
     }
 

--- a/angular/src/app/landing/landingpage.component.html
+++ b/angular/src/app/landing/landingpage.component.html
@@ -28,7 +28,8 @@
         <!-- landing page content -->
         <div class="ui-g-10 ui-md-10 ui-lg-10 ui-sm-12">
 
-          <app-landing [record]="md" [inBrowser]="inBrowser" [requestId]="reqId"></app-landing>
+          <app-landing [record]="md" [inBrowser]="inBrowser" [requestId]="reqId"
+                       [showMetadata]="showMetadata"></app-landing>
 
         </div>
 

--- a/angular/src/app/landing/landingpage.component.ts
+++ b/angular/src/app/landing/landingpage.component.ts
@@ -189,6 +189,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
     }
 
     goToSection(sectionId: string) {
+        this.showMetadata = (sectionId == "metadata");
         if (sectionId) 
             this.router.navigate(['/od/id/', this.reqId], { fragment: sectionId });
         else

--- a/angular/src/app/landing/landingpage.component.ts
+++ b/angular/src/app/landing/landingpage.component.ts
@@ -45,6 +45,9 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
     citationVisible: boolean = false;
     editEnabled: boolean = false;
 
+    // this will be removed in next restructure
+    showMetadata = false;
+
     /**
      * create the component.
      * @param route   the requested URL path to be fulfilled with this view


### PR DESCRIPTION
In the last PDR-LPS code restructuring iteration, the "View Metadata" item in the right-side tools menu stopped working.  This PR restores its functionality.

Note that metadata visualization is expected to change in further iterations of the code restructuring.
