### PR TITLE
publish bug fix: remove sha file entries from NERDm when files are remove

### DIFF
--- a/python/nistoar/pdr/preserv/bagger/midas.py
+++ b/python/nistoar/pdr/preserv/bagger/midas.py
@@ -469,7 +469,8 @@ class MIDASMetadataBagger(SIPBagger):
                 
             resmd = self.bagbldr.bag.nerdm_record(False)
             for cmp in resmd.get('components', []):
-                if any([':DataFile' in t for t in cmp.get('@type',[])]) and \
+                if any([(':DataFile' in t or ':ChecksumFile' in t)
+                        for t in cmp.get('@type',[])]) and \
                    cmp.get('filepath') and \
                    not has_cmp_with_path(podnerd.get('components', []),
                                          cmp['filepath']):

--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
@@ -233,6 +233,10 @@ class TestMIDASMetadataBaggerMixed(test.TestCase):
         self.assertEqual(data['@context'][1]['@base'], data['@id'])
 
     def test_ensure_res_metadata_wremove(self):
+        # don't use upload version of pod file
+        self.bagr = midas.MIDASMetadataBagger(self.midasid, self.bagparent,
+                                              self.revdir, None)
+
         self.assertFalse(os.path.exists(self.bagdir))
         self.assertIsNone(self.bagr.inpodfile)
         self.bagr.ensure_res_metadata()
@@ -240,19 +244,29 @@ class TestMIDASMetadataBaggerMixed(test.TestCase):
         # make sure file components were registered
         self.assertTrue(os.path.isfile(
             self.bagr.bagbldr.bag.nerd_file_for("trial1.json")))
+        self.assertTrue(os.path.isfile(
+            self.bagr.bagbldr.bag.nerd_file_for("trial1.json.sha256")))
 
         # add metadata for a data file that doesn't exist in the source dir
         self.bagr.bagbldr.register_data_file(os.path.join("gold","trial5.json"),
                                              os.path.join(self.revdir,
                                                           self.midasid[32:],
                                                           "trial1.json") )
+        self.bagr.bagbldr.register_data_file(os.path.join("gold","trial5.json.sha256"),
+                                             os.path.join(self.revdir,
+                                                          self.midasid[32:],
+                                                          "trial1.json.sha256") )
         self.assertTrue(os.path.isfile(
             self.bagr.bagbldr.bag.nerd_file_for("gold/trial5.json")))
+        self.assertTrue(os.path.isfile(
+            self.bagr.bagbldr.bag.nerd_file_for("gold/trial5.json.sha256")))
 
         # now watch it get erased
         self.bagr.ensure_res_metadata(force=True)
         self.assertTrue(not os.path.exists(
             self.bagr.bagbldr.bag.nerd_file_for("gold/trial5.json")))
+        self.assertTrue(not os.path.exists(
+            self.bagr.bagbldr.bag.nerd_file_for("gold/trial5.json.sha256")))
         self.assertTrue(not os.path.exists(
             self.bagr.bagbldr.bag.nerd_file_for("gold")))
         self.assertTrue(not os.path.exists(


### PR DESCRIPTION
There is a bug in the Python publishing code such that when a user removes a file and its corresponding `.sha256` file via MIDAS, MIDAS will remove both entries in the POD record; however, only the file would get removed from the NERDm metadata.  Consequently, the landing page would continue to show the sha files for files that had been removed.  This PR corrects this bug.  
