### PR TITLE
ODD-859: Fix propagation of research themes into NERDm records

### DIFF
--- a/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
@@ -1210,6 +1210,14 @@ class TestBuilder2(test.TestCase):
         self.assertFalse(os.path.exists(self.bag.bag.nerd_file_for("trial1.json")))
         self.assertFalse(os.path.exists(self.bag.bag.nerd_file_for("trial3/trial3a.json")))
 
+        # special check for theme processing
+        self.assertEqual(poddata['theme'][0], "Optical physics")
+        self.assertEqual(len(poddata['theme']), 1)
+        self.assertEqual(len(data['topic']), 1)
+        self.assertEqual(data['topic'][0]['tag'], "Physics: Optical physics")
+        self.assertEqual(len(data['theme']), 1)
+        self.assertEqual(data['theme'][0], "Physics: Optical physics")
+
     def test_add_ds_pod_filemd(self):
         podfile = os.path.join(datadir, "_pod.json")
         with open(podfile) as fd:
@@ -1574,7 +1582,7 @@ class TestBuilder2(test.TestCase):
         self.assertEqual(len(oxum), 1)
         oxum = [int(n) for n in oxum[0].split(': ')[1].split('.')]
         self.assertEqual(oxum[1], 14)
-        self.assertEqual(oxum[0], 11970)  # this will change if logging changes
+        self.assertEqual(oxum[0], 12152)  # this will change if logging changes
 
         bagsz = [l for l in lines if "Bag-Size: " in l]
         self.assertEqual(len(bagsz), 1)


### PR DESCRIPTION
This PR addresses ticket [ODD-859](http://mml.nist.gov:8080/browse/ODD-859) which reported that themes that users selected in MIDAS were not appearing as research themes on the landing page; further, many records were showing in the SDP search results as having the research themes as "unspecified".  This PR uses an underlying fix applied to `oar-metadata` ([PR#35](https://github.com/usnistgov/oar-metadata/pull/35)).

As described in [`oar-metadata` PR#35](https://github.com/usnistgov/oar-metadata/pull/35), themes are handled in a special way in the PDR publishing system because in the original, pre-PDR POD records, full taxonomy terms were not be properly specified: only the lowest (most-specific) term was being set.  For example, "Glycomics" would be specified rather than "Bioscience: Glycomics".  (This means in the former case, the record would not match a search for "Bioscience".)  Special code was put into the PDR publishing code to detect this error and replace the theme term with its fully specified term.  However, this code was only applied to records ingest from the original PDL; it was not getting applied to new submissions via MIDAS.  This produced a  NERDm record with an uncorrected `theme` property an empty `topic` property (which is used by the SDP and the landing page).  This PR applies the special theme handling to new submissions from MIDAS.

## Review and Testing

This fix should be tested using the integration branch of `oar-docker`.  After checking out the integration branch of an existing `oar-docker` clone, be sure to run `git pull` to get the latest changes.  The fix is demonstrated using the internal "publish" application, so change into the `publish` directory within the `oar-docker` repo directory.  

### Demonstrating the error

I recommend that you first run the publish application without the fix, building it with the latest releases already set in the deployment file:
```
cd publish
../scripts/localdeploy
../scripts/oarctl local build
../scripts/oarctl local up
```
Next access the landing page for a built-in MIDAS submission at https://localhost/od/id/0531A570681DB5D3A1EE2F169DD3B8CE1491.

Notice the following:

1. The landing page does not include any Research Topics display
1. Inspect the input POD file, `mdserver/sample_review/1491/_pod.json`; look for the `theme` property and notice that its value is "Optical physics" (not "Physics: Optical Physics").
1. Inspect the resulting NERDm record in `data/pdr/mdserv/0531A570681DB5D3A1EE2F169DD3B8CE1491/metadata/nerdm.json`; notice its `theme` property also has the incorrect term, "Optical physics" and the `topic` property is empty (as in `[]`).

### Testing the fix

To test the fix, bring down the application and rebuild it with the fix to mdserver:
```
../scripts/oarctl local down
../scripts/localdeploy mdserver
../scripts/oarctl local build mdserver
../scripts/oarctl local up -p          # Notice -p which clears results from the previous run above.
```
Load the same landing page (https://localhost/od/id/0531A570681DB5D3A1EE2F169DD3B8CE1491), and notice the following:

1. The landing page should now display the research topic, "Physics: Optical physics".
1.  Inspect the resulting NERDm record in `data/pdr/mdserv/0531A570681DB5D3A1EE2F169DD3B8CE1491/metadata/nerdm.json`; notice its `theme` property now has the correct term, "Physics: Optical physics" and the `topic` property contains this term, too.