### PR TITLE
ODD-881: don't let file examination override download URL

### DIFF
--- a/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
@@ -1016,6 +1016,7 @@ class TestBuilder2(test.TestCase):
         self.assertEqual(md['checksum'], {"algorithm": {'@type': 'Thing',
                                                         "tag": "sha256" },
     "hash": "d155d99281ace123351a311084cd8e34edda6a9afcddd76eb039bad479595ec9"})
+        self.assertNotIn('downloadURL', md)  # because bag does not exist
 
         md = self.bag.describe_data_file(srcfile, "goob/trial1.json", False)
         self.assertEqual(md['filepath'], "goob/trial1.json")
@@ -1044,6 +1045,39 @@ class TestBuilder2(test.TestCase):
         self.assertEqual(md['checksum'], {"algorithm": {'@type': 'Thing',
                                                         "tag": "sha256" },
     "hash": "d155d99281ace123351a311084cd8e34edda6a9afcddd76eb039bad479595ec9"})
+
+        # if bag exists, downloadURL will be set
+        self.bag.ensure_bagdir()
+        self.bag.ediid = "goober"
+        md = self.bag.describe_data_file(srcfile, "foo/trial1.json")
+        self.assertEqual(md['filepath'], "foo/trial1.json")
+        self.assertIn('downloadURL', md)
+        self.assertTrue(md['downloadURL'].endswith("/od/ds/goober/foo/trial1.json"))
+
+        self.bag.ediid = "ark:/88434/goober"
+        md = self.bag.describe_data_file(srcfile)
+        self.assertEqual(md['filepath'], "trial1.json")
+        self.assertIn('downloadURL', md)
+        self.assertTrue(md['downloadURL'].endswith("/od/ds/goober/trial1.json"))
+
+        # don't override existing metadata
+        exturl = "https://example.com/goober/trial1.json"
+        md['downloadURL'] = exturl
+        md['title'] = "a fine file"
+        self.bag.update_metadata_for("trial1.json", md)
+        md = self.bag.describe_data_file(srcfile)
+        self.assertEqual(md['filepath'], "trial1.json")
+        self.assertIn('downloadURL', md)
+        self.assertEqual(md['downloadURL'], exturl)
+        self.assertEqual(md['title'], "a fine file")
+
+        # override existing metadata when told to
+        self.bag.update_metadata_for("trial1.json", md)
+        md = self.bag.describe_data_file(srcfile, "foo/trial1.json", asupdate=False)
+        self.assertEqual(md['filepath'], "foo/trial1.json")
+        self.assertIn('downloadURL', md)
+        self.assertNotIn('title', md)
+        self.assertTrue(md['downloadURL'].endswith("/od/ds/goober/foo/trial1.json"))
 
     def test_register_data_file(self):
         srcfile = os.path.join(datadir, "trial1.json")


### PR DESCRIPTION
This PR addresses ticket [ODD-881](http://mml.nist.gov:8080/browse/ODD-881) that describes how during the publication process download URLs can get overridden when files are examined to extract extra metadata.  This was seen with new-style identifiers (e.g. `ark:/88434/mds2-7777`) in which a download URL that appears in the pod file like, say, `https://data.nist.gov/od/ds/mds2-7777/README.txt`, would get replaced in the NERDm file with `https://data.nist.gov/od/ds/ark/88434/mds2-7777/README.txt`.  While both URLs work in the PDR, the former is preferred.  