### PR TITLE
Customization: loosen validation restrictions on JSON submitted to /lp/editor

### DIFF
--- a/java/customization-api/src/main/java/gov/nist/oar/customizationapi/helpers/JSONUtils.java
+++ b/java/customization-api/src/main/java/gov/nist/oar/customizationapi/helpers/JSONUtils.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 
 import org.apache.commons.io.IOUtils;
 import org.everit.json.schema.Schema;
+import org.everit.json.schema.ValidationException;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -92,9 +93,14 @@ public final class JSONUtils {
 			System.out.println("Exception validating with json schema:" + e.getMessage());
 			throw new InvalidInputException("Exception validating input JSON against customization service schema");
 
-		} catch (Exception e) {
-			logger.error("There is error validation input against JSON schema:" + e.getMessage());
+		} catch (ValidationException e) {
+			StringBuilder sb = new StringBuilder("Schema validation error detected in input: ");
+			sb.append(e.getMessage());
+			for (ValidationException ve : e.getCausingExceptions()) 
+				sb.append("\n  ").append(ve.getMessage());
+			logger.error(sb.toString());
 			System.out.println("Exception validating with json schema:" + e.getMessage());
+			logger.debug("On record:\n"+jsonRequest);
 			throw new InvalidInputException("Exception validating input JSON against customization service schema");
 		}
 	}

--- a/java/customization-api/src/main/resources/logback.xml
+++ b/java/customization-api/src/main/resources/logback.xml
@@ -41,7 +41,7 @@
 		<appender-ref ref="SAVE-TO-FILE" />
 	</logger>
 
-	<logger name="gov.nist.oar.ds" level="DEBUG" additivity="false">
+	<logger name="gov.nist.oar.customizationapi" level="INFO" additivity="false">
 		<appender-ref ref="STDOUT" />
 		<appender-ref ref="SAVE-TO-FILE" />
 	</logger>

--- a/java/customization-api/src/main/resources/static/json-customization-schema.json
+++ b/java/customization-api/src/main/resources/static/json-customization-schema.json
@@ -323,7 +323,6 @@
 						"Often referred to in English-speaking conventions as the first name"
 					],
 					"type": "string",
-					"minLength": 1,
 					"asOntology": {
 						"@context": "profile-schema-onto.json",
 						"prefLabel": "Middle Names or Initials",
@@ -375,7 +374,7 @@
 		"ORCIDpath": {
 			"description": "the format of the path portion of an ORCID identifier (i.e. without the preceding resolver URL base)",
 			"type": "string",
-			"pattern": "^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$"
+			"pattern": "^([0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X])?$"
 		},
 		"Affiliation": {
 			"description": "a description of an organization that a person is a member of",

--- a/java/customization-api/src/main/resources/static/json-customization-schema.json
+++ b/java/customization-api/src/main/resources/static/json-customization-schema.json
@@ -114,8 +114,12 @@
 				"prefLabel": "Authors",
 				"referenceProperty": "bibo:authorList"
 			}
+		},
+		"_editStatus": {
+			"type": "string"
 		}
 	},
+	"additionalProperties": false,
 	"definitions": {
 		"Topic": {
 			"description": "a container for an identified concept term or proper thing",
@@ -406,6 +410,5 @@
 				}
 			]
 		}
-	},
-	"additionalProperties": false
+	}
 }


### PR DESCRIPTION
The customization service (CS) was raising validation exceptions when the landing page service 
 (LPS) submitted author updates.  This was due in part because the latter was sending empty values for fields that the user did not fill in.  Leaving values empty, of course, is normal.  Rather than making the LPS remove unfilled properties, I thought it would be simpler to loosen the JSON schema definition the CS using to validate the changes.  The pubserver can scrub the changes more thoroughly to match the NERDm schema definition when it receives all the updates.  

I also tweaked the validation check to log all of the specific errors found in validation to aid in debugging such issues.  