### PR TITLE
LPS expanded author display: align attribute title and subunits and italicize

### DIFF
--- a/angular/src/app/landing/author/author.component.html
+++ b/angular/src/app/landing/author/author.component.html
@@ -22,8 +22,10 @@
                         <div *ngFor="let author of record.authors; let i = index">
                             <div>{{ author.fn}}</div>
                             <div *ngFor="let aff of author.affiliation" style="padding-left: 1em">
+                                <i>
                                 <div>{{aff.title}}</div>
-                                <div *ngIf="aff.subunits" style="padding-left: 1em">{{getSubunites(aff.subunits)}}</div>
+                                <div *ngIf="aff.subunits">{{getSubunites(aff.subunits)}}</div>
+                                </i>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
This tweaks the layout of the expanded author display that appears after the user clicks on the plus icon to the right of the author list.  In the expanded display, the authors' affiliations titles and subunits are made to aligned and italicized.
