### PR TITLE
Fix/odd866 bundle update

### DIFF
--- a/angular/src/app/_helpers/fakeBackendInterceptor.ts
+++ b/angular/src/app/_helpers/fakeBackendInterceptor.ts
@@ -36,11 +36,11 @@ export class FakeBackendInterceptor implements HttpInterceptor {
       // }
 
       // Generate bundle plan
-      if (request.url.indexOf('_bundle_plan') > -1 && request.method === 'POST') 
-      {
-        console.log("Record saved...");
-        return of(new HttpResponse({ status: 200, body: bundlePlanRes }));
-      }
+    //   if (request.url.indexOf('_bundle_plan') > -1 && request.method === 'POST') 
+    //   {
+    //     console.log("Record saved...");
+    //     return of(new HttpResponse({ status: 200, body: bundlePlanRes }));
+    //   }
 
       // Generate bundle plan internal error
       // if (request.url.indexOf('_bundle_plan') > -1 && request.method === 'POST') 
@@ -55,6 +55,20 @@ export class FakeBackendInterceptor implements HttpInterceptor {
       //       url: request.url
       //     });
       // }
+
+    // Generate bundle download internal error
+      if (request.url.indexOf('_bundle') > -1 && request.url.indexOf('_bundle_plan') <= 0 && request.method === 'POST') 
+      {
+        console.log("Throw error...");
+        throw new HttpErrorResponse(
+          {
+            error: 'internal error message goes here...',
+            headers: request.headers,
+            status: 500,
+            statusText: 'internal error',
+            url: request.url
+          });
+      }
 
       // // authenticate
       // if (request.url.indexOf('auth/_perm/') > -1 && request.method === 'GET') {

--- a/angular/src/app/app.module.ts
+++ b/angular/src/app/app.module.ts
@@ -67,6 +67,7 @@ import { DatePipe } from '@angular/common';
 
 // used to create fake backend
 import { fakeBackendProvider } from './_helpers/fakeBackendInterceptor';
+import { DownloadConfirmComponent } from './datacart/download-confirm/download-confirm.component';
 
 @NgModule({
   declarations: [
@@ -75,7 +76,7 @@ import { fakeBackendProvider } from './_helpers/fakeBackendInterceptor';
     AuthorPopupComponent, ContactPopupComponent,
     ErrorComponent, UserErrorComponent,ComboBoxComponent,ComboBoxPipe,
     AppShellNoRenderDirective, AppShellRenderDirective, ModalComponent, ContenteditableModel, 
-    LandingAboutComponent
+    LandingAboutComponent, DownloadConfirmComponent
   ],
   imports: [
       HttpClientModule,
@@ -125,7 +126,8 @@ import { fakeBackendProvider } from './_helpers/fakeBackendInterceptor';
     SearchTopicsComponent, 
     DescriptionPopupComponent, 
     AuthorPopupComponent,
-    ContactPopupComponent
+    ContactPopupComponent,
+    DownloadConfirmComponent
   ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA]
 })

--- a/angular/src/app/datacart/datacart.component.css
+++ b/angular/src/app/datacart/datacart.component.css
@@ -233,7 +233,7 @@ tr {
 .span-end{
     display: inline-block;
     padding-left:.5em;
-    width: 35%;
+    /* width: 35%; */
 }
 
 .header-orange {
@@ -341,9 +341,9 @@ button:disabled{
     overflow-wrap: break-word;
 }
 
-.overlay-title {
+.warning-overlay-title {
     color: white; 
-    background-color: #1c4d9b;
+    background-color: darkorange;
     width: 100%;
     text-align: center;
     height: 2.5em;

--- a/angular/src/app/datacart/datacart.component.css
+++ b/angular/src/app/datacart/datacart.component.css
@@ -248,7 +248,7 @@ tr {
 
 .header-green {
     display: inline-block;
-    background-color: green;
+    background-color: rgb(41, 123, 61);
     color:white;
     font-weight: bolder;
     margin-bottom: .2em;

--- a/angular/src/app/datacart/datacart.component.css
+++ b/angular/src/app/datacart/datacart.component.css
@@ -171,7 +171,7 @@
 }
 
 .filedesc{
-  background-color:#307F38;
+  background-color:rgb(245, 245, 245);
   text-align: left;
   color: white;
   word-wrap: break-word;
@@ -339,6 +339,18 @@ button:disabled{
 
 .long-text {
     overflow-wrap: break-word;
+}
+
+.overlay-title {
+    color: white; 
+    background-color: #1E6BA1;
+    width: 100%;
+    text-align: center;
+    height: 2.5em;
+    padding-top: .5em;
+    font-weight: bolder;
+    font-size: larger;
+    margin-bottom: .5em;
 }
 
 .warning-overlay-title {

--- a/angular/src/app/datacart/datacart.component.css
+++ b/angular/src/app/datacart/datacart.component.css
@@ -212,6 +212,12 @@ tr {
   z-index: 999;
 }
 
+.span15 {
+    display: inline-block;
+    width: 15% !important;
+    padding-left:.5em;
+}
+
 .span30 {
     display: inline-block;
     width: 30% !important;
@@ -333,4 +339,16 @@ button:disabled{
 
 .long-text {
     overflow-wrap: break-word;
+}
+
+.overlay-title {
+    color: white; 
+    background-color: #1c4d9b;
+    width: 100%;
+    text-align: center;
+    height: 2.5em;
+    padding-top: .5em;
+    font-weight: bolder;
+    font-size: larger;
+    margin-bottom: .5em;
 }

--- a/angular/src/app/datacart/datacart.component.html
+++ b/angular/src/app/datacart/datacart.component.html
@@ -115,8 +115,7 @@
                             [striped]="true"></ngb-progressbar>
                     </span>
 
-                    <span (click)="cancelDownloadZip(zip)" style="float: right;cursor: pointer;padding-left:5px;"><i
-                            class="faa faa-remove"></i></span>
+                    <span (click)="cancelDownloadZip(zip)" style="float: right;cursor: pointer;padding-left:5px;" data-toggle="tooltip" title="Cancel current download"><i class="faa faa-remove"></i></span>
                 </div>
                 <ng-template #not_downloading style="display:inline-block;">
                     <div *ngIf="zip.downloadStatus != 'error'; else download_error" style="display:inline-block;"
@@ -148,8 +147,7 @@
                     <ngb-progressbar type="info" [value]="overallProgress" textType="white" [showValue]="true"
                         [striped]="true"></ngb-progressbar>
                 </span>
-                <span (click)="cancelDownloadAll()" style="float: right;cursor: pointer;padding-left:5px;"><i
-                        class="faa faa-remove"></i></span>
+                <span (click)="cancelDownloadAll()" style="float: right;cursor: pointer;padding-left:5px;" data-toggle="tooltip" title="Cancel all downloads"><i class="faa faa-remove"></i></span>
             </div>
             <ng-template #not_overall_downloading style="display:inline-block;">
                 <span *ngIf="overallStatus === 'complete';else other">

--- a/angular/src/app/datacart/datacart.component.html
+++ b/angular/src/app/datacart/datacart.component.html
@@ -128,11 +128,15 @@
             </span>
             Zip File Name
         </span>
+        <span class="span15">File Size</span>
         Download Status
         <span class="span-end" *ngIf="!allProcessed" class="faa-stack fa-lg"
             style="cursor: pointer; display: inline-block;" (click)="cancelDownloadAll()" data-toggle="tooltip"
             title="Cancel All Downloads">
             <i class="faa faa-remove faa-stack-1x" aria-hidden="true" style="color: rgb(255, 255, 255);"></i>
+        </span>
+        <span style="float: right; margin: .2em .5em 0 0;">Estimated downloading time
+            <i class="faa faa-info-circle" (click)="openDetails($event,op5)" data-toggle="tooltip" title="Show download time help"></i>
         </span>
     </div>
     <!-- body -->
@@ -140,9 +144,13 @@
         <div [ngStyle]="{'width': '100%', 'background-color': getBackColor(i)}"
             *ngFor="let zip of zipData; let i=index">
             <span class="span30">{{zip.fileName}}</span>
-            <span class="span-end" style="width: 70%;">
-                <span style="float: right;margin-right: 0.5em;">Estimated downloading time: {{getDownloadTime(zip.downloadTime)}}
+            <span class="span15">{{getSizeForDisplay(zip.bundleSize)}}</span>
+            <span class="span-end" style="width: 55%;">
+                <span *ngIf="zip.downloadStatus === 'downloading' && zip.downloadTime != null; else calculating" style="float: right;margin-right: 0.5em;">{{getDownloadTime(zip.downloadTime)}}
                 </span>
+                <ng-template #calculating>
+                    <span *ngIf="zip.downloadStatus === 'downloading' && zip.downloadTime == null" style="float: right;margin-right: 0.5em;">Calculating...</span>
+                </ng-template>
                 <div style="display:inline-block;" *ngIf="zip.downloadStatus === 'downloading';else not_downloading">
                     <span style="display:inline-block;padding-left: .5em;">
                         <p-progressSpinner [style]="{width: '12px', height: '12px'}"></p-progressSpinner>
@@ -224,7 +232,7 @@
                         <p-treeTableToggler [rowNode]="rowNode"></p-treeTableToggler>
                         &nbsp;<p-treeTableCheckbox [value]="rowNode"></p-treeTableCheckbox>
                         <span *ngIf="rowData.isLeaf">
-                            <a (click)="openDetails($event,rowData,op3) " style="color: #1471AE; cursor: pointer;"
+                            <a (click)="openDetails($event,op3,rowData) " style="color: #1471AE; cursor: pointer;"
                                 data-toggle="tooltip" title="Click for more details">
                                 {{rowData.resTitle}} </a>
                         </span>
@@ -264,7 +272,7 @@
                             <span
                                 *ngIf="rowData.downloadStatus == 'error' || rowData.downloadStatus == 'failed'; else normal"
                                 style="cursor: pointer;"
-                                (click)="openDetails($event,rowData,op4) "><u>{{getStatusForDisplay(rowData.downloadStatus)}}</u></span>
+                                (click)="openDetails($event,op4,rowData) "><u>{{getStatusForDisplay(rowData.downloadStatus)}}</u></span>
                             <ng-template #normal>
                                 <span>{{getStatusForDisplay(rowData.downloadStatus)}}</span>
                             </ng-template>
@@ -329,4 +337,13 @@
             </div>
         </div>
     </div>
+</p-overlayPanel>
+
+<!-- Popup dialog for download time info -->
+<p-overlayPanel class="fileDialog" #op5 [dismissable]="true" [showCloseIcon]="true"
+[style]="{'display':'inline-block','position':'related','left':'50%','top':'80%','max-width':'400px'}" appendToBody=true>
+    <div class="overlay-title">
+        How download time get estimated
+    </div>
+    <div style="width: 90%;">The download time was calculated based on the data downloaded in the past 10 seconds. Depends on the download speed, the estimated download time may vary from time to time.</div>
 </p-overlayPanel>

--- a/angular/src/app/datacart/datacart.component.html
+++ b/angular/src/app/datacart/datacart.component.html
@@ -153,7 +153,7 @@
                 style="float: right;margin-right: 0.5em;">{{getDownloadTime(downloadService.overallDownloadTime)}}
             </span> -->
             <div style="display:inline-block;" *ngIf="overallStatus === 'downloading';else not_overall_downloading">
-                <span style="display:inline-block;margin-left: 0.5em;width: 200px;">
+                <span style="display:inline-block;margin-left: 0.5em;width: 100px;">
                     <ngb-progressbar type="info" [value]="overallProgress" textType="white" [showValue]="true"
                         [striped]="true"></ngb-progressbar>
                 </span>
@@ -162,11 +162,14 @@
             </div>
             <ng-template #not_overall_downloading style="display:inline-block;">
                 <span *ngIf="overallStatus === 'complete';else other">
-                    Download started at: {{downloadStartTime}}, ended at: {{downloadEndTime}}.
+                    Finished at: {{downloadEndTime | date:'shortTime'}}.
                 </span>
                 <ng-template #other>
                     {{getStatusForDisplay(overallStatus)}}
                 </ng-template>
+                <span *ngIf="overallStatus === 'complete'" style="float: right;margin-right: 0.5em;">
+                    Download time: {{getDownloadTime(totalDownloadTime)}}
+                </span>
             </ng-template>
         </span>
     </div>
@@ -319,9 +322,12 @@
 </div>
 
 <!-- Popup dialog for file details -->
-<p-overlayPanel class="fileDialog" #op3 [dismissable]="true" [showCloseIcon]="true"
+<p-overlayPanel class="fileDialog" #op3 [dismissable]="true" [showCloseIcon]="false"
     [style]="{'display':'inline-block','position':'related','left':'50%','top':'80%'}" appendToBody=true>
     <div *ngIf="isNodeSelected" class="filecard" [ngStyle]="{'max-width':getDialogWidth()}">
+        <div class="overlay-title">
+            File details
+        </div>
         <div class="ui-g filesection">
             <div *ngIf="fileNode" class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-10">
                 <span class="font8" style="color:grey">
@@ -352,13 +358,13 @@
 </p-overlayPanel>
 
 <!-- Popup dialog for download details -->
-<p-overlayPanel class="fileDialog" #op4 [dismissable]="true" [showCloseIcon]="true"
+<p-overlayPanel class="fileDialog" #op4 [dismissable]="true" [showCloseIcon]="false"
     [style]="{'display':'inline-block','position':'related','left':'50%','top':'80%','max-width':'400px'}"
     appendToBody=true>
     <div class="filecard">
         <div class="ui-g filesection">
             <div *ngIf="fileNode" class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-10">
-                <div class="message-details">Message details</div>
+                <div class="warning-overlay-title">Message details</div>
                 <div class="long-text">File path: {{fileNode.filePath}}</div>
                 <div class="long-text">Download URL: {{fileNode.downloadUrl}}</div>
                 <div class="long-text">Message: {{fileNode.message}}</div>
@@ -368,7 +374,7 @@
 </p-overlayPanel>
 
 <!-- Popup dialog for download time info -->
-<p-overlayPanel class="fileDialog" #op5 [dismissable]="true" [showCloseIcon]="true"
+<p-overlayPanel class="fileDialog" #op5 [dismissable]="true" [showCloseIcon]="false"
     [style]="{'display':'inline-block','position':'related','top':'80%','max-width':getDialogWidth(),'overflow-wrap': 'break-word'}"
     appendToBody=true>
     <div class="warning-overlay-title">

--- a/angular/src/app/datacart/datacart.component.html
+++ b/angular/src/app/datacart/datacart.component.html
@@ -76,6 +76,99 @@
     </div>
 </div>
 
+<!-- Display zip files if any -->
+<!-- header -->
+<div class="full-span">
+    <div *ngIf="zipData.length > 0" class="header-green" style="width: 100%;" data-toggle="tooltip" title="Zip Files">
+        <span class="span30">
+            <!-- Toggle button to show/hide zip files-->
+            <span (click)="showZipFiles = !showZipFiles">
+                <i *ngIf="!showZipFiles" class="faa faa-arrow-circle-down faa-1x icon-white"
+                    style="cursor: pointer;color: rgb(255, 255, 255);" data-toggle="tooltip" title="Expand All"></i>
+                <i *ngIf="showZipFiles" class="faa faa-arrow-circle-up faa-1x icon-white"
+                    style="cursor: pointer;color: rgb(255, 255, 255);" data-toggle="tooltip" title="Collapse All"></i>
+            </span>
+            Zip File Name
+        </span>
+        <span class="span15">Zip File Size</span>
+        Download Status
+        <span style="float: right; margin: .2em .5em 0 0;">Estimated downloading time
+            <i class="faa faa-info-circle" (click)="openDetails($event,op5)" data-toggle="tooltip"
+                title="Show download time help"></i>
+        </span>
+    </div>
+    <!-- body -->
+    <div class="unhandled-files" *ngIf="showZipFiles">
+        <div [ngStyle]="{'width': '100%', 'background-color': getBackColor(i)}"
+            *ngFor="let zip of zipData; let i=index">
+            <span class="span30">{{zip.fileName}}</span>
+            <span class="span15">{{commonFunctionService.getSizeForDisplay(zip.bundleSize)}}</span>
+            <span class="span-end" style="width: 55%;">
+                <span *ngIf="zip.downloadStatus === 'downloading' && zip.downloadTime != null; else calculating"
+                    style="float: right;margin-right: 0.5em;">{{getDownloadTime(zip.downloadTime)}}
+                </span>
+                <ng-template #calculating>
+                    <span *ngIf="zip.downloadStatus === 'downloading' && zip.downloadTime == null"
+                        style="float: right;margin-right: 0.5em;">Calculating...</span>
+                </ng-template>
+                <div style="display:inline-block;" *ngIf="zip.downloadStatus === 'downloading';else not_downloading">
+                    <span style="display:inline-block;padding-left: .5em;">
+                        <p-progressSpinner [style]="{width: '12px', height: '12px'}"></p-progressSpinner>
+                    </span>
+                    <span style="display:inline-block;margin-left: 0.5em;">
+                        {{getStatusForDisplay(zip.downloadStatus)}}
+                    </span>
+                    <span style="display:inline-block;margin-left: 0.5em;width: 100px;">
+                        <ngb-progressbar type="info" [value]="zip.downloadProgress" textType="white" [showValue]="true"
+                            [striped]="true"></ngb-progressbar>
+                    </span>
+
+                    <span (click)="cancelDownloadZip(zip)" style="float: right;cursor: pointer;padding-left:5px;"><i
+                            class="faa faa-remove"></i></span>
+                </div>
+                <ng-template #not_downloading style="display:inline-block;">
+                    <div *ngIf="zip.downloadStatus != 'error'; else download_error" style="display:inline-block;"
+                        [ngStyle]="{'color':getDownloadStatusColor(zip.downloadStatus)}">
+                        <i [class]="getIconClass(zip.downloadStatus)" style="margin-top: 8px;"></i>
+                        {{getStatusForDisplay(zip.downloadStatus)}}
+                    </div>
+                    <ng-template #download_error>
+                        <div style="display:inline-block;margin-left: .5em;font-size: 0.8em; color: red">
+                            <i class="faa faa-warning" [ngStyle]="{'padding-right':'.5em', 'margin-top':'8px'}"></i>
+                            {{getStatusForDisplay(zip.downloadStatus)}}
+                        </div>
+                    </ng-template>
+                    <i *ngIf="zip.downloadStatus != null" class="faa faa-repeat"
+                        style="display: inline-block; margin-left: .5em; font-size: 0.8em; color: #1E6BA1; cursor: pointer;"
+                        data-toggle="tooltip" title="Retry" (click)="downloadOneZip(zip)"></i>
+                </ng-template>
+            </span>
+        </div>
+    </div>
+
+    <!-- Overall progress -->
+    <div *ngIf="overallStatus != null" style="background-color: rgb(170, 212, 189);">
+        <span class="span30">Overall progress</span>
+        <span class="span15">{{commonFunctionService.getSizeForDisplay(totalDownloadSize)}}</span>
+        <span class="span-end" style="width: 55%;">
+            <span *ngIf="overallStatus === 'downloading'"
+                style="float: right;margin-right: 0.5em;">{{getDownloadTime(overallDownloadTime)}}
+            </span>
+            <div style="display:inline-block;" *ngIf="overallStatus === 'downloading';else not_overall_downloading">
+                <span style="display:inline-block;margin-left: 0.5em;width: 100px;">
+                    <ngb-progressbar type="info" [value]="overallProgress" textType="white" [showValue]="true"
+                        [striped]="true"></ngb-progressbar>
+                </span>
+                <span (click)="cancelDownloadAll()" style="float: right;cursor: pointer;padding-left:5px;"><i
+                        class="faa faa-remove"></i></span>
+            </div>
+            <ng-template #not_overall_downloading style="display:inline-block;">
+                {{getStatusForDisplay(overallStatus)}}
+            </ng-template>
+        </span>
+    </div>
+</div>
+
 <!-- Display bundle message details -->
 <div class="full-span"
     *ngIf="bundlePlanStatus == 'error' || bundlePlanStatus == 'internal error' || bundlePlanStatus === 'warnings'">
@@ -111,78 +204,6 @@
                 {{msg}}
             </div>
         </ng-template>
-    </div>
-</div>
-
-<!-- Display zip files if any -->
-<!-- header -->
-<div class="full-span">
-    <div *ngIf="zipData.length > 0" class="header-green" style="width: 100%;" data-toggle="tooltip" title="Zip Files">
-        <span class="span30">
-            <!-- Toggle button to show/hide zip files-->
-            <span (click)="showZipFiles = !showZipFiles">
-                <i *ngIf="!showZipFiles" class="faa faa-arrow-circle-down faa-1x icon-white"
-                    style="cursor: pointer;color: rgb(255, 255, 255);" data-toggle="tooltip" title="Expand All"></i>
-                <i *ngIf="showZipFiles" class="faa faa-arrow-circle-up faa-1x icon-white"
-                    style="cursor: pointer;color: rgb(255, 255, 255);" data-toggle="tooltip" title="Collapse All"></i>
-            </span>
-            Zip File Name
-        </span>
-        <span class="span15">File Size</span>
-        Download Status
-        <span class="span-end" *ngIf="!allProcessed" class="faa-stack fa-lg"
-            style="cursor: pointer; display: inline-block;" (click)="cancelDownloadAll()" data-toggle="tooltip"
-            title="Cancel All Downloads">
-            <i class="faa faa-remove faa-stack-1x" aria-hidden="true" style="color: rgb(255, 255, 255);"></i>
-        </span>
-        <span style="float: right; margin: .2em .5em 0 0;">Estimated downloading time
-            <i class="faa faa-info-circle" (click)="openDetails($event,op5)" data-toggle="tooltip" title="Show download time help"></i>
-        </span>
-    </div>
-    <!-- body -->
-    <div class="unhandled-files" *ngIf="showZipFiles">
-        <div [ngStyle]="{'width': '100%', 'background-color': getBackColor(i)}"
-            *ngFor="let zip of zipData; let i=index">
-            <span class="span30">{{zip.fileName}}</span>
-            <span class="span15">{{getSizeForDisplay(zip.bundleSize)}}</span>
-            <span class="span-end" style="width: 55%;">
-                <span *ngIf="zip.downloadStatus === 'downloading' && zip.downloadTime != null; else calculating" style="float: right;margin-right: 0.5em;">{{getDownloadTime(zip.downloadTime)}}
-                </span>
-                <ng-template #calculating>
-                    <span *ngIf="zip.downloadStatus === 'downloading' && zip.downloadTime == null" style="float: right;margin-right: 0.5em;">Calculating...</span>
-                </ng-template>
-                <div style="display:inline-block;" *ngIf="zip.downloadStatus === 'downloading';else not_downloading">
-                    <span style="display:inline-block;padding-left: .5em;">
-                        <p-progressSpinner [style]="{width: '12px', height: '12px'}"></p-progressSpinner>
-                    </span>
-                    <span style="display:inline-block;margin-left: 0.5em;">
-                        {{getStatusForDisplay(zip.downloadStatus)}}
-                    </span>
-                    <span style="display:inline-block;margin-left: 0.5em;width: 100px;">
-                        <ngb-progressbar type="info" [value]="zip.downloadProgress" textType="white" [showValue]="true" [striped]="true"></ngb-progressbar>
-                    </span>
-
-                    <span (click)="cancelDownloadZip(zip)"
-                        style="float: right;cursor: pointer;padding-left:5px;"><i
-                            class="faa faa-remove"></i></span>
-                </div>
-                <ng-template #not_downloading style="display:inline-block;" >
-                    <div *ngIf="zip.downloadStatus != 'error'; else download_error" style="display:inline-block;" [ngStyle]="{'color':getDownloadStatusColor(zip.downloadStatus)}">
-                        <i [class]="getIconClass(zip.downloadStatus)" style="margin-top: 8px;"></i>
-                        {{getStatusForDisplay(zip.downloadStatus)}}
-                    </div>
-                    <ng-template #download_error>
-                        <div style="display:inline-block;margin-left: .5em;font-size: 0.8em; color: red">
-                            <i class="faa faa-warning" [ngStyle]="{'padding-right':'.5em', 'margin-top':'8px'}"></i>
-                            {{getStatusForDisplay(zip.downloadStatus)}}
-                        </div>
-                    </ng-template>
-                    <i *ngIf="zip.downloadStatus != null" class="faa faa-repeat"
-                        style="display: inline-block; margin-left: .5em; font-size: 0.8em; color: #1E6BA1; cursor: pointer;"
-                        data-toggle="tooltip" title="Retry" (click)="downloadOneZip(zip)"></i>
-                </ng-template>
-            </span>
-        </div>
     </div>
 </div>
 
@@ -244,13 +265,16 @@
                     </td>
                     <td [ngStyle]="sizeStyle()">
                         <div *ngIf="rowData.isLeaf;else space_holder" style="display:inline;">
-                            <a href='{{rowData.downloadUrl}}' target='_blank' download="download" data-toggle="tooltip"
+                            <a *ngIf="rowData.downloadStatus != 'downloading'" href='{{rowData.downloadUrl}}' target='_blank' download="download" data-toggle="tooltip" 
                                 title="Download this file" aria-label="Download this file">
-                                <i class="faa faa-download" *ngIf="rowData.downloadStatus != 'downloading'"
+                                <i class="faa faa-download"
                                     aria-hidden="true" (click)="setFileDownloaded(rowData)"></i>
-                                <i class="faa faa-download blinking" *ngIf="rowData.downloadStatus == 'downloading'"
-                                    aria-hidden="true"></i>
                             </a>
+                            <a *ngIf="rowData.downloadStatus == 'downloading'" data-toggle="tooltip" 
+                            title="Download this file" aria-label="Download this file">
+                            <i class="faa faa-download"
+                                aria-hidden="true"></i>
+                        </a>
                         </div>
                         <ng-template #space_holder>
                             <div style="display:inline;padding-right: 0.4em;">&nbsp;&nbsp;</div>
@@ -266,7 +290,7 @@
                         <div id="downloadstatus" *ngIf="rowData.isLeaf" style="display:inline;"
                             [ngStyle]="{'color':getDownloadStatusColor(rowData.downloadStatus)}">
                             <i [class]="getIconClass(rowData.downloadStatus)" style="margin-right: .5em;"
-                            aria-hidden="true" data-toggle="tooltip" title="{{rowData.downloadStatus}}"></i>
+                                aria-hidden="true" data-toggle="tooltip" title="{{rowData.downloadStatus}}"></i>
                             <p-progressSpinner *ngIf="rowData.downloadStatus == 'downloading'"
                                 [style]="{width: '12px', height: '12px', 'margin-right': '.5em'}"></p-progressSpinner>
                             <span
@@ -326,7 +350,8 @@
 
 <!-- Popup dialog for download details -->
 <p-overlayPanel class="fileDialog" #op4 [dismissable]="true" [showCloseIcon]="true"
-[style]="{'display':'inline-block','position':'related','left':'50%','top':'80%','max-width':'400px'}" appendToBody=true>
+    [style]="{'display':'inline-block','position':'related','left':'50%','top':'80%','max-width':'400px'}"
+    appendToBody=true>
     <div class="filecard">
         <div class="ui-g filesection">
             <div *ngIf="fileNode" class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-10">
@@ -341,9 +366,11 @@
 
 <!-- Popup dialog for download time info -->
 <p-overlayPanel class="fileDialog" #op5 [dismissable]="true" [showCloseIcon]="true"
-[style]="{'display':'inline-block','position':'related','left':'50%','top':'80%','max-width':'400px'}" appendToBody=true>
+    [style]="{'display':'inline-block','position':'related','left':'50%','top':'80%','max-width':'400px'}"
+    appendToBody=true>
     <div class="overlay-title">
         How download time get estimated
     </div>
-    <div style="width: 90%;">The download time was calculated based on the data downloaded in the past 10 seconds. Depends on the download speed, the estimated download time may vary from time to time.</div>
+    <div style="width: 90%;">The download time was calculated based on the data downloaded in the past 20 seconds.
+        Depends on the download speed, the estimated download time may vary from time to time.</div>
 </p-overlayPanel>

--- a/angular/src/app/datacart/datacart.component.html
+++ b/angular/src/app/datacart/datacart.component.html
@@ -149,13 +149,13 @@
     <!-- Overall progress -->
     <div *ngIf="overallStatus != null" style="background-color: rgb(170, 212, 189);">
         <span class="span30">Overall progress</span>
-        <span class="span15">{{commonFunctionService.getSizeForDisplay(totalDownloadSize)}}</span>
+        <span class="span15">{{commonFunctionService.getSizeForDisplay(downloadService.totalBundleSize)}}</span>
         <span class="span-end" style="width: 55%;">
             <span *ngIf="overallStatus === 'downloading'"
-                style="float: right;margin-right: 0.5em;">{{getDownloadTime(overallDownloadTime)}}
+                style="float: right;margin-right: 0.5em;">{{getDownloadTime(downloadService.overallDownloadTime)}}
             </span>
             <div style="display:inline-block;" *ngIf="overallStatus === 'downloading';else not_overall_downloading">
-                <span style="display:inline-block;margin-left: 0.5em;width: 100px;">
+                <span style="display:inline-block;margin-left: 0.5em;width: 200px;">
                     <ngb-progressbar type="info" [value]="overallProgress" textType="white" [showValue]="true"
                         [striped]="true"></ngb-progressbar>
                 </span>
@@ -163,7 +163,12 @@
                         class="faa faa-remove"></i></span>
             </div>
             <ng-template #not_overall_downloading style="display:inline-block;">
-                {{getStatusForDisplay(overallStatus)}}
+                <span *ngIf="overallStatus === 'complete';else other">
+                    Download started at: {{downloadStartTime}}, ended at: {{downloadEndTime}}.
+                </span>
+                <ng-template #other>
+                    {{getStatusForDisplay(overallStatus)}}
+                </ng-template>
             </ng-template>
         </span>
     </div>
@@ -215,7 +220,7 @@
             [style]="{'margin':'auto', 'padding-bottom':'3%', 'color':'black'}">
             <ng-template pTemplate="header">
                 <tr>
-                    <th [ngStyle]="titleStyleHeader()" ttResizableColumn>
+                    <th [ngStyle]="headerStyle(titleWidth)" ttResizableColumn>
                         <span (click)="expandToLevel(dataFiles, !isExpanded, null)" style="padding-right:0.5em;">
                             <i *ngIf="!isExpanded" class="faa faa-arrow-circle-down faa-1x icon-white"
                                 style="cursor: pointer;color: rgb(255, 255, 255);" data-toggle="tooltip"
@@ -235,12 +240,12 @@
                         </span>
                         Name
                     </th>
-                    <th [ngStyle]="actionStyleHeader()" ttResizableColumn>
+                    <th [ngStyle]="headerStyle(actionWidth)" ttResizableColumn>
                         <i class="faa faa-cloud-download" aria-hidden="true" data-toggle="tooltip" title="Actions"></i>
                     </th>
-                    <th [ngStyle]="typeStyleHeader()" ttResizableColumn>Media Type</th>
-                    <th [ngStyle]="sizeStyleHeader()" ttResizableColumn>Size</th>
-                    <th [ngStyle]="statusStyleHeader()" ttResizableColumn>
+                    <th [ngStyle]="headerStyle(typeWidth)" ttResizableColumn>Media Type</th>
+                    <th [ngStyle]="headerStyle(sizeWidth)" ttResizableColumn>Size</th>
+                    <th [ngStyle]="headerStyle(statusWidth)" ttResizableColumn>
                         Status
                         <div class="badge status-reset-button" (click)="clearDownloadStatus()" data-toggle="tooltip"
                             title="Reset status">Reset</div>
@@ -249,7 +254,7 @@
             </ng-template>
             <ng-template let-rowNode let-rowData="rowData" let-i="rowIndex" pTemplate="body">
                 <tr style="background: #FFFFFF">
-                    <td [ngStyle]="titleStyle()">
+                    <td [ngStyle]="bodyStyle(titleWidth)">
                         <p-treeTableToggler [rowNode]="rowNode"></p-treeTableToggler>
                         &nbsp;<p-treeTableCheckbox [value]="rowNode"></p-treeTableCheckbox>
                         <span *ngIf="rowData.isLeaf">
@@ -263,7 +268,7 @@
                         <span *ngIf="showZipFilesNmaes" style="color:grey;margin-left: 1em;font-style: italic;">
                             {{rowData.zipFile}}</span>
                     </td>
-                    <td [ngStyle]="sizeStyle()">
+                    <td [ngStyle]="bodyStyle(sizeWidth)">
                         <div *ngIf="rowData.isLeaf;else space_holder" style="display:inline;">
                             <a *ngIf="rowData.downloadStatus != 'downloading'" href='{{rowData.downloadUrl}}' target='_blank' download="download" data-toggle="tooltip" 
                                 title="Download this file" aria-label="Download this file">
@@ -280,13 +285,13 @@
                             <div style="display:inline;padding-right: 0.4em;">&nbsp;&nbsp;</div>
                         </ng-template>
                     </td>
-                    <td [ngStyle]="typeStyle()">
+                    <td [ngStyle]="bodyStyle(typeWidth)">
                         <span>{{rowData.mediatype}}</span>
                     </td>
-                    <td [ngStyle]="sizeStyle()">
+                    <td [ngStyle]="bodyStyle(sizeWidth)">
                         <span *ngIf="rowData.isLeaf">{{formatBytes(rowData.fileSize)}}</span>
                     </td>
-                    <td [ngStyle]="statusStyle()">
+                    <td [ngStyle]="bodyStyle(statusWidth)">
                         <div id="downloadstatus" *ngIf="rowData.isLeaf" style="display:inline;"
                             [ngStyle]="{'color':getDownloadStatusColor(rowData.downloadStatus)}">
                             <i [class]="getIconClass(rowData.downloadStatus)" style="margin-right: .5em;"

--- a/angular/src/app/datacart/datacart.component.html
+++ b/angular/src/app/datacart/datacart.component.html
@@ -141,6 +141,8 @@
             *ngFor="let zip of zipData; let i=index">
             <span class="span30">{{zip.fileName}}</span>
             <span class="span-end" style="width: 70%;">
+                <span style="float: right;margin-right: 0.5em;">Estimated downloading time: {{getDownloadTime(zip.downloadTime)}}
+                </span>
                 <div style="display:inline-block;" *ngIf="zip.downloadStatus === 'downloading';else not_downloading">
                     <span style="display:inline-block;padding-left: .5em;">
                         <p-progressSpinner [style]="{width: '12px', height: '12px'}"></p-progressSpinner>
@@ -151,8 +153,7 @@
                     <span style="display:inline-block;margin-left: 0.5em;width: 100px;">
                         <ngb-progressbar type="info" [value]="zip.downloadProgress" textType="white" [showValue]="true" [striped]="true"></ngb-progressbar>
                     </span>
-                    <span style="display:inline-block;margin-left: 0.5em;">Estimated download time: {{getDownloadTime(zip.downloadTime)}}
-                    </span>
+
                     <span (click)="cancelDownloadZip(zip)"
                         style="float: right;cursor: pointer;padding-left:5px;"><i
                             class="faa faa-remove"></i></span>

--- a/angular/src/app/datacart/datacart.component.html
+++ b/angular/src/app/datacart/datacart.component.html
@@ -147,7 +147,7 @@
                     <ngb-progressbar type="info" [value]="overallProgress" textType="white" [showValue]="true"
                         [striped]="true"></ngb-progressbar>
                 </span>
-                <span (click)="cancelDownloadAll()" style="float: right;cursor: pointer;padding-left:5px;" data-toggle="tooltip" title="Cancel all downloads"><i class="faa faa-remove"></i></span>
+                <span (click)="cancelDownloadAllConfirmation()" style="float: right;cursor: pointer;padding-left:5px;" data-toggle="tooltip" title="Cancel all downloads"><i class="faa faa-remove"></i></span>
             </div>
             <ng-template #not_overall_downloading style="display:inline-block;">
                 <span *ngIf="overallStatus === 'complete';else other">

--- a/angular/src/app/datacart/datacart.component.html
+++ b/angular/src/app/datacart/datacart.component.html
@@ -110,12 +110,6 @@
                         style="float: right;margin-right: 0.5em;">Calculating...</span>
                 </ng-template>
                 <div style="display:inline-block;" *ngIf="zip.downloadStatus === 'downloading';else not_downloading">
-                    <span style="display:inline-block;padding-left: .5em;">
-                        <p-progressSpinner [style]="{width: '12px', height: '12px'}"></p-progressSpinner>
-                    </span>
-                    <span style="display:inline-block;margin-left: 0.5em;">
-                        {{getStatusForDisplay(zip.downloadStatus)}}
-                    </span>
                     <span style="display:inline-block;margin-left: 0.5em;width: 100px;">
                         <ngb-progressbar type="info" [value]="zip.downloadProgress" textType="white" [showValue]="true"
                             [striped]="true"></ngb-progressbar>
@@ -145,13 +139,10 @@
     </div>
 
     <!-- Overall progress -->
-    <div *ngIf="overallStatus != null" style="background-color: rgb(170, 212, 189);">
+    <div *ngIf="zipData.length > 0 && overallStatus != null" style="background-color: rgb(170, 212, 189);">
         <span class="span30">Overall progress</span>
         <span class="span15">{{commonFunctionService.getSizeForDisplay(downloadService.totalBundleSize)}}</span>
         <span class="span-end" style="width: 55%;">
-            <!-- <span *ngIf="overallStatus === 'downloading'"
-                style="float: right;margin-right: 0.5em;">{{getDownloadTime(downloadService.overallDownloadTime)}}
-            </span> -->
             <div style="display:inline-block;" *ngIf="overallStatus === 'downloading';else not_overall_downloading">
                 <span style="display:inline-block;margin-left: 0.5em;width: 100px;">
                     <ngb-progressbar type="info" [value]="overallProgress" textType="white" [showValue]="true"
@@ -194,7 +185,6 @@
             For tech support, please email <a style="color: rgb(255, 248, 182);"
                 href="mailto:datasupport@nist.gov?subject={{emailSubject}}&body={{getEmailBody()}}"
                 (click)="gaService.gaTrackEvent('Email', $event, 'AskHelp', 'mailto:datasupport@nist.gov')">datasupport@nist.gov
-                <!-- <i class="faa faa-envelope" data-toggle="tooltip" title="Email tech support"></i> -->
             </a>
         </span>
     </div>

--- a/angular/src/app/datacart/datacart.component.html
+++ b/angular/src/app/datacart/datacart.component.html
@@ -77,8 +77,8 @@
 </div>
 
 <!-- Display zip files if any -->
-<!-- header -->
 <div class="full-span">
+    <!-- header -->
     <div *ngIf="zipData.length > 0" class="header-green" style="width: 100%;" data-toggle="tooltip" title="Zip Files">
         <span class="span30">
             <!-- Toggle button to show/hide zip files-->
@@ -93,8 +93,6 @@
         <span class="span15">Zip File Size</span>
         Download Status
         <span style="float: right; margin: .2em .5em 0 0;">Estimated downloading time
-            <i class="faa faa-info-circle" (click)="openDetails($event,op5)" data-toggle="tooltip"
-                title="Show download time help"></i>
         </span>
     </div>
     <!-- body -->
@@ -133,9 +131,9 @@
                         {{getStatusForDisplay(zip.downloadStatus)}}
                     </div>
                     <ng-template #download_error>
-                        <div style="display:inline-block;margin-left: .5em;font-size: 0.8em; color: red">
+                        <div style="display:inline-block;margin-left: .5em;font-size: 0.8em; color: red; cursor: pointer;" (click)="openZipDetails($event,op5,zip) ">
                             <i class="faa faa-warning" [ngStyle]="{'padding-right':'.5em', 'margin-top':'8px'}"></i>
-                            {{getStatusForDisplay(zip.downloadStatus)}}
+                            <u>{{getStatusForDisplay(zip.downloadStatus)}}</u>
                         </div>
                     </ng-template>
                     <i *ngIf="zip.downloadStatus != null" class="faa faa-repeat"
@@ -151,9 +149,9 @@
         <span class="span30">Overall progress</span>
         <span class="span15">{{commonFunctionService.getSizeForDisplay(downloadService.totalBundleSize)}}</span>
         <span class="span-end" style="width: 55%;">
-            <span *ngIf="overallStatus === 'downloading'"
+            <!-- <span *ngIf="overallStatus === 'downloading'"
                 style="float: right;margin-right: 0.5em;">{{getDownloadTime(downloadService.overallDownloadTime)}}
-            </span>
+            </span> -->
             <div style="display:inline-block;" *ngIf="overallStatus === 'downloading';else not_overall_downloading">
                 <span style="display:inline-block;margin-left: 0.5em;width: 200px;">
                     <ngb-progressbar type="info" [value]="overallProgress" textType="white" [showValue]="true"
@@ -174,7 +172,7 @@
     </div>
 </div>
 
-<!-- Display bundle message details -->
+<!-- Display bundle plan message details -->
 <div class="full-span"
     *ngIf="bundlePlanStatus == 'error' || bundlePlanStatus == 'internal error' || bundlePlanStatus === 'warnings'">
     <div class="header-orange" data-toggle="tooltip" title="Bundle message details">
@@ -371,11 +369,36 @@
 
 <!-- Popup dialog for download time info -->
 <p-overlayPanel class="fileDialog" #op5 [dismissable]="true" [showCloseIcon]="true"
-    [style]="{'display':'inline-block','position':'related','left':'50%','top':'80%','max-width':'400px'}"
+    [style]="{'display':'inline-block','position':'related','top':'80%','max-width':getDialogWidth(),'overflow-wrap': 'break-word'}"
     appendToBody=true>
-    <div class="overlay-title">
-        How download time get estimated
+    <div class="warning-overlay-title">
+        Message details
     </div>
-    <div style="width: 90%;">The download time was calculated based on the data downloaded in the past 20 seconds.
-        Depends on the download speed, the estimated download time may vary from time to time.</div>
+
+    <table class="table">
+        <tbody>
+            <tr>
+                <th scope="row" style="width: 40%;">Zip file name</th>
+                <td>{{problemZip.fileName}}</td>
+            </tr>
+            <tr>
+                <th scope="row">Download URL</th>
+                <td>{{problemZip.downloadUrl}}</td>
+            </tr>
+            <tr>
+                <th scope="row">Size</th>
+                <td>{{problemZip.bundleSize}}</td>
+            </tr>
+            <tr>
+                <th scope="row">Error message</th>
+                <td>{{problemZip.downloadErrorMessage}}</td>
+            </tr>
+            <tr>
+                <th scope="row">Tech support</th>
+                <td><a href="mailto:datasupport@nist.gov?subject={{emailSubject}}&body={{getEmailBody()}}"
+                    (click)="gaService.gaTrackEvent('Email', $event, 'AskHelp', 'mailto:datasupport@nist.gov')">datasupport@nist.gov
+                </a></td>
+            </tr>
+        </tbody>
+    </table>
 </p-overlayPanel>

--- a/angular/src/app/datacart/datacart.component.html
+++ b/angular/src/app/datacart/datacart.component.html
@@ -148,8 +148,13 @@
                     <span style="display:inline-block;margin-left: 0.5em;">
                         {{getStatusForDisplay(zip.downloadStatus)}}
                     </span>
+                    <span style="display:inline-block;margin-left: 0.5em;width: 100px;">
+                        <ngb-progressbar type="info" [value]="zip.downloadProgress" textType="white" [showValue]="true" [striped]="true"></ngb-progressbar>
+                    </span>
+                    <span style="display:inline-block;margin-left: 0.5em;">Estimated download time: {{getDownloadTime(zip.downloadTime)}}
+                    </span>
                     <span (click)="cancelDownloadZip(zip)"
-                        style="display:inline-block;cursor: pointer;padding-left:5px;"><i
+                        style="float: right;cursor: pointer;padding-left:5px;"><i
                             class="faa faa-remove"></i></span>
                 </div>
                 <ng-template #not_downloading style="display:inline-block;" >

--- a/angular/src/app/datacart/datacart.component.ts
+++ b/angular/src/app/datacart/datacart.component.ts
@@ -665,13 +665,6 @@ export class DatacartComponent implements OnInit, OnDestroy {
             return 0;
     }
 
-    // get overallDownloadTime(){
-    //     if(this.downloadService.downloadSpeed > 0)
-    //         return Math.round((this.downloadService.totalBundleSize-this.downloadService.totalDownloaded)/this.downloadService.downloadSpeed);
-    //     else    
-    //         return 0;
-    // }
-
     /**
     * Download one particular zip
     **/

--- a/angular/src/app/datacart/datacart.component.ts
+++ b/angular/src/app/datacart/datacart.component.ts
@@ -93,11 +93,22 @@ export class DatacartComponent implements OnInit, OnDestroy {
     zipData: ZipData[] = [];
     allDownloadCancelled: boolean = false;
     subscriptions: any = [];
+    problemZip: ZipData = {
+        fileName: "",
+        downloadProgress: 0,
+        downloadStatus: null,
+        downloadInstance: null,
+        bundle: null,
+        downloadUrl: null,
+        downloadErrorMessage: '',
+        bundleSize: 0,
+        downloadTime: 0
+    };
 
     // Email
     emailSubject: string;
     emailBody: string;
-    emailBodyBase: string = 'The information below describes an error that occurred while downloading data via the data cart. %0D%0A%0D%0A [From the PDR Team:  feel free to add additional information about the failure or your questions here.  Thanks for sending this message!] %0D%0A%0D%0A';
+    emailBodyBase: string = 'The information below describes an error that occurred while downloading data via the data cart. %0D%0A%0D%0A [From the PDR Team:  feel free to add additional information about the failure or your questions here. Thanks for sending this message!] %0D%0A%0D%0A';
 
     // Overall progress
     totalDownloadedSize: number = 0;
@@ -189,7 +200,7 @@ export class DatacartComponent implements OnInit, OnDestroy {
                 {
                     this.totalDownloadedSize = 0;
                     let today = new Date();
-                    this.downloadEndTime = formatDate(today, 'dd-MM-yyyy hh:mm:ss a', 'en-US', '+0530');
+                    this.downloadEndTime = formatDate(today, 'dd-MM-yyyy hh:mm:ss a', 'en-US');
                     console.log('this.downloadEndTime', this.downloadEndTime);
                     this.overallStatus = 'complete';
                 }
@@ -470,7 +481,7 @@ export class DatacartComponent implements OnInit, OnDestroy {
         this.downloadService.setDownloadingNumber(0, "datacart");
 
         let today = new Date();
-        this.downloadStartTime = formatDate(today, 'dd-MM-yyyy hh:mm:ss a', 'en-US', '+0530')
+        this.downloadStartTime = formatDate(today, 'dd-MM-yyyy hh:mm:ss a', 'en-US')
 
         // create root
         const newPart = {
@@ -523,7 +534,6 @@ export class DatacartComponent implements OnInit, OnDestroy {
                             + 'Time: ' + dateTime.toString() + '%0D%0A%0D%0A'
                             + 'Post message:%0D%0A' + JSON.stringify(postMessage[0]) + ';' + '%0D%0A%0D%0A' + 'Return message:%0D%0A' + JSON.stringify(blob);
                     }
-                    console.log("Bundle plan:", blob);
 
                     this.bundleplan = blob;
                     this.downloadService.setTotalBundleSize(blob.size);
@@ -1069,6 +1079,19 @@ export class DatacartComponent implements OnInit, OnDestroy {
     }
 
     /*
+    * Display zip file error message
+    */
+    openZipDetails(event, overlaypanel: OverlayPanel, zip: ZipData = null ) {
+        console.log('zip', zip);
+        this.problemZip = zip;
+        this.emailSubject = 'PDR: Error downloading zip file';
+
+        overlaypanel.hide();
+        setTimeout(() => {
+            overlaypanel.show(event);
+        }, 100);
+    }
+    /*
         Return button color based on Downloaded status
     */
     getButtonColor() {
@@ -1205,14 +1228,19 @@ export class DatacartComponent implements OnInit, OnDestroy {
         let emaibody = this.emailBody;
         if(!emaibody)
         {
-            emaibody = this.emailBodyBase + 'Time: ' + dateTime.toString() + '%0D%0A%0D%0A';
+            emaibody = this.emailBodyBase + 'Time: ' + dateTime.toString();
         }
+
+        emaibody += '%0D%0A%0D%0A details:';
 
         for (let zip of this.zipData) 
         {
             if(zip.downloadStatus == 'error')
             {
-                emaibody += '%0D%0A%0D%0A'+ 'Zip error details:%0D%0A' + JSON.stringify(zip.bundle);
+                emaibody += '%0D%0A%0D%0A'+ zip.fileName 
+                         + ':%0D%0A download URL: ' + zip.downloadUrl
+                         + ':%0D%0A error message: ' + zip.downloadErrorMessage
+                         + ':%0D%0A details: ' + JSON.stringify(zip.bundle);
             }
         }
 

--- a/angular/src/app/datacart/datacart.component.ts
+++ b/angular/src/app/datacart/datacart.component.ts
@@ -114,8 +114,9 @@ export class DatacartComponent implements OnInit, OnDestroy {
     totalDownloadedSize: number = 0;
     downloadSpeed = 0.00;
     overallStatus: string = null;
-    downloadStartTime: string;
-    downloadEndTime: string;
+    downloadStartTime: any;
+    downloadEndTime: any;
+    totalDownloadTime: number;
 
     // For pop up
     modalRef: any;
@@ -199,8 +200,9 @@ export class DatacartComponent implements OnInit, OnDestroy {
                 if(value)
                 {
                     this.totalDownloadedSize = 0;
-                    let today = new Date();
-                    this.downloadEndTime = formatDate(today, 'dd-MM-yyyy hh:mm:ss a', 'en-US');
+                    this.downloadService.setTotalBundleSize(0);
+                    this.downloadEndTime = new Date();
+                    this.totalDownloadTime = this.downloadEndTime.getTime() / 1000 - this.downloadStartTime.getTime() / 1000;
                     console.log('this.downloadEndTime', this.downloadEndTime);
                     this.overallStatus = 'complete';
                 }
@@ -480,8 +482,7 @@ export class DatacartComponent implements OnInit, OnDestroy {
         this.currentTask = "Zipping files...";
         this.downloadService.setDownloadingNumber(0, "datacart");
 
-        let today = new Date();
-        this.downloadStartTime = formatDate(today, 'dd-MM-yyyy hh:mm:ss a', 'en-US')
+        this.downloadStartTime = new Date();
 
         // create root
         const newPart = {
@@ -1072,24 +1073,18 @@ export class DatacartComponent implements OnInit, OnDestroy {
     openDetails(event, overlaypanel: OverlayPanel, fileNode: TreeNode = null ) {
         this.isNodeSelected = true;
         this.fileNode = fileNode;
-        overlaypanel.hide();
-        setTimeout(() => {
-            overlaypanel.show(event);
-        }, 100);
+
+        overlaypanel.toggle(event);
     }
 
     /*
     * Display zip file error message
     */
     openZipDetails(event, overlaypanel: OverlayPanel, zip: ZipData = null ) {
-        console.log('zip', zip);
         this.problemZip = zip;
         this.emailSubject = 'PDR: Error downloading zip file';
 
-        overlaypanel.hide();
-        setTimeout(() => {
-            overlaypanel.show(event);
-        }, 100);
+        overlaypanel.toggle(event);
     }
     /*
         Return button color based on Downloaded status

--- a/angular/src/app/datacart/datacart.component.ts
+++ b/angular/src/app/datacart/datacart.component.ts
@@ -132,7 +132,7 @@ export class DatacartComponent implements OnInit, OnDestroy {
         private _FileSaverService: FileSaverService,
         public commonFunctionService: CommonFunctionService,
         private route: ActivatedRoute,
-        private gaService: GoogleAnalyticsService,
+        public gaService: GoogleAnalyticsService,
         private modalService: NgbModal,
         ngZone: NgZone) 
     {

--- a/angular/src/app/datacart/datacart.component.ts
+++ b/angular/src/app/datacart/datacart.component.ts
@@ -655,10 +655,10 @@ export class DatacartComponent implements OnInit, OnDestroy {
         let bundlePlan: any[] = res.bundleNameFilePathUrl;
         let downloadUrl: any = this.distApi + res.postEachTo;
         console.log("Bundle url:", downloadUrl);
-        console.log("bundleSize", res.size);
+        let bundleSize = res.size;
 
         for (let bundle of bundlePlan) {
-            this.zipData.push({ "fileName": bundle.bundleName, "downloadProgress": 0, "downloadStatus": null, "downloadInstance": null, "bundle": bundle, "downloadUrl": downloadUrl, "downloadErrorMessage": "","bundleSize": bundle.bundleSize, 'downloadTime': 0 });
+            this.zipData.push({ "fileName": bundle.bundleName, "downloadProgress": 0, "downloadStatus": null, "downloadInstance": null, "bundle": bundle, "downloadUrl": downloadUrl, "downloadErrorMessage": "","bundleSize": bundleSize, 'downloadTime': null });
         }
         // Associate zipData with files
         for (let zip of this.zipData) {
@@ -1073,7 +1073,7 @@ export class DatacartComponent implements OnInit, OnDestroy {
     /*
     * Popup file details
     */
-    openDetails(event, fileNode: TreeNode, overlaypanel: OverlayPanel) {
+    openDetails(event, overlaypanel: OverlayPanel, fileNode: TreeNode = null ) {
         this.isNodeSelected = true;
         this.fileNode = fileNode;
         overlaypanel.hide();
@@ -1353,11 +1353,28 @@ export class DatacartComponent implements OnInit, OnDestroy {
         let minutes = Math.floor((downloadTime - hours * 3600)/60);
         let seconds = Math.floor(downloadTime - hours * 3600 - minutes * 60);
 
-        let returnFormat = seconds + "";
-        if(minutes > 0) returnFormat = minutes + ":" + returnFormat;
-        if(hours > 0) returnFormat = hours + ":" + returnFormat;
+        let returnFormat = seconds + "sec";
+        if(minutes > 0) returnFormat = minutes + "min " + returnFormat;
+        if(hours > 0) returnFormat = hours + "hour " + returnFormat;
 
         return returnFormat;
+    }
+
+    /**
+     *  Convert the file size into display format
+     * @param bundleSize - input file size in byte
+     */
+    getSizeForDisplay(bundleSize: number)
+    {
+        let displaySize = "";
+        if(bundleSize >= 1000000000)
+            displaySize = Math.round(bundleSize / 1000000000) + "GB";
+        else if(bundleSize >= 1000000)
+            displaySize = Math.round(bundleSize / 1000000) + "MB";
+        else 
+            displaySize = Math.round(bundleSize / 1000) + "KB";
+
+        return displaySize;
     }
 }
 

--- a/angular/src/app/datacart/datacart.component.ts
+++ b/angular/src/app/datacart/datacart.component.ts
@@ -17,6 +17,7 @@ import { GoogleAnalyticsService } from '../shared/ga-service/google-analytics.se
 import { NgbModalOptions, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { DownloadConfirmComponent } from './download-confirm/download-confirm.component';
 import {formatDate } from '@angular/common';
+import { ConfirmationDialogComponent } from '../shared/confirmation-dialog/confirmation-dialog.component';
 
 declare var saveAs: any;
 declare var $: any;
@@ -200,7 +201,7 @@ export class DatacartComponent implements OnInit, OnDestroy {
                 if(value)
                 {
                     this.totalDownloadedSize = 0;
-                    this.downloadService.setTotalBundleSize(0);
+                    // this.downloadService.setTotalBundleSize(0);
                     this.downloadEndTime = new Date();
                     this.totalDownloadTime = this.downloadEndTime.getTime() / 1000 - this.downloadStartTime.getTime() / 1000;
                     console.log('this.downloadEndTime', this.downloadEndTime);
@@ -687,6 +688,31 @@ export class DatacartComponent implements OnInit, OnDestroy {
         this.downloadService.download(zip, this.zipData, this.dataFiles, "datacart");
     }
 
+    /**
+     * Cancel all downloads confirmation
+     */
+    cancelDownloadAllConfirmation()
+    {
+        var message = 'This will cancel all current and pending download process.';
+
+        this.modalRef = this.modalService.open(ConfirmationDialogComponent);
+        this.modalRef.componentInstance.title = 'Please confirm';
+        this.modalRef.componentInstance.btnOkText = 'Yes';
+        this.modalRef.componentInstance.btnCancelText = 'No';
+        this.modalRef.componentInstance.message = message;
+        this.modalRef.componentInstance.showWarningIcon = true;
+        this.modalRef.componentInstance.showCancelButton = true;
+
+        this.modalRef.result.then((result) => {
+            console.log("Confirmation:", result);
+            if ( result ) {
+                this.cancelDownloadAll();
+            }else{
+                console.log("User changed mind.");
+            }
+        }, (reason) => {
+        });
+    }
     /**
     * Cancell all download instances
     **/

--- a/angular/src/app/datacart/datacart.component.ts
+++ b/angular/src/app/datacart/datacart.component.ts
@@ -655,10 +655,9 @@ export class DatacartComponent implements OnInit, OnDestroy {
         let bundlePlan: any[] = res.bundleNameFilePathUrl;
         let downloadUrl: any = this.distApi + res.postEachTo;
         console.log("Bundle url:", downloadUrl);
-        let bundleSize = res.size;
 
         for (let bundle of bundlePlan) {
-            this.zipData.push({ "fileName": bundle.bundleName, "downloadProgress": 0, "downloadStatus": null, "downloadInstance": null, "bundle": bundle, "downloadUrl": downloadUrl, "downloadErrorMessage": "","bundleSize": bundleSize, 'downloadTime': null });
+            this.zipData.push({ "fileName": bundle.bundleName, "downloadProgress": 0, "downloadStatus": null, "downloadInstance": null, "bundle": bundle, "downloadUrl": downloadUrl, "downloadErrorMessage": "","bundleSize": bundle.bundleSize, 'downloadTime': null });
         }
         // Associate zipData with files
         for (let zip of this.zipData) {
@@ -1368,11 +1367,11 @@ export class DatacartComponent implements OnInit, OnDestroy {
     {
         let displaySize = "";
         if(bundleSize >= 1000000000)
-            displaySize = Math.round(bundleSize / 1000000000) + "GB";
+            displaySize = (bundleSize / 1000000000).toFixed(2) + "GB";
         else if(bundleSize >= 1000000)
-            displaySize = Math.round(bundleSize / 1000000) + "MB";
+            displaySize = (bundleSize / 1000000).toFixed(2) + "MB";
         else 
-            displaySize = Math.round(bundleSize / 1000) + "KB";
+            displaySize = (bundleSize / 1000).toFixed(2) + "KB";
 
         return displaySize;
     }

--- a/angular/src/app/datacart/datacart.component.ts
+++ b/angular/src/app/datacart/datacart.component.ts
@@ -656,11 +656,9 @@ export class DatacartComponent implements OnInit, OnDestroy {
         let downloadUrl: any = this.distApi + res.postEachTo;
         console.log("Bundle url:", downloadUrl);
         console.log("bundleSize", res.size);
-        let bundleSize = res.size;
-        let tempData: any[] = [];
 
         for (let bundle of bundlePlan) {
-            this.zipData.push({ "fileName": bundle.bundleName, "downloadProgress": 0, "downloadStatus": null, "downloadInstance": null, "bundle": bundle, "downloadUrl": downloadUrl, "downloadErrorMessage": "","bundleSize": bundleSize, 'downloadTime': 0 });
+            this.zipData.push({ "fileName": bundle.bundleName, "downloadProgress": 0, "downloadStatus": null, "downloadInstance": null, "bundle": bundle, "downloadUrl": downloadUrl, "downloadErrorMessage": "","bundleSize": bundle.bundleSize, 'downloadTime': 0 });
         }
         // Associate zipData with files
         for (let zip of this.zipData) {

--- a/angular/src/app/datacart/datacart.component.ts
+++ b/angular/src/app/datacart/datacart.component.ts
@@ -1,33 +1,22 @@
-import { Component, OnInit, OnDestroy, AfterViewInit, ElementRef, ViewChildren, Input, NgZone, HostListener } from '@angular/core';
-import { HttpClientModule, HttpClient, HttpParams, HttpRequest, HttpEventType } from '@angular/common/http';
+import { Component, OnInit, OnDestroy, NgZone, HostListener } from '@angular/core';
+import { HttpClient, HttpRequest, HttpEventType } from '@angular/common/http';
 import { ActivatedRoute } from '@angular/router';
-// import { Http, HttpModule } from '@angular/http';
 import 'rxjs/add/operator/map';
-// import { Subscription } from 'rxjs/Subscription';
-import { Message } from 'primeng/components/common/api';
-import {
-    TreeTableModule, TreeNode, MenuItem, OverlayPanelModule,
-    FieldsetModule, PanelModule, ContextMenuModule,
-    MenuModule
-} from 'primeng/primeng';
+import { TreeNode } from 'primeng/primeng';
 import { CartService } from './cart.service';
 import { CartEntity } from './cart.entity';
-// import { Observable } from 'rxjs/Observable';
-// import { ProgressSpinnerModule, DialogModule } from 'primeng/primeng';
 import { DownloadData } from '../shared/download-service/downloadData';
 
 import { DownloadService } from '../shared/download-service/download-service.service';
 import { ZipData } from '../shared/download-service/zipData';
 import { OverlayPanel } from 'primeng/overlaypanel';
 import { AppConfig } from '../config/config';
-// import { BootstrapOptions } from '@angular/core/src/application_ref';
-// import { AsyncBooleanResultCallback } from 'async';
 import { FileSaverService } from 'ngx-filesaver';
 import { CommonFunctionService } from '../shared/common-function/common-function.service';
 import { GoogleAnalyticsService } from '../shared/ga-service/google-analytics.service';
 import { NgbModalOptions, NgbModal } from '@ng-bootstrap/ng-bootstrap';
-// import { ConfirmationDialogComponent } from '../shared/confirmation-dialog/confirmation-dialog.component';
 import { DownloadConfirmComponent } from './download-confirm/download-confirm.component';
+import {formatDate } from '@angular/common';
 
 declare var saveAs: any;
 declare var $: any;
@@ -40,64 +29,8 @@ declare var $: any;
 })
 
 export class DatacartComponent implements OnInit, OnDestroy {
-    layoutCompact: boolean = true;
-    layoutMode: string = 'horizontal';
-    profileMode: string = 'inline';
-    msgs: Message[] = [];
-    exception: string;
-    errorMsg: string;
-    status: string;
-    errorMessage: string;
-    errorMessageArray: string[];
-    //searchResults: any[] = [];
-    searchValue: string;
-    recordDisplay: any[] = [];
-    keyword: string;
-    downloadZIPURL: string;
-    summaryCandidate: any[];
-    showSpinner: boolean = false;
-    findId: string;
-    leftmenu: MenuItem[];
-    rightmenu: MenuItem[];
-    similarResources: boolean = false;
-    similarResourcesResults: any[] = [];
-    qcriteria: string = '';
-    selectedFile: TreeNode;
-    isDOI = false;
-    isEmail = false;
-    citeString: string = '';
-    type: string = '';
-    process: any[];
-    requestedId: string = '';
-    isCopied: boolean = false;
-    distdownload: string = '';
-    serviceApi: string = '';
-    metadata: boolean = false;
+    //Data cart
     cartEntities: CartEntity[];
-    cols: any[];
-    selectedData: TreeNode[] = [];
-    dataFiles: TreeNode[] = [];
-    childNode: TreeNode = {};
-    minimum: number = 1;
-    maximum: number = 100000;
-    displayFiles: any = [];
-    index: any = {};
-    selectedNode: TreeNode[] = [];
-    selectedFileCount: number = 0;
-    selectedParentIndex: number = 0;
-    downloadInstance: any;
-    downloadStatus: any;
-    downloadProgress: any;
-    displayDownloadFiles: boolean = false;
-    downloadData: DownloadData[];
-    zipData: ZipData[] = [];
-    cancelAllDownload: boolean = false;
-    treeRoot = [];
-    selectedTreeRoot = [];
-    subscriptions: any = [];
-    showZipFiles: boolean = true;
-    showZipFilesNmaes: boolean = true;
-    allProcessed: boolean = false;
 
     //Bundle
     bundlePlanStatus: any;
@@ -106,6 +39,7 @@ export class DatacartComponent implements OnInit, OnDestroy {
     bundlePlanUnhandledFiles: any[] = null;
     bundleSizeAlert: number;
     bundleplan: any;
+    bundlePlanRef: any;
 
     //For display
     downloadStatusExpanded: boolean = true;
@@ -113,23 +47,12 @@ export class DatacartComponent implements OnInit, OnDestroy {
     isVisible: boolean = true;
     isExpanded: boolean = true;
     showUnhandledFilesTable: boolean = true;
-
-    fileNode: TreeNode;
-    messageColor: any;
-    noFileDownloaded: boolean; // will be true if any item in data cart is downloaded
-    totalDownloaded: number = 0;
-    selectedNodes: TreeNode[] = [];
-    distApi: string;
-    currentTask: string = '';
+    showZipFiles: boolean = true;
+    showZipFilesNmaes: boolean = true;
     showCurrentTask: boolean = false;
     showMessage: boolean = true;
-    broadcastMessage: string = '';
-    showDownloadProgress: boolean = false;
-    isProcessing: boolean = false;
-    isNodeSelected: boolean = false;
-    getBundlePlanRef: any;
-    mode: any;
-    routerparams: any;
+    messageColor: any;
+    currentTask: string = '';
     mobWidth: number;
     mobHeight: number;
     titleWidth: string;
@@ -138,22 +61,50 @@ export class DatacartComponent implements OnInit, OnDestroy {
     actionWidth: string;
     statusWidth: string;
     fontSize: string;
-    downloadflag: boolean = true;
+    screenWidth: number;
+    screenSizeBreakPoint: number;
+    imageURL: string;
+
+    //Connection
+    distApi: string;
+    routerparams: any;
+    serviceApi: string = '';
+
+    //Data
+    fileNode: TreeNode;
+    selectedNodes: TreeNode[] = [];
+    isNodeSelected: boolean = false;
+    mode: any;
+    treeRoot = [];
+    selectedTreeRoot = [];
+    index: any = {};
+    selectedNode: TreeNode[] = [];
+    selectedFileCount: number = 0;
+    selectedParentIndex: number = 0;
+    minimum: number = 1;
+    maximum: number = 100000;
+    selectedData: TreeNode[] = [];
+    dataFiles: TreeNode[] = [];
+
+    //Download
+    totalDownloaded: number = 0;
+    noFileDownloaded: boolean; // will be true if any item in data cart is downloaded
+    downloadData: DownloadData[];
+    zipData: ZipData[] = [];
+    allDownloadCancelled: boolean = false;
+    subscriptions: any = [];
 
     // Email
     emailSubject: string;
     emailBody: string;
     emailBodyBase: string = 'The information below describes an error that occurred while downloading data via the data cart. %0D%0A%0D%0A [From the PDR Team:  feel free to add additional information about the failure or your questions here.  Thanks for sending this message!] %0D%0A%0D%0A';
 
-    imageURL: string;
-    screenWidth: number;
-    screenSizeBreakPoint: number;
-
     // Overall progress
     totalDownloadedSize: number = 0;
-    totalDownloadSize: number = 0;
     downloadSpeed = 0.00;
     overallStatus: string = null;
+    downloadStartTime: string;
+    downloadEndTime: string;
 
     // For pop up
     modalRef: any;
@@ -203,7 +154,6 @@ export class DatacartComponent implements OnInit, OnDestroy {
         this.imageURL = 'assets/images/sdp-background.jpg';
 
         console.log("Datacart init...");
-        this.isProcessing = true;
         this.distApi = this.cfg.get("distService", "/od/ds/");
         this.bundleSizeAlert = +this.cfg.get("bundleSizeAlert", "1000000000");
         this.routerparams = this.route.params.subscribe(params => {
@@ -235,8 +185,14 @@ export class DatacartComponent implements OnInit, OnDestroy {
 
         this.downloadService.watchDownloadProcessStatus("datacart").subscribe(
             value => {
-                this.allProcessed = value;
-                // this.updateDownloadStatus(this.files);
+                if(value)
+                {
+                    this.totalDownloadedSize = 0;
+                    let today = new Date();
+                    this.downloadEndTime = formatDate(today, 'dd-MM-yyyy hh:mm:ss a', 'en-US', '+0530');
+                    console.log('this.downloadEndTime', this.downloadEndTime);
+                    this.overallStatus = 'complete';
+                }
             }
         );
 
@@ -269,39 +225,12 @@ export class DatacartComponent implements OnInit, OnDestroy {
     /*
     * Following functions set tree table style
     */
-    titleStyleHeader() {
-        return { 'background-color': '#1E6BA1', 'width': this.titleWidth, 'color': 'white', 'font-size': this.fontSize };
+    headerStyle(width) {
+        return { 'background-color': '#1E6BA1', 'width': width, 'color': 'white', 'font-size': this.fontSize };
     }
 
-    typeStyleHeader() {
-        return { 'background-color': '#1E6BA1', 'width': this.typeWidth, 'color': 'white', 'font-size': this.fontSize };
-    }
-
-    sizeStyleHeader() {
-        return { 'background-color': '#1E6BA1', 'width': this.sizeWidth, 'color': 'white', 'font-size': this.fontSize };
-    }
-
-    actionStyleHeader() {
-        return { 'background-color': '#1E6BA1', 'width': this.actionWidth, 'color': 'white', 'font-size': this.fontSize };
-    }
-
-    statusStyleHeader() {
-        return { 'background-color': '#1E6BA1', 'width': this.statusWidth, 'color': 'white', 'font-size': this.fontSize, 'white-space': 'nowrap' };
-    }
-
-    titleStyle() {
-        return { 'width': this.titleWidth, 'font-size': this.fontSize };
-    }
-
-    typeStyle() {
-        return { 'width': this.typeWidth, 'font-size': this.fontSize };
-    }
-
-    sizeStyle() {
-        return { 'width': this.sizeWidth, 'font-size': this.fontSize };
-    }
-    statusStyle() {
-        return { 'width': this.statusWidth, 'font-size': this.fontSize };
+    bodyStyle(width) {
+        return { 'width': width, 'font-size': this.fontSize };
     }
 
     setWidth(mobWidth: number) {
@@ -528,18 +457,21 @@ export class DatacartComponent implements OnInit, OnDestroy {
    downloadAllFilesFromAPI() {
         this.gaService.gaTrackEvent('download', undefined, 'all files', "Data cart");
         this.clearDownloadStatus();
-        this.isProcessing = true;
         this.showCurrentTask = true;
         let postMessage: any[] = [];
         this.downloadData = [];
         this.zipData = [];
-        this.displayDownloadFiles = true;
-        this.cancelAllDownload = false;
+        // this.displayDownloadFiles = true;
+        this.allDownloadCancelled = false;
         this.bundlePlanMessage = null;
-        this.downloadStatus = 'downloading';
+        // this.downloadStatus = 'downloading';
         this.downloadService.setDownloadProcessStatus(false, "datacart");
         this.currentTask = "Zipping files...";
         this.downloadService.setDownloadingNumber(0, "datacart");
+
+        let today = new Date();
+        this.downloadStartTime = formatDate(today, 'dd-MM-yyyy hh:mm:ss a', 'en-US', '+0530')
+
         // create root
         const newPart = {
             data: {
@@ -563,15 +495,15 @@ export class DatacartComponent implements OnInit, OnDestroy {
         // console.log('Bundle plan post message:', JSON.stringify(postMessage[0]));
         console.log("Calling following end point to get bundle plan:", this.distApi + "_bundle_plan");
 
-        this.getBundlePlanRef = this.downloadService.getBundlePlan(this.distApi + "_bundle_plan", JSON.stringify(postMessage[0])).subscribe(
+        this.bundlePlanRef = this.downloadService.getBundlePlan(this.distApi + "_bundle_plan", JSON.stringify(postMessage[0])).subscribe(
             blob => {
                 console.log('Bundle plan return:', blob);
                 this.bundlePlanStatus = blob.status.toLowerCase();
                 this.bundlePlanMessage = blob.messages;
                 this.bundlePlanUnhandledFiles = blob.notIncluded;
-                if (this.bundlePlanMessage != null && this.bundlePlanMessage != undefined && this.bundlePlanStatus != 'complete') {
-                    this.broadcastMessage = 'Server responsed with ' + this.bundlePlanStatus + '.';
-                }
+                // if (this.bundlePlanMessage != null && this.bundlePlanMessage != undefined && this.bundlePlanStatus != 'complete') {
+                //     this.broadcastMessage = 'Server responsed with ' + this.bundlePlanStatus + '.';
+                // }
                 this.messageColor = this.getColor();
                 //   console.log("Bundle plan return:", JSON.stringify(blob));
 
@@ -594,7 +526,7 @@ export class DatacartComponent implements OnInit, OnDestroy {
                     console.log("Bundle plan:", blob);
 
                     this.bundleplan = blob;
-                    this.totalDownloadSize = blob.size;
+                    this.downloadService.setTotalBundleSize(blob.size);
 
                     let bundlePlan: any[] = blob.bundleNameFilePathUrl;
                     let downloadUrl: any = this.distApi + blob.postEachTo;
@@ -637,24 +569,20 @@ export class DatacartComponent implements OnInit, OnDestroy {
                             console.log(returnValue);
                             if ( returnValue ) {
                                 this.showCurrentTask = false;
-                                this.isProcessing = false;
                                 this.processBundle(this.bundleplan);
                             }else{
                                 this.showCurrentTask = false;
-                                this.isProcessing = false;
                                 this.cancelDownloadAll()
                                 console.log("User canceled download");
                             }
                         }, (reason) => {
                             this.showCurrentTask = false;
-                            this.isProcessing = false;
                             this.cancelDownloadAll()
                         });
 
                     // }else  // If bundle size does not exceed the alert limit, continue download
                     // {
                     //     this.showCurrentTask = false;
-                    //     this.isProcessing = false;
                     //     this.processBundle(this.bundleplan);
                     // }
                 }
@@ -681,7 +609,6 @@ export class DatacartComponent implements OnInit, OnDestroy {
                 console.log("Error message:", err);
                 this.bundlePlanMessage = err;
                 this.bundlePlanStatus = "internal error";
-                this.isProcessing = false;
                 this.showCurrentTask = false;
                 this.messageColor = this.getColor();
                 this.emailSubject = 'PDR: Error getting download plan';
@@ -699,8 +626,8 @@ export class DatacartComponent implements OnInit, OnDestroy {
     }
 
     unsubscribeBundleplan() {
-        this.getBundlePlanRef.unsubscribe();
-        this.getBundlePlanRef = null;
+        this.bundlePlanRef.unsubscribe();
+        this.bundlePlanRef = null;
     }
 
     /**
@@ -716,7 +643,7 @@ export class DatacartComponent implements OnInit, OnDestroy {
         this.subscriptions.push(this.downloadService.watchDownloadingNumber("datacart").subscribe(
             value => {
                 if (value >= 0) {
-                    if (!this.cancelAllDownload) {
+                    if (!this.allDownloadCancelled) {
                         this.overallStatus = "downloading";
                         this.downloadService.downloadNextZip(this.zipData, this.dataFiles, "datacart");
                     }
@@ -724,29 +651,26 @@ export class DatacartComponent implements OnInit, OnDestroy {
                     {
                         this.overallStatus = "Cancelled";
                     }
-                }else
-                {
-                    this.overallStatus = "completed";
                 }
             }
         ));
     }
 
     get overallProgress(){
-        if(this.totalDownloadSize > 0 && this.totalDownloadSize >= this.downloadService.totalDownloaded)
-            return Math.round(100 * this.downloadService.totalDownloaded / this.totalDownloadSize);
-        else if(this.totalDownloadSize > 0)
+        if(this.downloadService.totalBundleSize > 0 && this.downloadService.totalBundleSize >= this.downloadService.totalDownloaded)
+            return Math.round(100 * this.downloadService.totalDownloaded / this.downloadService.totalBundleSize);
+        else if(this.downloadService.totalBundleSize > 0)
             return 100;
         else    
             return 0;
     }
 
-    get overallDownloadTime(){
-        if(this.downloadService.downloadSpeed > 0)
-            return Math.round((this.totalDownloadSize-this.downloadService.totalDownloaded)/this.downloadService.downloadSpeed);
-        else    
-            return 0;
-    }
+    // get overallDownloadTime(){
+    //     if(this.downloadService.downloadSpeed > 0)
+    //         return Math.round((this.downloadService.totalBundleSize-this.downloadService.totalDownloaded)/this.downloadService.downloadSpeed);
+    //     else    
+    //         return 0;
+    // }
 
     /**
     * Download one particular zip
@@ -755,7 +679,7 @@ export class DatacartComponent implements OnInit, OnDestroy {
         if (zip.downloadInstance != null) {
             zip.downloadInstance.unsubscribe();
         }
-        this.totalDownloadSize += zip.bundleSize;
+        this.downloadService.increaseTotalBundleBySize(zip.bundleSize);
         this.downloadService.download(zip, this.zipData, this.dataFiles, "datacart");
     }
 
@@ -778,10 +702,8 @@ export class DatacartComponent implements OnInit, OnDestroy {
 
         this.resetDownloadParams();
         this.clearDownloadingStatus();
-        this.isProcessing = false;
         this.showCurrentTask = false;
         this.overallStatus = "cancelled";
-        this.totalDownloadSize = 0;
         this.downloadService.resetDownloadData();
     }
 
@@ -791,9 +713,9 @@ export class DatacartComponent implements OnInit, OnDestroy {
     resetDownloadParams() {
         this.zipData = [];
         this.downloadService.setDownloadingNumber(-1, "datacart");
-        this.downloadStatus = null;
-        this.cancelAllDownload = true;
-        this.displayDownloadFiles = false;
+        // this.downloadStatus = null;
+        this.allDownloadCancelled = true;
+        // this.displayDownloadFiles = false;
         this.downloadService.resetZipName(this.treeRoot[0]);
         this.bundlePlanMessage = null;
         this.bundlePlanStatus = null;
@@ -810,7 +732,6 @@ export class DatacartComponent implements OnInit, OnDestroy {
             rowData.downloadProgress = 0;
             let url = rowData.downloadUrl.replace('http:', 'https:');
             // if (rowData.downloadUrl.length > 5 && rowData.downloadUrl.substring(0, 5).toLowerCase() == 'https') {
-            this.showDownloadProgress = true;
             const req = new HttpRequest('GET', url, {
                 reportProgress: true, responseType: 'blob'
             });
@@ -1117,7 +1038,9 @@ export class DatacartComponent implements OnInit, OnDestroy {
      */
     cancelDownloadZip(zip: any) {
         //Need to re-calculate the total file size and total downloaded size
-        this.totalDownloadSize -= zip.bundleSize*(100-zip.downloadProgress)/100;
+        this.downloadService.decreaseTotalBundleBySize(zip.bundleSize);
+        let downloaded = this.downloadService.totalDownloaded - zip.bundleSize*zip.downloadProgress/100;
+        this.downloadService.setTotalDownloaded(downloaded);
 
         zip.downloadInstance.unsubscribe();
         zip.downloadInstance = null;

--- a/angular/src/app/datacart/download-confirm/download-confirm.component.css
+++ b/angular/src/app/datacart/download-confirm/download-confirm.component.css
@@ -42,3 +42,8 @@
     font-size: 30px;
     font-weight: bolder;
 }
+
+#summary {
+    background-color: rgb(170, 212, 189);
+    margin: .5em 0em;
+}

--- a/angular/src/app/datacart/download-confirm/download-confirm.component.css
+++ b/angular/src/app/datacart/download-confirm/download-confirm.component.css
@@ -1,0 +1,44 @@
+#btn-download {
+    /* width:200px;  */
+    background-color:green;
+    color:white;
+    margin-right: 1em;
+    /* white-space: nowrap; */
+}
+
+#btn-cancel {
+    background-color:rgb(94, 94, 94);
+    color:white;
+    border-color: grey;
+    margin-right: 3%;
+}
+
+.control-btns {
+    width: 94%;
+    height: 3em; 
+    color:white;
+    margin: 1em 0em;
+    /* border: 1px solid green; */
+    border-top-style: 1px solid grey;
+}
+
+.span50 {
+    display: inline-block;
+    width: 50% !important;
+    padding-left:.5em;
+}
+
+.zip-details{
+    overflow-y:auto;
+    max-height:200px;
+    word-wrap: break-word;
+}
+
+.bar {
+    color: white;
+    background-color:#153971;
+    width: 100%;
+    text-align: center;
+    font-size: 30px;
+    font-weight: bolder;
+}

--- a/angular/src/app/datacart/download-confirm/download-confirm.component.html
+++ b/angular/src/app/datacart/download-confirm/download-confirm.component.html
@@ -1,0 +1,39 @@
+<!-- Make the pop up window look similar to the landingpage with black header bar and blue tool bar -->
+<div class="bar" style="color: white !important;">
+    Confirm Downloading
+</div>
+
+<!-- Display zip info -->
+<div class="full-span" style="margin: auto; padding: .5em 0em;">
+    You have selected {{totalFiles}} file<span *ngIf="totalFiles > 1">s</span>. The total file size is {{commonFunctionService.getSizeForDisplay(bundle_plan_size)}}<span *ngIf="bundle_plan_size > bundleSizeAlert"> which might take a while to download</span>. The file<span *ngIf="totalFiles > 1">s along with the folder structure</span> will be packed into following zip file<span *ngIf="zipData.length > 1">s</span>. Would you like to continue?
+</div>
+
+<!-- Display zip files if any -->
+<!-- header -->
+<div class="full-span">
+    <div *ngIf="zipData.length > 0" class="header-green" style="width: 100%;" data-toggle="tooltip" title="Zip Files">
+        <span class="span50">
+            Zip File Name
+        </span>
+        <span class="span-end">Zip File Size</span>
+    </div>
+    <!-- body -->
+    <div class="zip-details">
+        <div [ngStyle]="{'width': '100%', 'background-color': getBackColor(i)}"
+            *ngFor="let zip of zipData; let i=index">
+            <span class="span50">{{zip.fileName}}</span>
+            <span class="span-end">{{commonFunctionService.getSizeForDisplay(zip.bundleSize)}}</span>
+        </div>
+    </div>
+</div>
+<hr>
+<div class="control-btns">
+    <!-- Buttons are arranged from right to left -->
+        <!-- Continue Download button -->
+        <button pButton type="submit" class="btn btn-labeled" id="btn-download" (click)="ContinueDownload()"
+        label="Continue Download" icon="faa faa-cloud-download faa-1x icon-white" iconPos="left"></button>
+
+        <!-- Cancel button -->
+        <button pButton type="submit" class="btn btn-labeled" id="btn-cancel" (click)="CancelDownload()"
+        label="Cancel Download" icon="faa faa-remove faa-1x icon-white" iconPos="left"></button>
+</div>

--- a/angular/src/app/datacart/download-confirm/download-confirm.component.html
+++ b/angular/src/app/datacart/download-confirm/download-confirm.component.html
@@ -25,6 +25,12 @@
             <span class="span-end">{{commonFunctionService.getSizeForDisplay(zip.bundleSize)}}</span>
         </div>
     </div>
+
+    <!-- Summary -->
+    <div id="summary">
+        <span class="span50">{{totalFiles}} file<span *ngIf="totalFiles > 1">s</span> selected</span>
+        <span class="span-end">Total size: {{commonFunctionService.getSizeForDisplay(bundle_plan_size)}}</span>
+    </div>
 </div>
 <hr>
 <div class="control-btns">

--- a/angular/src/app/datacart/download-confirm/download-confirm.component.html
+++ b/angular/src/app/datacart/download-confirm/download-confirm.component.html
@@ -5,7 +5,11 @@
 
 <!-- Display zip info -->
 <div class="full-span" style="margin: auto; padding: .5em 0em;">
-    You have selected {{totalFiles}} file<span *ngIf="totalFiles > 1">s</span>. The total file size is {{commonFunctionService.getSizeForDisplay(bundle_plan_size)}}<span *ngIf="bundle_plan_size > bundleSizeAlert"> which might take a while to download</span>. The file<span *ngIf="totalFiles > 1">s along with the folder structure</span> will be packed into following zip file<span *ngIf="zipData.length > 1">s</span>. Would you like to continue?
+    You have selected {{totalFiles}} file<span *ngIf="totalFiles > 1">s</span> with a total size of {{commonFunctionService.getSizeForDisplay(bundle_plan_size)}}.
+ 
+    <div *ngIf="bundle_plan_size > bundleSizeAlert" style="margin-top: .5em;">Warning:  this may a take a long time to download completely. </div> 
+    
+    <div style="margin-top: .5em;">The files will be downloaded in the following zip files.</div>
 </div>
 
 <!-- Display zip files if any -->
@@ -32,12 +36,17 @@
         <span class="span-end">Total size: {{commonFunctionService.getSizeForDisplay(bundle_plan_size)}}</span>
     </div>
 </div>
+
+<div class="full-span" style="margin-top: .5em;">
+    Unpack each zip file in the same folder on your disk to preserve the data hierarchy.
+</div>
+
 <hr>
 <div class="control-btns">
     <!-- Buttons are arranged from right to left -->
         <!-- Continue Download button -->
         <button pButton type="submit" class="btn btn-labeled" id="btn-download" (click)="ContinueDownload()"
-        label="Continue Download" icon="faa faa-cloud-download faa-1x icon-white" iconPos="left"></button>
+        label="Start Download" icon="faa faa-cloud-download faa-1x icon-white" iconPos="left"></button>
 
         <!-- Cancel button -->
         <button pButton type="submit" class="btn btn-labeled" id="btn-cancel" (click)="CancelDownload()"

--- a/angular/src/app/datacart/download-confirm/download-confirm.component.spec.ts
+++ b/angular/src/app/datacart/download-confirm/download-confirm.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DownloadConfirmComponent } from './download-confirm.component';
+
+describe('DownloadConfirmComponent', () => {
+  let component: DownloadConfirmComponent;
+  let fixture: ComponentFixture<DownloadConfirmComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DownloadConfirmComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DownloadConfirmComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular/src/app/datacart/download-confirm/download-confirm.component.spec.ts
+++ b/angular/src/app/datacart/download-confirm/download-confirm.component.spec.ts
@@ -1,14 +1,19 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { DownloadConfirmComponent } from './download-confirm.component';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { CommonFunctionService } from '../../shared/common-function/common-function.service';
+import { config } from '../../../environments/environment';
+import { AppConfig } from '../../config/config';
 
 describe('DownloadConfirmComponent', () => {
   let component: DownloadConfirmComponent;
   let fixture: ComponentFixture<DownloadConfirmComponent>;
+  let cfg : AppConfig = new AppConfig(config);
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ DownloadConfirmComponent ]
+      declarations: [ DownloadConfirmComponent ],
+      providers: [{ provide: AppConfig, useValue: cfg }, NgbActiveModal, CommonFunctionService]
     })
     .compileComponents();
   }));
@@ -16,10 +21,41 @@ describe('DownloadConfirmComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(DownloadConfirmComponent);
     component = fixture.componentInstance;
+    component.bundle_plan_size = 1000;
+    component.zipData = [{
+            fileName: "",
+            downloadProgress: 0,
+            downloadStatus: null,
+            downloadInstance: null,
+            bundle: null,
+            downloadUrl: null,
+            downloadErrorMessage: '',
+            bundleSize: 0,
+            downloadTime: 0
+    }];
+    component.totalFiles = 10;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('ContinueDownload()', async(() => {
+    spyOn(component.returnValue, 'emit');
+    component.ContinueDownload();
+    expect(component.returnValue.emit).toHaveBeenCalledWith(true);
+  }));
+
+  it('CancelDownload()', async(() => {
+    spyOn(component.returnValue, 'emit');
+
+    component.CancelDownload();
+     expect(component.returnValue.emit).toHaveBeenCalledWith(false);
+  }));
+
+  it('getBackColor()', async(() => {
+    expect(component.getBackColor(0)).toEqual('white');
+    expect(component.getBackColor(1)).toEqual('rgb(231, 231, 231)');
+  }));
 });

--- a/angular/src/app/datacart/download-confirm/download-confirm.component.ts
+++ b/angular/src/app/datacart/download-confirm/download-confirm.component.ts
@@ -1,0 +1,59 @@
+import { Component, OnInit, Input, EventEmitter, Output, ElementRef, ViewChild } from '@angular/core';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { ZipData } from '../../shared/download-service/zipData';
+import { CommonFunctionService } from '../../shared/common-function/common-function.service';
+import { AppConfig } from '../../config/config';
+
+@Component({
+    selector: 'app-download-confirm',
+    templateUrl: './download-confirm.component.html',
+    styleUrls: ['./download-confirm.component.css','../datacart.component.css']
+})
+export class DownloadConfirmComponent implements OnInit {
+    @Input() bundle_plan_size: number;
+    @Input() zipData: ZipData;
+    @Input() totalFiles: number;
+    @Output() returnValue: EventEmitter<boolean> = new EventEmitter();
+
+    bundleSizeAlert: number;
+
+    constructor
+    (
+        public activeModal: NgbActiveModal,
+        private cfg: AppConfig,
+        private commonFunctionService: CommonFunctionService
+    ) 
+    { }
+
+    ngOnInit() 
+    {
+        this.bundleSizeAlert = +this.cfg.get("bundleSizeAlert", "1000000000");
+    }
+
+    /* 
+     *   Return true when user click on Continue Download
+     */
+    ContinueDownload() 
+    {
+        this.returnValue.emit(true);
+        this.activeModal.close('Close click');
+    }
+
+    /* 
+     *   Return false when user click on Cancel button
+     */
+    CancelDownload() 
+    {
+        this.returnValue.emit(false);
+        this.activeModal.close('Close click');
+    }
+
+    /**
+     * Return row background color
+     * @param i - row number
+     */
+    getBackColor(i: number) {
+        if (i % 2 != 0) return 'rgb(231, 231, 231)';
+        else return 'white';
+    }
+}

--- a/angular/src/app/datacart/download-confirm/download-confirm.component.ts
+++ b/angular/src/app/datacart/download-confirm/download-confirm.component.ts
@@ -21,7 +21,7 @@ export class DownloadConfirmComponent implements OnInit {
     (
         public activeModal: NgbActiveModal,
         private cfg: AppConfig,
-        private commonFunctionService: CommonFunctionService
+        public commonFunctionService: CommonFunctionService
     ) 
     { }
 

--- a/angular/src/app/datacart/download-confirm/download-confirm.component.ts
+++ b/angular/src/app/datacart/download-confirm/download-confirm.component.ts
@@ -28,6 +28,7 @@ export class DownloadConfirmComponent implements OnInit {
     ngOnInit() 
     {
         this.bundleSizeAlert = +this.cfg.get("bundleSizeAlert", "1000000000");
+        console.log('bundleSizeAlert', this.bundleSizeAlert);
     }
 
     /* 

--- a/angular/src/app/datacart/download-confirm/download-confirm.component.ts
+++ b/angular/src/app/datacart/download-confirm/download-confirm.component.ts
@@ -11,7 +11,7 @@ import { AppConfig } from '../../config/config';
 })
 export class DownloadConfirmComponent implements OnInit {
     @Input() bundle_plan_size: number;
-    @Input() zipData: ZipData;
+    @Input() zipData: ZipData[];
     @Input() totalFiles: number;
     @Output() returnValue: EventEmitter<boolean> = new EventEmitter();
 

--- a/angular/src/app/landing/data-files/data-files.component.html
+++ b/angular/src/app/landing/data-files/data-files.component.html
@@ -69,7 +69,7 @@
                         <div style="flex: 0 0 110px; text-align: left; padding-bottom: 0em;">
                             <span><b>Files </b> </span>
                             <a class="faa-stack fa-lg icon-download" *ngIf="!editEnabled"
-                                (click)="downloadAllConfirm('Download All Files', 'This will download all files. Continue?', 'downloadAllConfirm')"
+                                (click)="downloadFromRoot()"
                                 data-toggle="tooltip" title="Download all files"
                                 [ngStyle]="{'color':getDownloadAllBtnColor(),'cursor':'pointer'}">
                                 <i class="faa faa-circle-thin faa-stack-2x" aria-hidden="true"></i>
@@ -98,9 +98,6 @@
                         Total No. files: {{ totalFiles }}
                     </div>
                 </div>
-
-                <!-- Popup confirm dialog for 'Download all' button -->
-                <p-confirmDialog key='downloadAllConfirm'></p-confirmDialog>
 
                 <!-- Display tree table -->
                 <p-treeTable *ngIf="visible" [value]="files" [columns]="cols" selectionMode="single"

--- a/angular/src/app/landing/data-files/data-files.component.ts
+++ b/angular/src/app/landing/data-files/data-files.component.ts
@@ -673,6 +673,12 @@ export class DataFilesComponent {
     * Function to download all.
     **/
     downloadFromRoot() {
+        let popupWidth: number = this.mobWidth * 0.8;
+        let left: number = this.mobWidth * 0.1;
+        let screenSize = 'height=880,width=' + popupWidth.toString() + ',top=100,left=' + left.toString();
+        window.open('/datacart/popup', 'DownloadManager', screenSize);
+        this.cancelAllDownload = false;
+        console.log("Downloading...");
         this.cartService.setCurrentCart('landing_popup');
         setTimeout(() => {
             this.cartService.clearTheCart();

--- a/angular/src/app/shared/common-function/common-function.service.ts
+++ b/angular/src/app/shared/common-function/common-function.service.ts
@@ -30,4 +30,23 @@ export class CommonFunctionService {
     deepCopy(obj) {
         return JSON.parse(JSON.stringify(obj));
     }
+
+    /**
+     *  Convert the file size into display format
+     * @param fileSize - input file size in byte
+     */
+    getSizeForDisplay(fileSize: number)
+    {
+        let displaySize = "";
+        if(fileSize >= 1000000000)
+            displaySize = Math.round(fileSize / 1000000000) + " GB";
+        else if(fileSize >= 1000000)
+            displaySize = Math.round(fileSize / 1000000) + " MB";
+        else if(fileSize >= 1000)
+            displaySize = (fileSize / 1000).toFixed(2) + " KB";
+        else
+            displaySize = fileSize + " Bytes";
+
+        return displaySize;
+    }    
 }

--- a/angular/src/app/shared/common-function/common-function.service.ts
+++ b/angular/src/app/shared/common-function/common-function.service.ts
@@ -38,15 +38,13 @@ export class CommonFunctionService {
     getSizeForDisplay(fileSize: number)
     {
         let displaySize = "";
-        if(fileSize >= 1000000000)
-            displaySize = Math.round(fileSize / 1000000000) + " GB";
-        else if(fileSize >= 1000000)
-            displaySize = Math.round(fileSize / 1000000) + " MB";
-        else if(fileSize >= 1000)
-            displaySize = (fileSize / 1000).toFixed(2) + " KB";
-        else
-            displaySize = fileSize + " Bytes";
+        let dm = 0;
+        const k = 1024;
+        const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+        const i = Math.floor(Math.log(fileSize) / Math.log(k));
 
-        return displaySize;
+        if(i > 2) dm = 2;
+
+        return parseFloat((fileSize / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
     }    
 }

--- a/angular/src/app/shared/confirmation-dialog/confirmation-dialog.component.css
+++ b/angular/src/app/shared/confirmation-dialog/confirmation-dialog.component.css
@@ -4,7 +4,7 @@
 }
 
 #cd-ok-button {
-    width:150px;
+    width:200px;
     height:2em;
     vertical-align: middle;
     background-color: green;
@@ -12,10 +12,9 @@
 }
 
 #cd-cancel-button {
-    width:150px;
+    width:200px;
     height:2em;
     vertical-align: middle;
     background-color: grey;
     color: white;
 }
-

--- a/angular/src/app/shared/download-service/download-service.service.ts
+++ b/angular/src/app/shared/download-service/download-service.service.ts
@@ -242,6 +242,7 @@ export class DownloadService {
                 nextZip.downloadErrorMessage = err.message;
                 nextZip.downloadProgress = 0;
                 this.decreaseNumberOfDownloading(whichPage);
+                this.setDownloadStatus(nextZip, dataFiles, "failed", err.message);
             }
         );
     }
@@ -381,13 +382,14 @@ export class DownloadService {
     /**
      * Set download status of given tree node
      **/
-    setDownloadStatus(zip: any, dataFiles: any, status: any) {
+    setDownloadStatus(zip: any, dataFiles: any, status: any, message: string = '') {
         for (let includeFile of zip.bundle.includeFiles) {
             let resFilePath = includeFile.filePath.substring(includeFile.filePath.indexOf('/'));
             for (let dataFile of dataFiles) {
                 let node = this.searchTreeByfilePath(dataFile, resFilePath);
                 if (node != null) {
                     node.data.downloadStatus = status;
+                    node.data.message = message;
                     this.cartService.updateCartItemDownloadStatus(node.data['cartId'], status);
                     break;
                 }

--- a/angular/src/app/shared/download-service/zipData.ts
+++ b/angular/src/app/shared/download-service/zipData.ts
@@ -12,4 +12,6 @@ export interface ZipData {
     bundle: any;
     downloadUrl: any;
     downloadErrorMessage: any;
+    bundleSize: number;
+    downloadTime: number;
   }

--- a/angular/src/environments/environment.prod.ts
+++ b/angular/src/environments/environment.prod.ts
@@ -30,7 +30,7 @@ export const config : LPSConfig = {
     editEnabled: false,
     gacode: "not-set",
     screenSizeBreakPoint: 1060,
-    bundleSizeAlert: 1000000000
+    bundleSizeAlert: 500000000
 }
 
 export const testdata : {} = { }

--- a/angular/src/environments/environment.prod.ts
+++ b/angular/src/environments/environment.prod.ts
@@ -28,7 +28,8 @@ export const config : LPSConfig = {
     appVersion:  "v1.1.0",
     production:  context.production,
     editEnabled: false,
-    gacode: "UA-66610693-14"
+    gacode: "not-set",
+    screenSizeBreakPoint: 1060
 }
 
 export const testdata : {} = { }

--- a/angular/src/environments/environment.prod.ts
+++ b/angular/src/environments/environment.prod.ts
@@ -29,7 +29,8 @@ export const config : LPSConfig = {
     production:  context.production,
     editEnabled: false,
     gacode: "not-set",
-    screenSizeBreakPoint: 1060
+    screenSizeBreakPoint: 1060,
+    bundleSizeAlert: 1000000000
 }
 
 export const testdata : {} = { }

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -34,7 +34,7 @@ export const config: LPSConfig = {
     distService: "https://testdata.nist.gov/od/ds/",
     gacode: "not-set",
     screenSizeBreakPoint: 1060,
-    bundleSizeAlert: 1000000000
+    bundleSizeAlert: 500000000
 }
 
 export const testdata: {} = {

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -32,7 +32,7 @@ export const config: LPSConfig = {
     production: context.production,
     editEnabled: false,
     distService: "https://testdata.nist.gov/od/ds/",
-    gacode: "UA-115121490-8",
+    gacode: "not-set",
     screenSizeBreakPoint: 1060
 }
 

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -33,7 +33,8 @@ export const config: LPSConfig = {
     editEnabled: false,
     distService: "https://testdata.nist.gov/od/ds/",
     gacode: "not-set",
-    screenSizeBreakPoint: 1060
+    screenSizeBreakPoint: 1060,
+    bundleSizeAlert: 1000000000
 }
 
 export const testdata: {} = {


### PR DESCRIPTION
Changes in this branch:

1. Changes to the download all confirmation popup
  a. Display the popup after bundle plan was received
  b. Display bundle details in the popup
  c. Display different message if bundle size exceed the threshold. The threshold is configurable.

2. Changes to bundle download UI layout
  a. Moved bundle download details (the green table) to the top and the warning message (the orange table) to be under the green table.
  b. Display progress bar for each bundle download. Removed spinner and the status display when downloading.
  c. Display bundle size
  d. Made error status clickable and display detail error message in a popup window
  e. Display overall download status
  f. Display estimated download time for each bundle
  g. Moved download status column to the left of Media Type column.
  h. Added a status icon to each file status
  i. Added background image to the title "Download Manager"
  h. Moved the three major control buttons into the title portion
 

More details at http://mml.nist.gov:8080/browse/ODD-866