### PR TITLE
Fixed github link

### DIFF
--- a/angular/src/app/landingAbout/landingAbout.component.html
+++ b/angular/src/app/landingAbout/landingAbout.component.html
@@ -12,7 +12,7 @@
     <p>
       The PDR is designed as a <b>trusted repository</b>, one which complies with long term data preservation and publication
       standards.   It is built using community open source software (See
-      <a href="github.com/usnistgov/OAR-Develop">Github repository</a> for more details).
+      <a href="https://github.com/usnistgov/oar-developer">Github repository</a> for more details).
       Each record has a persistent identifier,  and may be viewed on a unique web <b>“landing page”</b> which includes user-friendly and readable views
       of key  metadata, high level terms which detail the nature of the record dataset.
       Additionally the PDR landing page provides access to Download public data files and citation (See <b>NIST</b><a href="https://www.nist.gov/topics/data/public-access-nist-research/copyright-fair-use-and-licensing-statements-srd-data-and"> <b> Fair Use


### PR DESCRIPTION
As you can see in the comments I misspelled "github" as "giyhub" :)

The fix in this branch is simple - just fixed the Github url.