### PR TITLE
ODD-954: Require POD as input to preservation service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
   - docker
 
 before_install:
+  - bash scripts/dhsetup.sh
   - cd docker && bash ./dockbuild.sh
 
 script:

--- a/angular/src/app/landing/data-files/data-files.component.html
+++ b/angular/src/app/landing/data-files/data-files.component.html
@@ -182,37 +182,21 @@
     </div>
 </div>
 
-<div id="reference">
+<!-- references -->
+<div id="reference" style="margin: 1em 0em;">
     <div [hidden]="metadata">
-        <br>
         <div *ngIf="checkReferences()">
-            <h3><b>References</b></h3>
-            <span class="font14" *ngIf="isDocumentedBy">
-                This data is discussed in :
-                <span *ngFor="let refs of record['references']">
-                    <span *ngIf="refs['refType'] == 'IsDocumentedBy'">
-                        <br>
-                        <i class="faa faa-external-link">
-                            <a style="margin-left:0.3em;" href={{refs.location}} target="blank">{{ refs.label }}</a>
-                        </i>
-                    </span>
-                </span>
-            </span>
-            <span class="font14" *ngIf="isReferencedBy">
-                This data are referenced in :
-                <span class="reflinks" *ngFor="let refs of record['references']">
-                    <span *ngIf="refs['refType'] == 'IsReferencedBy'">
-                        <br>
-                        <i class="faa faa-external-link"> </i>
-                        <a style="margin-left:0.3em;" href={{refs.location}} target="blank">
-                            {{ refs.location }}</a>
-                    </span>
-
-                </span>
-            </span>
+            <div style="margin-bottom: 1em;"><h3><b>References</b></h3></div>
+            <div class="font14" style="margin: 0em 0em .5em 1em;" *ngFor="let refs of record['references']">
+                <i class="faa faa-external-link"> &nbsp;
+                    <a href={{refs.location}} target="blank">{{ getReferenceText(refs) }}</a>
+                </i>
+            </div>
         </div>
     </div>
 </div>
+
+<!-- file details -->
 <p-overlayPanel class="fileDialog" #op3 [dismissable]="true" [showCloseIcon]="true"
     [style]="{'display':'inline-block','position':'related','left':'50%','top':'80%'}" [appendTo]="'body'">
     <div *ngIf="isNodeSelected" class="filecard" [ngStyle]="{'max-width':getDialogWidth()}">

--- a/angular/src/app/landing/data-files/data-files.component.ts
+++ b/angular/src/app/landing/data-files/data-files.component.ts
@@ -288,13 +288,10 @@ export class DataFilesComponent {
      * Function to Check whether given record has references in it.
      */
     checkReferences() {
-        if (Array.isArray(this.record['references'])) {
-            for (let ref of this.record['references']) {
-                if (ref.refType === 'IsDocumentedBy') this.isDocumentedBy = true;
-                if (ref.refType === 'IsReferencedBy') this.isReferencedBy = true;
-            }
-            if (this.isDocumentedBy || this.isReferencedBy)
-                return true;
+        if (this.record['references'] && this.record['references'].length > 0) {
+            return true;
+        }else{
+            return false;
         }
     }
 
@@ -823,5 +820,20 @@ export class DataFilesComponent {
     getDialogWidth() {
         var w = window.innerWidth > 500 ? 500 : window.innerWidth;
         return w + 'px';
+    }
+
+    /**
+     * Return the link text of the given reference.
+     * 1. the value of the citation property (if set and is not empty)
+     * 2. the value of the label property (if set and is not empty)
+     * 3. to "URL: " appended by the value of the location property.
+     * @param refs reference object
+     */
+    getReferenceText(refs){
+        if(refs['citation']) 
+            return refs['citation'];
+        if(refs['label'])
+            return refs['label'];
+        return refs['location'];
     }
 }

--- a/angular/src/app/landing/landing.component.html
+++ b/angular/src/app/landing/landing.component.html
@@ -10,57 +10,7 @@
                     <app-title [record]="record" [inBrowser]="inBrowser"></app-title>
                     <app-author [record]="record" [inBrowser]="inBrowser"></app-author>
                 </div>
-                <div class="ui-g-8 ui-md-8 ui-lg-8 ui-sm-12">
-                    <app-contact [record]="record" [inBrowser]="inBrowser"></app-contact>
-
-                    <span>Identifier: </span>
-                    <span *ngIf="doiUrl"><i> <a class="font14" href="{{doiUrl}}"
-                                >{{record.doi}}</a></i></span>
-                    <span *ngIf="!doiUrl"><i> <a class="font14"
-                                href="{{ cfg.get('landingPageService','/od/id/') }}{{record['@id']}}">{{record["@id"]}}</a></i>
-                    </span>
-                    <span *ngIf="checkReferences()"><br>
-                        <span>Described in article: </span>
-                        <small *ngFor="let refs of record['references']; let i =index">
-                            <span style="padding-left:2.75em" *ngIf="refs.refType == 'IsDocumentedBy'">
-                                <br><i class="faa faa-external-link"> &nbsp;
-                                    <a class="font14" href={{refs.location}} target="blank"
-                                        (click)="gaService.gaTrackEvent('outbound', $event, 'Resource title: ' + record.title, refs.location)">{{ refs.label }}</a></i>
-                                <span *ngIf="i < record.references.length-1 ">,</span>
-                            </span>
-                        </small>
-                    </span><br>
-                    <span class="" *ngIf="record.version"> Version: <strong>{{record.version}}</strong></span>
-                    <span class="" *ngIf="record.versionHistory" style="padding-right: 15pt;">...
-                        <i style="cursor: pointer;" class="faa" aria-hidden="true"
-                            [ngClass]="{'faa-plus-square-o': !clickHistory, 'faa-minus-square-o': clickHistory}"
-                            (click)="closeHistory = !closeHistory; clickHistory = expandHistory();"></i>
-                    </span>
-                    <span class="" *ngIf="record.issued" style="padding-right: 10pt;"> Released:
-                        <strong>{{record.issued}}</strong></span>
-                    <span class="" *ngIf="record.modified" style="padding-right: 10pt;"> Last modified:
-                        <strong>{{record.modified}}</strong></span>
-                    <div class="card customcard" [collapse]="!closeHistory">
-                        <b>Version History:</b>
-                        <span *ngFor="let release of record.versionHistory">
-                            <br> <b [innerHTML]="renderRelVer(release, record.version)"></b> &nbsp;&nbsp;
-                            <span *ngIf="release.issued">Released: {{release.issued}}</span>
-                            <span *ngIf="release.location || release.refid"> &nbsp;&nbsp;
-                                <i [innerHTML]="renderRelId(release, record.version)"></i>
-                            </span>
-                            <span *ngIf="release.description"> <br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-                                <i>{{release.description}}</i>
-                            </span>
-                        </span>
-                    </div>
-                    <p style="margin-top: 10px;" *ngIf="newer.location">
-                        <b>There is a more recent release of this resource available: &nbsp;&nbsp;
-                            <a href="{{newer.location}}"
-                                (click)="gaService.gaTrackEvent('outbound', $event, 'Resource title: ' + record.title, newer.label)">{{newer.label}}</a></b>
-                    </p>
-                </div>
-
-                <div class="ui-g-4 ui-md-4 ui-lg-4 ui-sm-12">
+                <div class="ui-g-12 ui-md-12 ui-lg-12 ui-sm-12">
                     <span *ngIf="HomePageLink" style="float: right;">
                         <span *ngIf="inBrowser; else visitHomeOnServer">
                             <button type="button"
@@ -75,6 +25,70 @@
                         </span>
                         <ng-template #visitHomeOnServer><a href="{{record.landingPage}}">Visit Home Page</a></ng-template>
                     </span>
+
+                    <!-- Contact point -->
+                    <app-contact [record]="record" [inBrowser]="inBrowser"></app-contact>
+
+                    <!-- Identifier -->
+                    <div>
+                        <span>Identifier: </span>
+                        <span *ngIf="doiUrl"><i> <a class="font14" href="{{doiUrl}}"
+                                    >{{record.doi}}</a></i></span>
+                        <span *ngIf="!doiUrl"><i> <a class="font14"
+                                    href="{{ cfg.get('landingPageService','/od/id/') }}{{record['@id']}}">{{record["@id"]}}</a></i>
+                        </span>
+                    </div>
+
+                    <!-- References -->
+                    <div *ngIf="checkReferences()">
+                        <div>This data is described in:</div>
+                        <small *ngFor="let refs of record['references']; let i =index">
+                            <span style="margin-left:1em;" *ngIf="refs.refType == 'IsDocumentedBy' || refs.refType == 'IsSupplementTo'">
+                                <i class="faa faa-external-link"> &nbsp;
+                                    <span *ngIf="!refs['label'] && !refs['citation']">URL: </span>
+                                    <a class="font14" href={{refs.location}} target="blank"
+                                        (click)="gaService.gaTrackEvent('outbound', $event, 'Resource title: ' + record.title, refs.location)">{{getReferenceText(refs)}}</a></i>
+                            </span>
+                        </small>
+                    </div>
+
+                    <!-- Version -->
+                    <div *ngIf="record.version"> Version: <strong>{{record.version}}</strong>
+                        <span *ngIf="record.versionHistory" style="padding-right: 15pt;">...
+                            <i style="cursor: pointer;" class="faa" aria-hidden="true"
+                                [ngClass]="{'faa-plus-square-o': !clickHistory, 'faa-minus-square-o': clickHistory}"
+                                (click)="closeHistory = !closeHistory; clickHistory = expandHistory();"></i>
+                        </span>
+
+                        <!-- Last modified -->
+                        <span *ngIf="record.modified" style="padding-right: 10pt;margin-left: 1em;"> Last modified:
+                            <strong>{{record.modified}}</strong></span>
+                    </div>
+                    <div class="card customcard" [collapse]="!closeHistory">
+                        <b>Version History:</b>
+                        <span *ngFor="let release of record.versionHistory">
+                            <br> <b [innerHTML]="renderRelVer(release, record.version)"></b> &nbsp;&nbsp;
+                            <span *ngIf="release.issued">Released: {{release.issued}}</span>
+                            <span *ngIf="release.location || release.refid"> &nbsp;&nbsp;
+                                <i [innerHTML]="renderRelId(release, record.version)"></i>
+                            </span>
+                            <span *ngIf="release.description"> <br> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                                <i>{{release.description}}</i>
+                            </span>
+                        </span>
+                    </div>
+
+                    <!-- Released -->
+                    <div *ngIf="record.issued" style="padding-right: 10pt;"> Released:
+                        <strong>{{record.issued}}</strong></div>
+
+
+
+                    <p style="margin-top: 10px;" *ngIf="newer.location">
+                        <b>There is a more recent release of this resource available: &nbsp;&nbsp;
+                            <a href="{{newer.location}}"
+                                (click)="gaService.gaTrackEvent('outbound', $event, 'Resource title: ' + record.title, newer.label)">{{newer.label}}</a></b>
+                    </p>
                 </div>
             </div>
 

--- a/angular/src/app/landing/landing.component.ts
+++ b/angular/src/app/landing/landing.component.ts
@@ -403,12 +403,31 @@ export class LandingComponent implements OnInit, OnChanges {
         this.titleService.setTitle(newTitle);
     }
 
+    /**
+     * Check if current record contains reference for display.
+     * Valid reference types are IsDocumentedBy and IsSupplementTo.
+     */
     checkReferences() {
         if (Array.isArray(this.record['references'])) {
             for (let ref of this.record['references']) {
-                if (ref.refType == "IsDocumentedBy") return true;
+                if (ref.refType == "IsDocumentedBy" || ref.refType == "IsSupplementTo") return true;
             }
         }
+    }
+
+    /**
+     * Return the link text of the given reference.
+     * 1. the value of the label property (if set and is not empty)
+     * 2. the value of the citation property (if set and is not empty)
+     * 3. to "URL: " appended by the value of the location property.
+     * @param refs reference object
+     */
+    getReferenceText(refs){
+        if(refs['label']) 
+            return refs['label'];
+        if(refs['citation'])
+            return refs['citation'];
+        return refs['location'];
     }
 
     isArray(obj: any) {

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -33,7 +33,7 @@ export const config: LPSConfig = {
     status: "Dev Version",
     appVersion: "v1.2.X",
     production: context.production,
-    editEnabled: true,
+    editEnabled: false,
     distService: "https://testdata.nist.gov/od/ds/",
     gacode: "not-set",
     screenSizeBreakPoint: 1060,
@@ -84,13 +84,25 @@ export const testdata: {} = {
         ],
         "references": [
             {
-                "@type": "deo:BibliographicReference",
-                "@id": "#ref:publications/multiple-encounter-dataset-i-meds-i",
-                "refType": "IsReferencedBy",
-                "location": "https://www.nist.gov/publications/multiple-encounter-dataset-i-meds-i",
-                "_extensionSchemas": [
-                    "https://www.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference"
-                ]
+                "refType":"IsDocumentedBy",
+                "title":"In-situ Raman spectroscopic measurements of the deformation region in indented glasses",
+                "issued":"2020-02",
+                "citation":"Gerbig, Y. B., & Michaels, C. A. (2020). In-situ Raman spectroscopic measurements of the deformation region in indented glasses. Journal of Non-Crystalline Solids, 530, 119828. doi:10.1016/j.jnoncrysol.2019.119828\n",
+                "label":"Journal of Non-Crystalline Solids: In-situ Raman spectroscopic measurements of the deformation region in indented glasses",
+                "location":"https://doi.org/10.1016/j.jnoncrysol.2019.119828",
+                "@id":"#ref:10.1016/j.jnoncrysol.2019.119828",
+                "@type":["schema:Article"],
+                "_extensionSchemas":["https://data.nist.gov/od/dm/nerdm-schema/v0.2#/definitions/DCiteReference"]
+            },
+            {
+                "refType":"IsCitedBy",
+                "title":"Indentation device forin situRaman spectroscopic and optical studies",
+                "issued":"2012-12",
+                "citation":"Gerbig, Y. B., Michaels, C. A., Forster, A. M., Hettenhouser, J. W., Byrd, W. E., Morris, D. J., & Cook, R. F. (2012). Indentation device forin situRaman spectroscopic and optical studies. Review of Scientific Instruments, 83(12), 125106. doi:10.1063/1.4769995\n",
+                "location":"https://doi.org/10.1063/1.4769995",
+                "@id":"#ref:10.1063/1.4769995",
+                "@type":["schema:Article"],
+                "_extensionSchemas":["https://data.nist.gov/od/dm/nerdm-schema/v0.2#/definitions/DCiteReference"]
             }
         ],
         "accessLevel": "public",

--- a/python/nistoar/pdr/preserv/bagger/utils.py
+++ b/python/nistoar/pdr/preserv/bagger/utils.py
@@ -13,7 +13,8 @@ import os, re
 from collections import Sequence, Mapping
 from urlparse import urlparse
 
-from ..bagit.builder import NERDM_SCH_ID_BASE, NERDM_SCH_VER, NERDMPUB_SCH_VER
+from ..bagit.builder import (NERDM_SCH_ID_BASE, NERDM_SCH_VER, NERDMPUB_SCH_VER,
+                             NERDMBIB_SCH_ID_BASE, NERDMBIB_SCH_VER)
 
 DEF_MBAG_VERSION = "0.4"
 DEF_NIST_PROF_VERSION = "0.4"
@@ -456,6 +457,8 @@ def update_nerdm_schema(nerdmd, version=None, byext={}):
         byext = dict(byext)
     if not version and "pub" not in byext:
         byext["pub"] = NERDMPUB_SCH_VER
+    if not version and "bib" not in byext:
+        byext["bib"] = NERDMBIB_SCH_VER
     if "" not in byext:
         byext[""] = defver
 
@@ -474,6 +477,14 @@ def update_nerdm_schema(nerdmd, version=None, byext={}):
     if updated:
         nerdmd[mtc+"schema"] = updated
     _upd_schema_ver_on_node(nerdmd, mtc+"extensionSchemas", matchrs, defver)
+
+    # correct to start using bib extension if needed
+    if any(mtc+"extensionSchemas" in r for r in nerdmd.get('references',[])):
+        for ref in nerdmd['references']:
+            for i, ext in enumerate(ref.get(mtc+"extensionSchemas", [])):
+                if ext.startswith(NERDM_SCH_ID_BASE+"v") and '#/definitions/DCite' in ext:
+                    ref[mtc+"extensionSchemas"][i] = NERDMBIB_SCH_ID_BASE + byext['bib'] + \
+                                                     ext[ext.index('#'):]
 
     return nerdmd
 

--- a/python/nistoar/pdr/preserv/bagit/builder.py
+++ b/python/nistoar/pdr/preserv/bagit/builder.py
@@ -16,6 +16,7 @@ from .exceptions import (BagProfileError, BagWriteError, BadBagRequest,
                          ComponentNotFound)
 from ....nerdm.exceptions import (NERDError, NERDTypeError)
 from ....nerdm.convert import PODds2Res
+from ....nerdm.constants import core_schema_base, schema_versions
 from ....id import PDRMinter, NIST_ARK_NAAN
 from ...utils import (build_mime_type_map, checksum_of, measure_dir_size,
                       read_nerd, read_pod, write_json)
@@ -48,14 +49,18 @@ COLLANNOT_FILENAME = ANNOT_FILENAME
 
 NERD_PRE = "nrd"
 NERDPUB_PRE = "nrdp"
-NERDM_SCH_ID_BASE = "https://data.nist.gov/od/dm/nerdm-schema/"
-NERDMPUB_SCH_ID_BASE = "https://data.nist.gov/od/dm/nerdm-schema/pub/"
-NERDM_SCH_VER = "v0.3"
+NERDM_SCH_ID_BASE = core_schema_base
+NERDMPUB_SCH_ID_BASE = core_schema_base + "pub/"
+NERDMBIB_SCH_ID_BASE = core_schema_base + "bib/"
+NERDM_SCH_VER = schema_versions[0]
 NERDMPUB_SCH_VER = NERDM_SCH_VER
+NERDMBIB_SCH_VER = NERDM_SCH_VER
 NERDM_SCH_ID = NERDM_SCH_ID_BASE + NERDM_SCH_VER + "#"
 NERDMPUB_SCH_ID = NERDMPUB_SCH_ID_BASE + NERDMPUB_SCH_VER + "#"
+NERDMBIB_SCH_ID = NERDMBIB_SCH_ID_BASE + NERDMPUB_SCH_VER + "#"
 NERD_DEF = NERDM_SCH_ID + "/definitions/"
 NERDPUB_DEF = NERDMPUB_SCH_ID + "/definitions/"
+NERDBIB_DEF = NERDMBIB_SCH_ID + "/definitions/"
 DATAFILE_TYPE = NERDPUB_PRE + ":DataFile"
 CHECKSUMFILE_TYPE = NERDPUB_PRE + ":ChecksumFile"
 DOWNLOADABLEFILE_TYPE = NERDPUB_PRE + ":DownloadableFile"

--- a/python/tests/nistoar/pdr/preserv/bagger/test_prepupd.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_prepupd.py
@@ -10,6 +10,7 @@ from nistoar.pdr.utils import checksum_of
 from nistoar.pdr.distrib import DistribResourceNotFound
 from nistoar.pdr.preserv.bagit import NISTBag
 from nistoar.pdr.utils import read_nerd
+from nistoar.nerdm.constants import CORE_SCHEMA_URI, PUB_SCHEMA_URI, BIB_SCHEMA_URI
 
 bagsrcdir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data")
 mdsrcdir = os.path.join(os.path.dirname(os.path.dirname(bagsrcdir)), "describe", "data")
@@ -136,7 +137,7 @@ class TestSimServices(test.TestCase):
 
         data = cli.get_json("ABCDEFG/_aip/_v/latest/_head")
         self.assertEqual(data, {"aipid": "ABCDEFG", "sinceVersion": "2", 
-                                "contentLength": 10083, "multibagSequence" : 4,
+                                "contentLength": 10080, "multibagSequence" : 4,
                                 "multibagProfileVersion" : "0.4",
                                 "contentType": "application/zip",
                                 "serialization": "zip",
@@ -145,7 +146,7 @@ class TestSimServices(test.TestCase):
 
         data = cli.get_json("ABCDEFG/_aip/_v/1/_head")
         self.assertEqual(data, {"aipid": "ABCDEFG", "sinceVersion": "1", 
-                                "contentLength": 10083, "multibagSequence" : 2,
+                                "contentLength": 10080, "multibagSequence" : 2,
                                 "multibagProfileVersion" : "0.4",
                                 "contentType": "application/zip",
                                 "serialization": "zip",
@@ -350,12 +351,11 @@ class TestUpdatePrepper(test.TestCase):
         self.assertTrue(os.path.isfile(nfile))
 
         md = read_nerd(nfile)
-        self.assertEqual(md["_schema"],
-                         "https://data.nist.gov/od/dm/nerdm-schema/v0.3#")
-        self.assertEqual(md["references"][0]["_extensionSchemas"][0],
-                         "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/DCiteReference")
+        self.assertEqual(md["_schema"], CORE_SCHEMA_URI+"#")
+        self.assertEqual(md["references"][0]["_extensionSchemas"][0], 
+                         BIB_SCHEMA_URI+"#/definitions/DCiteReference")
         self.assertEqual(md["references"][1]["_extensionSchemas"][0],
-                         "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/DCiteReference")
+                         BIB_SCHEMA_URI+"#/definitions/DCiteReference")
         
         depinfof = os.path.join(root, "multibag", "deprecated-info.txt")
         self.assertTrue(not os.path.isfile(depinfof))

--- a/python/tests/nistoar/pdr/preserv/bagger/test_utils.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_utils.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 
 from nistoar.testing import *
 from nistoar.pdr.preserv.bagger import utils as bagut
+from nistoar.nerdm.constants import CORE_SCHEMA_URI, PUB_SCHEMA_URI
 
 class TestVersion(test.TestCase):
 
@@ -546,6 +547,7 @@ class TestBagUtils(test.TestCase):
         byext = {
             "http://example.com/anext/": "v0.1",
             "pub":  "v1.2",
+            "bib":  "v0.8",
             "":     "v2.2"
         }
 
@@ -563,7 +565,16 @@ class TestBagUtils(test.TestCase):
                     "blah": "blah"
                 },
                 "$extensionSchemas": []
-            }
+            },
+            "references": [
+                {
+                    'location': 'https://tinyurl.com/asdf',
+                    "$extensionSchemas": [
+                        "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/BibliographicReference",
+                        "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/DCiteReference"
+                    ]
+                }
+            ]
         }
 
         bagut.update_nerdm_schema(data, "1.0", byext)
@@ -575,6 +586,10 @@ class TestBagUtils(test.TestCase):
         self.assertEqual(data['bar']['tex']['$extensionSchemas'], 
                      "https://data.nist.gov/od/dm/nerdm-schema/pub/v1.2#Contact")
         self.assertEqual(data['bar']['$extensionSchemas'], [])
+        self.assertEqual(data['references'][0]['$extensionSchemas'][0],
+                         "https://data.nist.gov/od/dm/nerdm-schema/v2.2#/definitions/BibliographicReference")
+        self.assertEqual(data['references'][0]['$extensionSchemas'][1],
+                         "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.8#/definitions/DCiteReference")
         
         data = {
             "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.3",
@@ -593,13 +608,11 @@ class TestBagUtils(test.TestCase):
             }
         }
         bagut.update_nerdm_schema(data)
-        self.assertEqual(data['_schema'], 
-                         "https://data.nist.gov/od/dm/nerdm-schema/v0.3")
+        self.assertEqual(data['_schema'], CORE_SCHEMA_URI)
         self.assertEqual(data['foo']['_extensionSchemas'], 
                          [ "http://example.com/anext/v88#goob",
                            "http://goober.com/foop/v99#big" ])
-        self.assertEqual(data['bar']['tex']['_extensionSchemas'], 
-                     "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#Contact")
+        self.assertEqual(data['bar']['tex']['_extensionSchemas'], PUB_SCHEMA_URI+"#Contact")
         self.assertEqual(data['bar']['_extensionSchemas'], [])
         
 

--- a/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
@@ -10,6 +10,7 @@ from nistoar.testing import *
 import nistoar.pdr.preserv.bagit.builder as bldr
 import nistoar.pdr.exceptions as exceptions
 from nistoar.pdr.utils import read_nerd
+from nistoar.nerdm.constants import CORE_SCHEMA_URI, PUB_SCHEMA_URI
 
 # datadir = tests/nistoar/pdr/preserv/data
 datadir = os.path.join(
@@ -346,18 +347,14 @@ class TestBuilder2(test.TestCase):
 
     def test_create_init_md_for(self):
         md = self.bag._create_init_md_for("", None)
-        self.assertEqual(md['_schema'],
-                         "https://data.nist.gov/od/dm/nerdm-schema/v0.3#")
-        self.assertEqual(md['_extensionSchemas'],
-                         ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/PublicDataResource"])
+        self.assertEqual(md['_schema'], CORE_SCHEMA_URI+"#")
+        self.assertEqual(md['_extensionSchemas'], [PUB_SCHEMA_URI+"#/definitions/PublicDataResource"])
         self.assertEqual(md['@type'], ["nrdp:PublicDataResource"])
         self.assertIn("@context", md)
 
         md = self.bag._create_init_md_for("foo/bar", "DataFile")
-        self.assertEqual(md['_schema'],
-          "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/Component")
-        self.assertEqual(md['_extensionSchemas'],
-                         ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"])
+        self.assertEqual(md['_schema'], CORE_SCHEMA_URI+"#/definitions/Component")
+        self.assertEqual(md['_extensionSchemas'], [PUB_SCHEMA_URI+"#/definitions/DataFile"])
         self.assertEqual(md['@type'],
                  ["nrdp:DataFile", "nrdp:DownloadableFile", "dcat:Distribution"])
         self.assertIn("@context", md)
@@ -366,10 +363,8 @@ class TestBuilder2(test.TestCase):
         self.assertNotIn('downloadURL', md)
 
         md = self.bag._create_init_md_for("foo/bar.sha256", "ChecksumFile")
-        self.assertEqual(md['_schema'],
-          "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/Component")
-        self.assertEqual(md['_extensionSchemas'],
-                         ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/ChecksumFile"])
+        self.assertEqual(md['_schema'], CORE_SCHEMA_URI+"#/definitions/Component")
+        self.assertEqual(md['_extensionSchemas'], [PUB_SCHEMA_URI+"#/definitions/ChecksumFile"])
         self.assertEqual(md['@type'],
             ["nrdp:ChecksumFile", "nrdp:DownloadableFile", "dcat:Distribution"])
         self.assertIn("@context", md)
@@ -378,10 +373,8 @@ class TestBuilder2(test.TestCase):
         self.assertNotIn('downloadURL', md)
 
         md = self.bag._create_init_md_for("foo/", "Subcollection")
-        self.assertEqual(md['_schema'],
-          "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/Component")
-        self.assertEqual(md['_extensionSchemas'],
-                         ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/Subcollection"])
+        self.assertEqual(md['_schema'], CORE_SCHEMA_URI+"#/definitions/Component")
+        self.assertEqual(md['_extensionSchemas'], [PUB_SCHEMA_URI+"#/definitions/Subcollection"])
         self.assertEqual(md['@type'], ["nrdp:Subcollection"])
         self.assertIn("@context", md)
         self.assertEqual(md['@id'], "cmps/foo")
@@ -389,10 +382,8 @@ class TestBuilder2(test.TestCase):
         self.assertNotIn('downloadURL', md)
 
         md = self.bag._create_init_md_for("@id:cmps/foo/", "Subcollection")
-        self.assertEqual(md['_schema'],
-          "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/Component")
-        self.assertEqual(md['_extensionSchemas'],
-                         ["https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/Subcollection"])
+        self.assertEqual(md['_schema'], CORE_SCHEMA_URI+"#/definitions/Component")
+        self.assertEqual(md['_extensionSchemas'], [PUB_SCHEMA_URI+"#/definitions/Subcollection"])
         self.assertEqual(md['@type'], ["nrdp:Subcollection"])
         self.assertIn("@context", md)
         self.assertEqual(md['@id'], "cmps/foo")
@@ -1144,7 +1135,7 @@ class TestBuilder2(test.TestCase):
         md = self.bag.bag.nerd_metadata_for("gurn")
         self.assertEqual(md['filepath'], "gurn")
         self.assertEqual(md['@id'], "cmps/gurn")
-                        
+
     def test_update_ediid(self):
         self.assertIsNone(self.bag.ediid)
         self.bag.ediid = "9999"
@@ -1737,7 +1728,7 @@ class TestBuilder2(test.TestCase):
         self.assertEqual(len(oxum), 1)
         oxum = [int(n) for n in oxum[0].split(': ')[1].split('.')]
         self.assertEqual(oxum[1], 14)
-        self.assertEqual(oxum[0], 12176)  # this will change if logging changes
+        self.assertEqual(oxum[0], 12180)  # this will change if logging changes
 
         bagsz = [l for l in lines if "Bag-Size: " in l]
         self.assertEqual(len(bagsz), 1)

--- a/python/tests/nistoar/pdr/preserv/bagit/tools/test_enchance.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/tools/test_enchance.py
@@ -201,10 +201,12 @@ class TestEnrichReferences(test.TestCase):
         self.assertEqual(enh.refs[doiu]['location'], doiu)
         self.assertIn('citation', enh.refs[doiu])
         self.assertIn('title', enh.refs[doiu])
+        self.assertEqual(enh.refs[doiu]['refType'], "IsCitedBy")
 
         # test effectiveness of override, and of updates
         del enh.refs[doiu]['title']
         enh.refs[doiu]['description'] = "The Real Story"
+        enh.refs[doiu]['refType'] = "IsSupplementTo"
         self.assertFalse(enh.merge_enhanced_ref("doi:"+doid, False))
         self.assertIn('citation', enh.refs[doiu])
         self.assertNotIn('title', enh.refs[doiu])
@@ -213,6 +215,7 @@ class TestEnrichReferences(test.TestCase):
         self.assertIn('citation', enh.refs[doiu])
         self.assertIn('title', enh.refs[doiu])
         self.assertEqual(enh.refs[doiu]['description'], "The Real Story")
+        self.assertEqual(enh.refs[doiu]['refType'], "IsSupplementTo")
 
         # test alternate forms of DOI
         del enh.refs[doiu]['citation']
@@ -221,6 +224,7 @@ class TestEnrichReferences(test.TestCase):
         self.assertIn('citation', enh.refs[doiu])
         self.assertIn('title', enh.refs[doiu])
         self.assertEqual(enh.refs[doiu]['description'], "The Real Story")
+        self.assertEqual(enh.refs[doiu]['refType'], "IsSupplementTo")
 
         del enh.refs[doiu]['citation']
         del enh.refs[doiu]['title']
@@ -228,6 +232,7 @@ class TestEnrichReferences(test.TestCase):
         self.assertIn('citation', enh.refs[doiu])
         self.assertIn('title', enh.refs[doiu])
         self.assertEqual(enh.refs[doiu]['description'], "The Real Story")
+        self.assertEqual(enh.refs[doiu]['refType'], "IsSupplementTo")
 
         # test enhancing existing reference
         doid = "10.1364/OE.24.014100"
@@ -239,6 +244,7 @@ class TestEnrichReferences(test.TestCase):
         self.assertIn('title', enh.refs[doiu])
         self.assertIn('optical sorting', enh.refs[doiu]['title'])
         self.assertNotIn('description', enh.refs[doiu])
+        self.assertEqual(enh.refs[doiu]['refType'], "IsReferencedBy")
 
         # test failure mode
         self.assertFalse(enh.merge_enhanced_ref("doi:88888/baddoi", False))
@@ -257,6 +263,8 @@ class TestEnrichReferences(test.TestCase):
         self.assertIn('title', enh.refs[enh.refs.keys()[0]])
         self.assertIn('citation', enh.refs[enh.refs.keys()[0]])
 
+    @test.skipIf("doi" not in os.environ.get("OAR_TEST_INCLUDE",""),
+                 "kindly skipping doi service checks")
     def test_remove_missing_from(self):
         enh = tools.ReferenceEnhancer(rescfg, self.log).enhancer_for(self.bag)
 
@@ -421,6 +429,7 @@ class TestEnrichReferences(test.TestCase):
         self.assertEqual(len(rmd), 3)
 
         self.assertEqual(rmd[0]['location'], origdoi)
+        self.assertEqual(rmd[0]['refType'], 'IsReferencedBy')
         self.assertNotEqual(rmd[0]['citation'], "in press")
         self.assertEqual(rmd[1]['location'], nondoi)
         self.assertEqual(rmd[1]['title'], "Irreproducibily")
@@ -428,7 +437,7 @@ class TestEnrichReferences(test.TestCase):
         self.assertEqual(rmd[2]['title'], "An old publication")
         self.assertNotIn('citation', rmd[2])
 
-        # check unannotated references are unchanged
+        # check unannotated references are unchanged (and that missing reference is removed)
         rmd = self.bag.bag.nerd_metadata_for('', False).get('references', [])
         self.assertEqual(len(rmd), 2)
         self.assertEqual(rmd[0]['location'], origdoi)
@@ -436,6 +445,48 @@ class TestEnrichReferences(test.TestCase):
         self.assertEqual(rmd[1]['location'], nondoi)
         self.assertEqual(rmd[1]['title'], "Irreproducibily")
         
+    @test.skipIf("doi" not in os.environ.get("OAR_TEST_INCLUDE",""),
+                 "kindly skipping doi service checks")
+    def test_synchronize_annotated_refs_reftype(self):
+        nondoi = "http://example.com/paper"
+        doid = "10.1126/science.169.3946.635"
+        doiu = "https://doi.org/"+doid
+        origdoi = "https://doi.org/10.1364/OE.24.014100"
+
+        # setup
+        rmd = self.bag.bag.nerd_metadata_for('', False).get('references', [])
+        self.assertEqual(len(rmd), 1)
+        rmd[0]['citation'] = "in press"
+        rmd[0]['refType'] = "References"
+        rmd.append({ "location": doiu, "citation": "in press", "refType": "IsSupplementTo",
+                     "@id": "#doi:"+doid })
+        self.bag.update_metadata_for('', {'references': rmd})
+        self.assertEqual(len(rmd), 2)
+        self.bag.update_annotations_for('', {'references': rmd})
+
+        # test
+        enh = tools.ReferenceEnhancer(rescfg, self.log)
+        enh.synchronize_annotated_refs(self.bag, override=True)
+
+        # check annotated references
+        rmd = self.bag.bag.annotations_metadata_for('').get('references', [])
+        self.assertEqual(len(rmd), 2)
+
+        self.assertEqual(rmd[0]['location'], origdoi)
+        self.assertEqual(rmd[0]['refType'], 'IsCitedBy')
+        self.assertNotEqual(rmd[0]['citation'], "in press")
+        self.assertEqual(rmd[1]['location'], doiu)
+        self.assertEqual(rmd[1]['@id'], "#doi:"+doid)
+        self.assertNotEqual(rmd[1]['citation'], "in press")
+        self.assertEqual(rmd[1]['refType'], 'IsSupplementTo')
+
+    def test_normalize_doi(self):
+        doi = "10.88888/goober"
+        self.assertEqual(tools.normalize_doi("doi:"+doi), "https://doi.org/"+doi)
+        self.assertEqual(tools.normalize_doi("https://dx.doi.org/"+doi), "https://doi.org/"+doi)
+        self.assertEqual(tools.normalize_doi("https://doi.org/"+doi), "https://doi.org/"+doi)
+        self.assertEqual(tools.normalize_doi(doi), doi)
+
         
         
         

--- a/python/tests/nistoar/pdr/preserv/data/samplembag/metadata/nerdm.json
+++ b/python/tests/nistoar/pdr/preserv/data/samplembag/metadata/nerdm.json
@@ -5,9 +5,9 @@
             "@base": "ark:/88434/edi00hw91c"
         }
     ],
-    "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.1#",
+    "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.4#",
     "_extensionSchemas": [
-        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/PublicDataResource"
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/PublicDataResource"
     ],
     "@type": [
         "nrdp:PublicDataResource"
@@ -42,7 +42,7 @@
             "refType": "IsReferencedBy",
             "location": "https://doi.org/10.1364/OE.24.014100",
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/v0.1#/definitions/DCiteDocumentReference"
+                "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.4#/definitions/DCiteReference"
             ]
         }
     ],

--- a/python/tests/nistoar/pdr/preserv/data/simplesip/_nerdm.json
+++ b/python/tests/nistoar/pdr/preserv/data/simplesip/_nerdm.json
@@ -1,8 +1,8 @@
 {
     "@context": "https://data.nist.gov/od/dm/nerdm-pub-context.jsonld",
-    "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.3#",
+    "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.4#",
     "_extensionSchemas": [
-        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/PublishedDataResource"
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/PublishedDataResource"
     ],
     "@type": [
         "nrdp:PublishedDataResource"
@@ -58,7 +58,7 @@
             "refType": "IsReferencedBy",
             "location": "https://doi.org/10.1364/OE.24.014100",
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/v0.3#/definitions/DCiteDocumentReference"
+                "https://data.nist.gov/od/dm/nerdm-schema/v0.4#/definitions/DCiteDocumentReference"
             ]
         }
     ],
@@ -76,7 +76,7 @@
                 "dcat:Distribution"
             ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ]
         },
         {
@@ -89,7 +89,7 @@
                 "dcat:Distribution"
             ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ]
         },
         {
@@ -113,7 +113,7 @@
                 "dcat:Distribution"
             ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ]
         },
         {
@@ -126,7 +126,7 @@
                 "dcat:Distribution"
             ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ]
         },
         {
@@ -139,7 +139,7 @@
                 "dcat:Distribution"
             ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ]
         },
         {
@@ -152,7 +152,7 @@
                 "dcat:Distribution"
             ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
             ]
         }
     ],

--- a/python/tests/nistoar/pdr/publish/midas3/test_service_preserve.py
+++ b/python/tests/nistoar/pdr/publish/midas3/test_service_preserve.py
@@ -24,6 +24,8 @@ cfgdir = os.path.join(os.path.dirname(__file__), "data")
 basedir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))))
 
+enrichrefs = "doi" in os.environ.get('OAR_TEST_INCLUDE',"")
+
 loghdlr = None
 rootlog = None
 def setUpModule():
@@ -150,6 +152,8 @@ class TestMIDAS3PublishingServicePreserve(test.TestCase):
             "prepub_nerd_dir":  self.nrddir,
             "postpub_nerd_dir": os.path.join(self.stagedir, "_nerdm")
         })
+        defcfg['sip_type']['midas3']['pubserv']['bagger']['enrich_refs'] = enrichrefs
+        defcfg['sip_type']['midas3']['preserv']['bagger']['enrich_refs'] = enrichrefs
         self.cfg = extract_sip_config(defcfg, "pubserv")
 
         self.svc = mdsvc.MIDAS3PublishingService(self.cfg)

--- a/python/tests/nistoar/pdr/publish/midas3/test_wsgi_preserve.py
+++ b/python/tests/nistoar/pdr/publish/midas3/test_wsgi_preserve.py
@@ -24,6 +24,8 @@ cfgdir = os.path.join(os.path.dirname(__file__), "data")
 basedir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))))
 
+enrichrefs = "doi" in os.environ.get('OAR_TEST_INCLUDE',"")
+
 loghdlr = None
 rootlog = None
 def setUpModule():
@@ -158,6 +160,9 @@ class TestPreserveHandler(test.TestCase):
             "prepub_nerd_dir":  self.nrddir,
             "postpub_nerd_dir": os.path.join(self.stagedir, "_nerdm")
         })
+        defcfg['sip_type']['midas3']['pubserv']['bagger']['enrich_refs'] = enrichrefs
+        defcfg['sip_type']['midas3']['preserv']['bagger']['enrich_refs'] = enrichrefs
+
         self.cfg = extract_sip_config(defcfg, "pubserv")
 
         self.svc = mdsvc.MIDAS3PublishingService(self.cfg)
@@ -219,9 +224,10 @@ class TestPreserveHandler(test.TestCase):
         mbdir = os.path.join(mdbag, "multbag")
         self.assertFalse(os.path.exists(os.path.join(mbdir,"file-lookup.tsv")))
         nerdf = os.path.join(mdbag, "metadata", "annot.json")
-        with open(nerdf) as fd:
-            nerd = json.load(fd)
-        self.assertNotIn('version', nerd)
+        if os.path.exists(nerdf):
+            with open(nerdf) as fd:
+                nerd = json.load(fd)
+            self.assertNotIn('version', nerd)
         
         req = {
             'REQUEST_METHOD': "PUT",

--- a/scripts/dhsetup.sh
+++ b/scripts/dhsetup.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+#
+# Authenticate to Docker Hub.
+#
+# Authenticating prevents failures due to pull request rate limits.  Authenticating should enabled via
+# Docker Hub access tokens
+#
+set -e
+[ -z "$OAR_DOCKERHUB_CRED" ] || {
+    DH_USER=`echo $OAR_DOCKERHUB_CRED | sed -e 's/:.*$//'`
+    DH_TOKEN=`echo $OAR_DOCKERHUB_CRED | sed -e 's/^[^:]*://'`
+    docker_version=`docker -v | awk '{ print $3}' | sed -e 's/,.*$//'`
+    docker_major_version=`echo $docker_version | sed -e 's/\..*$//'`
+
+    if [ "$docker_major_version" -gt 17 ]; then
+        echo '+' docker login --username '$DH_USER' --password-stdin
+        (echo "$DH_TOKEN" | docker login --username $DH_USER --password-stdin) || {
+            echo "dhsetup: docker login failed"
+            false
+        }
+    else
+        echo '+' docker login --username '$DH_USER' --password '$DH_TOKEN'
+        docker login --username $DH_USER --password $DH_TOKEN || {
+            echo "dhsetup: docker login failed"
+            false
+        }
+    fi
+}

--- a/scripts/tests/test-preserv.sh
+++ b/scripts/tests/test-preserv.sh
@@ -302,11 +302,11 @@ respcode=`"${curlcmd[@]}"`
 
 curlcmd=(curl -o /dev/null -s -w '%{http_code}\n' -H 'Authorization: Bearer secret' -X PUT http://localhost:9090/preserve/midas/goober)
 respcode=`"${curlcmd[@]}"`
-[ "$respcode" == "404" ] || {
+[ "$respcode" == "400" ] || {
     tell '---------------------------------------'
     tell FAILED
     tell "${curlcmd[@]}"
-    tell "Non-existent record does not produce 404 response:" $respcode
+    tell "Missing POD record does not produce 400 response:" $respcode
     ((failures += 1))
 }
 
@@ -356,7 +356,7 @@ for pod in "${pods[@]}"; do
     sleep 1
 
     if [ ${idcount[$id]} -gt 0 ]; then
-        curlcmd=(curl -o /dev/null -s -w '%{http_code}\n' -X PATCH -H 'Authorization: Bearer secret' http://localhost:9090/preserve/midas/$id)
+        curlcmd=(curl -o /dev/null -s -w '%{http_code}\n' -X PATCH --data @$pod -H 'Authorization: Bearer secret' http://localhost:9090/preserve/midas/$id)
         respcode=`"${curlcmd[@]}"`
         #
         # NOTE:  changing response to 201 (from 200)
@@ -383,7 +383,7 @@ for pod in "${pods[@]}"; do
         ((count += 1))
         ((idcount[$id] += 1))
     else
-        curlcmd=(curl -o /dev/null -s -w '%{http_code}\n' -X PUT -H 'Authorization: Bearer secret' http://localhost:9090/preserve/midas/$id)
+        curlcmd=(curl -o /dev/null -s -w '%{http_code}\n' -X PUT --data @$pod -H 'Authorization: Bearer secret' http://localhost:9090/preserve/midas/$id)
         respcode=`"${curlcmd[@]}"`
         if [ "$respcode" != "201" -a "$respcode" != "202" ]; then
             tell '---------------------------------------'


### PR DESCRIPTION
This PR addresses [ODD-954 ("pubserver: require POD record as input to preservation request")](https://mml.nist.gov:8080/browse/ODD-954) which calls for a change to the preservation service API intended to prevent a common failure mode.  The fix now requires that the latest POD record to be provide as input to the preservation request to ensure that archived POD data is in sync with MIDAS, and most importantly, to ensure that the latest date held by MIDAS is actually valid.  The preservation service now processes the POD record just as if it was sent to the `/latest/` pubserver endpoint, and then proceeds with preservation; if the POD record is invalid, preservation is not carried out, and the client returned an error status.  

Test this PR via the [oar-docker PR#134](https://github.com/usnistgov/oar-docker/pull/134).
