### PR TITLE
Modified contact url link to be the same as in SDP

### DIFF
--- a/angular/src/app/frame/headbar.component.ts
+++ b/angular/src/app/frame/headbar.component.ts
@@ -58,7 +58,7 @@ export class HeadbarComponent {
         if (!(cfg instanceof AppConfig))
             throw new Error("HeadbarComponent: Wrong config type provided: " + cfg);
         this.searchLink = cfg.get("locations.pdrSearch", "/sdp/");
-        this.contactLink = cfg.get("locations.pdrSearch", "/sdp/") + "#/help/app-contact-us";
+        this.contactLink = cfg.get("locations.pdrSearch", "/sdp/") + "#/help/contactus";
         this.status = cfg.get("status", "");
         this.appVersion = cfg.get("appVersion", "");
         this.editEnabled = cfg.get("editEnabled", "");


### PR DESCRIPTION
http://mml.nist.gov:8080/browse/ODD-934

This fix modified the url of contact link to be the same as the one in SDP - from help/app-contact-us to help/contactus.

To test, run it in local docker and click on "Contact" at top right menu. Make sure the target is https://data.nist.gov/sdp/#/contactus.