### PR TITLE
Fix/odd955-956-957 download all failure on mds2-2253, server side error and code clean up

### DIFF
--- a/angular/src/app/datacart/bundleplan/bundleplan.component.html
+++ b/angular/src/app/datacart/bundleplan/bundleplan.component.html
@@ -1,5 +1,5 @@
 <!-- Display zip files if any -->
-<div class="full-span">
+<div *ngIf="inBrowser" class="full-span">
     <!-- Show current task -->
     <div *ngIf="showCurrentTask" style="text-align: center; margin:auto; width:100%;"><i class="faa faa-spinner faa-spin" style="color:#1E6BA1;" aria-hidden="true"></i><span style="padding-left: .5em;">{{currentTask}}</span></div>
     <!-- header -->
@@ -90,7 +90,7 @@
 
 <!-- Display bundle plan message details -->
 <div class="full-span"
-    *ngIf="bundlePlanStatus == 'error' || bundlePlanStatus == 'internal error' || bundlePlanStatus === 'warnings'">
+    *ngIf="inBrowser && (bundlePlanStatus == 'error' || bundlePlanStatus == 'internal error' || bundlePlanStatus === 'warnings')">
     <div class="header-orange" data-toggle="tooltip" title="Bundle message details">
         <span style="margin-left: .5em;" *ngIf="bundlePlanMessage" (click)="showMessage = !showMessage">
             <i *ngIf="showMessage; else hideMessage" class="faa faa-arrow-circle-up faa-1x icon-white"

--- a/angular/src/app/datacart/bundleplan/bundleplan.component.html
+++ b/angular/src/app/datacart/bundleplan/bundleplan.component.html
@@ -48,7 +48,7 @@
                         {{getStatusForDisplay(zip.downloadStatus)}}
                     </div>
                     <ng-template #download_error>
-                        <div style="display:inline-block;margin-left: .5em;font-size: 0.8em; color: red; cursor: pointer;" (click)="openZipDetails($event,op5,zip) ">
+                        <div style="display:inline-block;margin-left: .5em;font-size: 0.8em; color: red; cursor: pointer;" (click)="openErrZipDetails($event,op5,zip) ">
                             <i class="faa faa-warning" [ngStyle]="{'padding-right':'.5em', 'margin-top':'8px'}"></i>
                             <u>{{getStatusForDisplay(zip.downloadStatus)}}</u>
                         </div>

--- a/angular/src/app/datacart/bundleplan/bundleplan.component.ts
+++ b/angular/src/app/datacart/bundleplan/bundleplan.component.ts
@@ -267,8 +267,12 @@ export class BundleplanComponent implements OnInit {
      * Make sure the width of popup dialog is less than 500px or 80% of the window width
      */
     getDialogWidth() {
-        var w = window.innerWidth > 500 ? 500 : window.innerWidth;
-        return w + 'px';
+        if(this.inBrowser){
+            var w = window.innerWidth > 500 ? 500 : window.innerWidth;
+            return w + 'px';
+        }else{
+            return '500px';
+        }
     }
 
     /**

--- a/angular/src/app/datacart/bundleplan/bundleplan.component.ts
+++ b/angular/src/app/datacart/bundleplan/bundleplan.component.ts
@@ -104,8 +104,8 @@ export class BundleplanComponent implements OnInit {
                 case 'downloadSelected': { 
                     if(command.data)
                         this.selectedData = command.data;
-                   this.downloadAllFilesFromAPI();
-                   break; 
+                        this.downloadAllFilesFromAPI();
+                    break; 
                 } 
                 case 'resetDownloadParams': {
                     this.resetDownloadParams();
@@ -331,7 +331,7 @@ export class BundleplanComponent implements OnInit {
         postMessage.push({ "bundleName": files.data.downloadFileName, "includeFiles": this.downloadData });
         // console.log('Bundle plan post message:', JSON.stringify(postMessage[0]));
         console.log("Calling following end point to get bundle plan:", this.distApi + "_bundle_plan");
-
+        
         this.bundlePlanRef = this.downloadService.getBundlePlan(this.distApi + "_bundle_plan", JSON.stringify(postMessage[0])).subscribe(
             blob => {
                 this.bundlePlanStatus = blob.status.toLowerCase();

--- a/angular/src/app/datacart/bundleplan/bundleplan.component.ts
+++ b/angular/src/app/datacart/bundleplan/bundleplan.component.ts
@@ -106,7 +106,6 @@ export class BundleplanComponent implements OnInit {
             if(this.inBrowser){
                 switch(command.command) { 
                     case 'downloadSelected': { 
-                        console.log("downloading selected...");
                         if(command.data)
                             this.selectedData = command.data;
                             this.downloadAllFilesFromAPI();
@@ -144,7 +143,6 @@ export class BundleplanComponent implements OnInit {
 
         this.downloadService.watchDownloadProcessStatus().subscribe(
             value => {
-                console.log("watchDownloadProcessStatus", value);
                 if(value && this.downloadStarted && this.inBrowser){
                     this.setProcessComplete();
                 }
@@ -169,7 +167,6 @@ export class BundleplanComponent implements OnInit {
         this.downloadEndTime = new Date();
         this.totalDownloadTime = this.downloadEndTime.getTime() / 1000 - this.downloadStartTime.getTime() / 1000;
         this.overallStatus = 'complete';
-        console.log("this.dataFiles", this.dataFiles);
         this.outputOverallStatus.emit(this.overallStatus);
         setTimeout(() => {
             this.updateDownloadPercentage(100);
@@ -317,18 +314,14 @@ export class BundleplanComponent implements OnInit {
      * Function to download all files from API call.
      */
     downloadAllFilesFromAPI() {
-        console.log("Start downloading...");
         this.showCurrentTask = true;
         this.currentTask = "Preparing downloads...";
-        console.log("Reset download status...");
         this.clearDownloadStatus();
         let postMessage: any[] = [];
         this.downloadData = [];
         this.zipData = [];
         this.allDownloadCancelled = false;
         this.bundlePlanMessage = null;
-        this.downloadService.setDownloadingNumber(0);
-
         this.downloadStartTime = new Date();
 
         // create root
@@ -349,7 +342,6 @@ export class BundleplanComponent implements OnInit {
         files.data.downloadStatus = 'downloading';
 
         postMessage.push({ "bundleName": files.data.downloadFileName, "includeFiles": this.downloadData });
-        // console.log('Bundle plan post message:', JSON.stringify(postMessage[0]));
         console.log("Calling following end point to get bundle plan:", this.distApi + "_bundle_plan");
         
         this.bundlePlanRef = this.downloadService.getBundlePlan(this.distApi + "_bundle_plan", JSON.stringify(postMessage[0])).subscribe(
@@ -362,7 +354,6 @@ export class BundleplanComponent implements OnInit {
                 if (this.bundlePlanUnhandledFiles) {
                     this.markUnhandledFiles();
                 }
-                console.log('bundlePlan return status:', this.bundlePlanStatus);
                 if (this.bundlePlanStatus == 'complete' || this.bundlePlanStatus == 'warnings') {
                     if(this.bundlePlanStatus == 'warnings'){
                         let dateTime = new Date();
@@ -385,7 +376,6 @@ export class BundleplanComponent implements OnInit {
                         this.zipData.push({ "fileName": bundle.bundleName, "downloadProgress": 0, "downloadStatus": null, "downloadInstance": null, "bundle": bundle, "downloadUrl": downloadUrl, "downloadErrorMessage": "","bundleSize": bundle.bundleSize, 'downloadTime': null });
                     }
 
-                    console.log('this.zipData', this.zipData);
                     let ngbModalOptions: NgbModalOptions = {
                         backdrop: 'static',
                         keyboard: false,
@@ -461,7 +451,6 @@ export class BundleplanComponent implements OnInit {
      * Process data returned from bundle_plan (stored in zipData)
      */
     processBundle() {
-        console.log("Processing Each Bundle...")
         this.gaService.gaTrackEvent('download', undefined, 'all files', "Data cart");
 
         this.messageColor = this.getColor();
@@ -529,8 +518,6 @@ export class BundleplanComponent implements OnInit {
         this.dataCart.restore();
         this.dataCart.resetDatafileDownloadStatus(this.dataFiles, '');
         this.dataCart.save();
-
-        this.downloadService.setTotalFileDownloaded(0);
         this.downloadService.resetDownloadData();
     }
 

--- a/angular/src/app/datacart/bundleplan/bundleplan.component.ts
+++ b/angular/src/app/datacart/bundleplan/bundleplan.component.ts
@@ -455,7 +455,8 @@ export class BundleplanComponent implements OnInit {
 
         this.messageColor = this.getColor();
 
-        // Start downloading the first one, this will set the downloaded zip file to 1
+        // Start downloading the first one, this will set the downloaded zip file to 1 which will
+        // trigger the following listener
         this.downloadService.downloadNextZip(this.zipData, this.dataFiles, this.dataCart);
 
         this.subscriptions.push(this.downloadService.watchDownloadingNumber().subscribe(

--- a/angular/src/app/datacart/bundleplan/bundleplan.component.ts
+++ b/angular/src/app/datacart/bundleplan/bundleplan.component.ts
@@ -300,7 +300,6 @@ export class BundleplanComponent implements OnInit {
      * Function to download all files from API call.
      **/
     downloadAllFilesFromAPI() {
-        this.gaService.gaTrackEvent('download', undefined, 'all files', "Data cart");
         this.clearDownloadStatus();
         this.showCurrentTask = true;
         let postMessage: any[] = [];
@@ -465,6 +464,8 @@ export class BundleplanComponent implements OnInit {
     **/
     processBundle(res: any) {
         this.currentTask = "Processing Each Bundle...";
+        this.gaService.gaTrackEvent('download', undefined, 'all files', "Data cart");
+
         this.messageColor = this.getColor();
 
         this.downloadService.downloadNextZip(this.zipData, this.dataFiles, this.dataCart);

--- a/angular/src/app/datacart/bundleplan/bundleplan.component.ts
+++ b/angular/src/app/datacart/bundleplan/bundleplan.component.ts
@@ -100,26 +100,28 @@ export class BundleplanComponent implements OnInit {
         this.CART_CONSTANTS = CartConstants.cartConst;
 
         this.cartService._watchRemoteCommand((command) => {
-            switch(command.command) { 
-                case 'downloadSelected': { 
-                    if(command.data)
-                        this.selectedData = command.data;
-                        this.downloadAllFilesFromAPI();
+            if(this.inBrowser){
+                switch(command.command) { 
+                    case 'downloadSelected': { 
+                        if(command.data)
+                            this.selectedData = command.data;
+                            this.downloadAllFilesFromAPI();
+                        break; 
+                    } 
+                    case 'resetDownloadParams': {
+                        this.resetDownloadParams();
+                        break;
+                    }
+                    case 'cancelDownloadAll': {
+                        this.cancelDownloadAll();
+                        break;
+                    }
+                    default: { 
+                    //statements; 
                     break; 
+                    } 
                 } 
-                case 'resetDownloadParams': {
-                    this.resetDownloadParams();
-                    break;
-                }
-                case 'cancelDownloadAll': {
-                    this.cancelDownloadAll();
-                    break;
-                }
-                default: { 
-                   //statements; 
-                   break; 
-                } 
-             } 
+            }
         });
     }
 
@@ -138,8 +140,7 @@ export class BundleplanComponent implements OnInit {
 
         this.downloadService.watchDownloadProcessStatus().subscribe(
             value => {
-                if(value && this.downloadStarted)
-                {
+                if(value && this.downloadStarted && this.inBrowser){
                     this.downloadEndTime = new Date();
                     this.totalDownloadTime = this.downloadEndTime.getTime() / 1000 - this.downloadStartTime.getTime() / 1000;
                     this.overallStatus = 'complete';

--- a/angular/src/app/datacart/cart.service.ts
+++ b/angular/src/app/datacart/cart.service.ts
@@ -67,20 +67,22 @@ export class CartService {
     }
 
     /**
-     * Reset datafile download status
-     **/
-    resetDatafileDownloadStatus(dataFiles: any, dataCart: DataCart, downloadStatus: string) {
-        for (let i = 0; i < dataFiles.length; i++) {
-            if (dataFiles[i].children.length > 0) {
-                this.resetDatafileDownloadStatus(dataFiles[i].children, dataCart, downloadStatus);
-            } else {
-                dataFiles[i].data.downloadStatus = downloadStatus;
-                dataCart.setDownloadStatus(dataFiles[i].data.resId, dataFiles[i].data.filePath, downloadStatus);
-            }
-        }
-
-        dataCart.save();
-    }
+     * Reset datafile download status. Because this is a recursive function, the datacart should be opened and saved outside this function
+     * otherwise it will take a long time for a large dataset. 
+     * @param dataFiles 
+     * @param dataCart 
+     * @param downloadStatus 
+     */
+    // resetDatafileDownloadStatus(dataFiles: any, dataCart: DataCart, downloadStatus: string) {
+    //     for (let i = 0; i < dataFiles.length; i++) {
+    //         if (dataFiles[i].children.length > 0) {
+    //             this.resetDatafileDownloadStatus(dataFiles[i].children, dataCart, downloadStatus);
+    //         } else {
+    //             dataFiles[i].data.downloadStatus = downloadStatus;
+    //             dataCart.setDownloadStatus(dataFiles[i].data.resId, dataFiles[i].data.filePath, downloadStatus);
+    //         }
+    //     }
+    // }
 
     /**
      * Return "download" button color based on download status

--- a/angular/src/app/datacart/cart.service.ts
+++ b/angular/src/app/datacart/cart.service.ts
@@ -67,24 +67,6 @@ export class CartService {
     }
 
     /**
-     * Reset datafile download status. Because this is a recursive function, the datacart should be opened and saved outside this function
-     * otherwise it will take a long time for a large dataset. 
-     * @param dataFiles 
-     * @param dataCart 
-     * @param downloadStatus 
-     */
-    // resetDatafileDownloadStatus(dataFiles: any, dataCart: DataCart, downloadStatus: string) {
-    //     for (let i = 0; i < dataFiles.length; i++) {
-    //         if (dataFiles[i].children.length > 0) {
-    //             this.resetDatafileDownloadStatus(dataFiles[i].children, dataCart, downloadStatus);
-    //         } else {
-    //             dataFiles[i].data.downloadStatus = downloadStatus;
-    //             dataCart.setDownloadStatus(dataFiles[i].data.resId, dataFiles[i].data.filePath, downloadStatus);
-    //         }
-    //     }
-    // }
-
-    /**
      * Return "download" button color based on download status
      */
     getDownloadStatusColor(downloadStatus: string) {

--- a/angular/src/app/datacart/cart.spec.ts
+++ b/angular/src/app/datacart/cart.spec.ts
@@ -214,7 +214,7 @@ describe('DataCart', () => {
         expect(dc.size()).toEqual(0);
         expect(localStorage.getItem("cart:cart")).toEqual("{}");
 
-        dc.addFile("foo", { filePath: "bar/goo", count: 3, downloadURL: "http://here" });
+        dc.addFile("foo", { filePath: "bar/goo", count: 3, downloadURL: "http://here" }, false, true);
         expect(dc.size()).toEqual(1);
         expect(parseCart(localStorage.getItem("cart:cart"))).toEqual(dc.contents);
         let file = dc.findFile("foo", "bar/goo");
@@ -224,7 +224,7 @@ describe('DataCart', () => {
         expect(file['downloadURL']).toEqual("http://here");
         expect(file['count']).toEqual(3);
 
-        dc.addFile("foo", { filePath: "bar/good", count: 8, downloadURL: "http://here" });
+        dc.addFile("foo", { filePath: "bar/good", count: 8, downloadURL: "http://here" }, false, true);
         expect(dc.size()).toEqual(2);
         expect(parseCart(localStorage.getItem("cart:cart"))).toEqual(dc.contents);
         file = dc.findFile("foo", "bar/good");
@@ -234,7 +234,7 @@ describe('DataCart', () => {
         expect(file['downloadURL']).toEqual("http://here");
         expect(file['count']).toEqual(8);
 
-        dc.addFile("foo", { filePath: "bar/goo", count: 1, downloadStatus: "downloaded", downloadURL: "http://here" });
+        dc.addFile("foo", { filePath: "bar/goo", count: 1, downloadStatus: "downloaded", downloadURL: "http://here" }, false, true);
         expect(dc.size()).toEqual(2);
         expect(parseCart(localStorage.getItem("cart:cart"))).toEqual(dc.contents);
         file = dc.findFile("foo", "bar/goo");

--- a/angular/src/app/datacart/cart.ts
+++ b/angular/src/app/datacart/cart.ts
@@ -222,7 +222,7 @@ export class DataCart {
      * @param resid   a repository-local identifier for the resource that the file is from
      * @param file    the DataCartItem or NerdmComp that describes the file being added.
      */
-    addFile(resid: string, file: DataCartItem|NerdmComp, markSelected: boolean = false) : void {
+    addFile(resid: string, file: DataCartItem|NerdmComp, markSelected: boolean = false, savecart:boolean = false) : void {
         let fail = function(msg: string) : void {
             console.error("Unable to load file NERDm component: "+msg+": "+JSON.stringify(file));
         }
@@ -236,6 +236,8 @@ export class DataCart {
             item['downloadStatus'] = "";
         item['isSelected'] = markSelected;
         this.addItem(item);
+
+        if(savecart) this.save();
     }
 
     /**

--- a/angular/src/app/datacart/cart.ts
+++ b/angular/src/app/datacart/cart.ts
@@ -83,7 +83,7 @@ export class DataCart {
     // Different listeners--namely a landing page and a data cart window--are not expected to execute
     // in the same runtime space; thus, they can't share their updates to a cart in real time via a Subject
     // 
-    private _statusUpdated = new BehaviorSubject<boolean>(false);   // for alerts about changes to the cart
+    // private _statusUpdated = new BehaviorSubject<boolean>(false);   // for alerts about changes to the cart
 
     /**
      * initialize this cart.  This is not intended to be called directly by users; the static functions
@@ -199,7 +199,12 @@ export class DataCart {
         return this.findFileById(this._idFor(item['resId'], item['filePath']));
     }
 
-    private _idFor(resId: string, filePath: string) { return resId+'/'+filePath; }
+    private _idFor(resId: string, filePath: string) { 
+        if(filePath[0] != '/')
+            return resId+'/'+filePath; 
+        else 
+            return resId+filePath; 
+    }
     private _idForItem(item: DataCartItem) {
         return this._idFor(item['resId'], item['filePath']);
     }
@@ -208,10 +213,8 @@ export class DataCart {
      * add a DataCartItem to the cart
      */
     addItem(item: DataCartItem) : void {
-        this.restore();
         this.contents[this._idForItem(item)] = item;
-        this.save();
-        this._statusUpdated.next(true);
+        // this._statusUpdated.next(true);
     }
 
     /**
@@ -227,14 +230,12 @@ export class DataCart {
         if (! file['filePath']) return fail("missing component property, filePath");
         if (! file['downloadURL']) return fail("missing component property, downloadURL");
 
-        this.restore();
         let item = JSON.parse(JSON.stringify(file));
         item['resId'] = resid;
         if (item['downloadStatus'] === undefined)
             item['downloadStatus'] = "";
         item['isSelected'] = markSelected;
         this.addItem(item);
-        this.save();
     }
 
     /**
@@ -243,16 +244,70 @@ export class DataCart {
      * @param filePath  the path to the file within the resource collection to remove.
      * @return boolean -- true if the file was found to be in the cart and then removed. 
      */
-    public removeFileById(resid: string, filePath: string) : boolean {
-        this.restore();
+    public removeFileById(resid: string, filePath: string, updateCart: boolean = false) : boolean {
+        if(updateCart) this.restore();
+
         let id = this._idFor(resid, filePath);
 
         let found = this.contents[id];
-        if (found) 
+        if (found){ 
             delete this.contents[id];
+        }else{
+            console.log("this.contents ", this.contents);
+            console.log("Not found ", id);
+        }
 
-        this.save();
+        if(updateCart) this.save();
         return !!found;
+    }
+
+    /**
+     * Remove all files from cart - used by removeFilesFromCart()
+     * @param files - file tree
+     */
+    removeFromTree(files: TreeNode[]) {
+        for (let comp of files) {
+            if (comp.children.length > 0) {
+                comp.data.isIncart = false;
+                this.removeFromTree(comp.children);
+            } else {
+                this.removeFileById(comp.data.resId,comp.data.filePath);
+                // this.cartService.removeCartId(comp.data.cartId);
+                comp.data.isIncart = false;
+            }
+        }
+    }
+
+    /**
+     * Reset datafile download status. Because this is a recursive function, the datacart should be opened and saved outside this function
+     * otherwise it will take a long time for a large dataset. 
+     * @param dataFiles 
+     * @param dataCart 
+     * @param downloadStatus 
+     */
+    resetDatafileDownloadStatus(dataFiles: any, downloadStatus: string) {
+        for (let i = 0; i < dataFiles.length; i++) {
+            if (dataFiles[i].children.length > 0) {
+                this.resetDatafileDownloadStatus(dataFiles[i].children, downloadStatus);
+            } else {
+                dataFiles[i].data.downloadStatus = downloadStatus;
+                this.setDownloadStatus(dataFiles[i].data.resId, dataFiles[i].data.filePath, downloadStatus);
+            }
+        }
+    }
+
+    /**
+     * Remove the selected data from the data cart
+     * @param selectedData 
+     */
+    removeSelectedData(selectedData: any){
+        for (let selData of selectedData) {
+            if(!selData.data.isLeaf){
+                    this.removeSelectedData(selData.children);
+            }else{
+                this.removeFileById(selData.data['resId'], selData.data['resFilePath'])
+            }
+        }
     }
 
     /**
@@ -275,16 +330,20 @@ export class DataCart {
      * @return boolean -- true if the identified file was found in this cart and its status updated; 
      *                    false, otherwise.
      */
-    public setDownloadStatus(resid: string, filePath: string, downloadedStatus: string = "downloaded") : boolean {
-        this.restore();
+    public setDownloadStatus(resid: string, filePath: string, downloadedStatus: string = "downloaded", updateCart:boolean = false) : boolean {
         
+        if(updateCart) this.restore();
+
         let item: DataCartItem = this.findFile(resid, filePath);
-        if (! item)
+        if (! item){
+            console.log("Not found", resid + '/' + filePath);
             return false;
+        }
 
         item.downloadStatus = downloadedStatus;
-        this.save();
-        this._statusUpdated.next(true);
+
+        if(updateCart) this.save();
+        // this._statusUpdated.next(true);
 
         return true;
     }
@@ -339,15 +398,15 @@ export class DataCart {
      * @param filePath  the path to the file within the resource collection.
      * @param unselect  if true, unselect the referenced files rather than selecting them
      */
-    public setSelected(resid: string, filePath: string = '', unselect: boolean = false) : void {
-        this.restore();
-        let match = this.matchFiles(resid, filePath);
-        if (match.length) {
-            for (let file of match) 
-                file['isSelected'] = !unselect;
-            this.save();
-        }
-    }
+    // public setSelected(resid: string, filePath: string = '', unselect: boolean = false) : void {
+    //     this.restore();
+    //     let match = this.matchFiles(resid, filePath);
+    //     if (match.length) {
+    //         for (let file of match) 
+    //             file['isSelected'] = !unselect;
+    //         this.save();
+    //     }
+    // }
 
     /**
      * return an array containing DataCartItem objects for file part of a resource with a given resource ID
@@ -404,9 +463,9 @@ export class DataCart {
     /**
      * register to get alerts when files have been downloaded
      */
-    public watchForChanges(subscriber): void {
-        this._statusUpdated.subscribe(subscriber);
-    }
+    // public watchForChanges(subscriber): void {
+    //     this._statusUpdated.subscribe(subscriber);
+    // }
 
     /**
      * Return cart items as an array for display purpose

--- a/angular/src/app/datacart/cart.ts
+++ b/angular/src/app/datacart/cart.ts
@@ -252,9 +252,6 @@ export class DataCart {
         let found = this.contents[id];
         if (found){ 
             delete this.contents[id];
-        }else{
-            console.log("this.contents ", this.contents);
-            console.log("Not found ", id);
         }
 
         if(updateCart) this.save();
@@ -291,7 +288,7 @@ export class DataCart {
                 this.resetDatafileDownloadStatus(dataFiles[i].children, downloadStatus);
             } else {
                 dataFiles[i].data.downloadStatus = downloadStatus;
-                this.setDownloadStatus(dataFiles[i].data.resId, dataFiles[i].data.filePath, downloadStatus);
+                this.setDownloadStatus(dataFiles[i].data.resId, dataFiles[i].data.resFilePath, downloadStatus);
             }
         }
     }
@@ -336,7 +333,6 @@ export class DataCart {
 
         let item: DataCartItem = this.findFile(resid, filePath);
         if (! item){
-            console.log("Not found", resid + '/' + filePath);
             return false;
         }
 

--- a/angular/src/app/datacart/cartcontrol/cartcontrol.component.html
+++ b/angular/src/app/datacart/cartcontrol/cartcontrol.component.html
@@ -1,4 +1,4 @@
-<div class="top-banner" [ngStyle]="{ 'background-image': 'url(' + imageURL + ')'}">
+<div *ngIf="inBrowser" class="top-banner" [ngStyle]="{ 'background-image': 'url(' + imageURL + ')'}">
     <div class="inner-box">
         <span style="font-size: xx-large;" class="top-banner-text">
             <i class="faa faa-cloud-download faa-lg" style="padding-right: .5em;text-shadow: 1px 1px 2px darkgrey;"></i><label>Download Manager</label>

--- a/angular/src/app/datacart/cartcontrol/cartcontrol.component.html
+++ b/angular/src/app/datacart/cartcontrol/cartcontrol.component.html
@@ -1,7 +1,7 @@
 <div class="top-banner" [ngStyle]="{ 'background-image': 'url(' + imageURL + ')'}">
     <div class="inner-box">
         <span style="font-size: xx-large;" class="top-banner-text">
-            <i class="faa faa-cloud-download faa-lg" style="padding-right: .5em;"></i><label>Download Manager</label>
+            <i class="faa faa-cloud-download faa-lg" style="padding-right: .5em;text-shadow: 1px 1px 2px darkgrey;"></i><label>Download Manager</label>
         </span>
 
         <!-- Control buttons for large screen -->

--- a/angular/src/app/datacart/cartcontrol/cartcontrol.component.html
+++ b/angular/src/app/datacart/cartcontrol/cartcontrol.component.html
@@ -62,7 +62,7 @@
             <i class="faa faa-trash faa-1x icon-white" style="color: #fff;"></i>
             Remove selected
             <span class="w3-circle button-badge"
-                [ngStyle]="{'color':'rgb(82, 82, 82)'}">&nbsp;{{selectedFileCount}}&nbsp;</span>
+                [ngStyle]="{'color':'rgb(82, 82, 82)'}">&nbsp;{{selectedFileCount}&nbsp;</span>
         </button>
     </div>
 </div>

--- a/angular/src/app/datacart/cartcontrol/cartcontrol.component.ts
+++ b/angular/src/app/datacart/cartcontrol/cartcontrol.component.ts
@@ -18,7 +18,6 @@ export class CartcontrolComponent implements OnInit {
     totalDownloaded: number = 0; 
     inBrowser: boolean = false;
     noFileDownloaded: boolean = true; // will be true if any item in data cart is downloaded
-    // dataFiles: TreeNode[] = [];
 
     @Input() dataFiles: TreeNode[] = [];
 
@@ -38,9 +37,7 @@ export class CartcontrolComponent implements OnInit {
         this.downloadService.watchTotalFileDownloaded((value) => {
             this.totalDownloaded = value;
         });
-    }
 
-    ngOnInit() {
         this.downloadService.watchAnyFileDownloaded().subscribe(
             value => {
                 if(this.inBrowser){
@@ -51,6 +48,9 @@ export class CartcontrolComponent implements OnInit {
                 }
             }
         );
+    }
+
+    ngOnInit() {
     }
 
     /**

--- a/angular/src/app/datacart/cartcontrol/cartcontrol.component.ts
+++ b/angular/src/app/datacart/cartcontrol/cartcontrol.component.ts
@@ -1,8 +1,9 @@
-import { Component, OnInit, Input, Output, HostListener, SimpleChanges, EventEmitter } from '@angular/core';
+import { Component, OnInit, Input, Output, HostListener, Inject, PLATFORM_ID } from '@angular/core';
 import { TreeNode } from 'primeng/primeng';
 import { AppConfig } from '../../config/config';
 import { CartService } from '../cart.service';
 import { DownloadService } from '../../shared/download-service/download-service.service';
+import { isPlatformBrowser } from '@angular/common';
 
 @Component({
   selector: 'app-cartcontrol',
@@ -12,19 +13,22 @@ import { DownloadService } from '../../shared/download-service/download-service.
 export class CartcontrolComponent implements OnInit {
     imageURL: string = 'assets/images/sdp-background.jpg';
     selectedFileCount: number = 0;
-    screenWidth: number;
+    screenWidth: number = 1080;
     screenSizeBreakPoint: number;
     totalDownloaded: number = 0; 
+    inBrowser: boolean = false;
     noFileDownloaded: boolean = true; // will be true if any item in data cart is downloaded
-    
+    // dataFiles: TreeNode[] = [];
+
     @Input() dataFiles: TreeNode[] = [];
-    @Input() inBrowser: boolean;
 
     constructor(
         private cfg: AppConfig,
         private downloadService: DownloadService,
-        public cartService: CartService
+        public cartService: CartService,
+        @Inject(PLATFORM_ID) private platformId: Object
     ) { 
+        this.inBrowser = isPlatformBrowser(platformId);
         this.screenSizeBreakPoint = +this.cfg.get("screenSizeBreakPoint", "1060");
 
         this.cartService.watchSelectedFileCount((value) => {
@@ -49,18 +53,6 @@ export class CartcontrolComponent implements OnInit {
         );
     }
 
-    getDownloadStatusColor(downloadStatus: string){
-        return this.cartService.getDownloadStatusColor(downloadStatus);
-    }
-
-    getStatusForDisplay(downloadStatus: string){
-        return this.cartService.getStatusForDisplay(downloadStatus);
-    }
-
-    getIconClass(downloadStatus: string){
-        return this.cartService.getIconClass(downloadStatus);
-    }
-
     /**
      *  Following functions detect screen size
      */
@@ -81,9 +73,9 @@ export class CartcontrolComponent implements OnInit {
         }, 0);
     }
 
-    /*
-        Return button color based on Downloaded status
-    */
+    /**
+     * Return button color based on Downloaded status
+     */
     getButtonColor() {
         if (this.noFileDownloaded) {
             return "#1E6BA1";
@@ -92,9 +84,9 @@ export class CartcontrolComponent implements OnInit {
         }
     }
 
-    /*
-        Return text color for Remove Downloaded badge
-    */
+    /**
+     * Return text color for Remove Downloaded badge
+     */
     getDownloadedColor() {
         if (this.noFileDownloaded) {
             return "rgb(82, 82, 82)";
@@ -103,9 +95,9 @@ export class CartcontrolComponent implements OnInit {
         }
     }
 
-    /*
-        Return background color for Remove Downloaded badge
-    */
+    /**
+     * Return background color for Remove Downloaded badge
+     */
     getDownloadedBkColor() {
         if (this.noFileDownloaded) {
             return "white";
@@ -115,7 +107,11 @@ export class CartcontrolComponent implements OnInit {
     }
 
     /**
-     *  Download selected files
+     * Issue a command (from control buttons)
+     *      - Download selected
+     *      - Remove selected
+     *      - Remove downloaded
+     * @param command 
      */
     executeCommand(command: string){
         this.cartService.executeCommand(command);

--- a/angular/src/app/datacart/cartcontrol/cartcontrol.component.ts
+++ b/angular/src/app/datacart/cartcontrol/cartcontrol.component.ts
@@ -18,6 +18,7 @@ export class CartcontrolComponent implements OnInit {
     noFileDownloaded: boolean = true; // will be true if any item in data cart is downloaded
     
     @Input() dataFiles: TreeNode[] = [];
+    @Input() inBrowser: boolean;
 
     constructor(
         private cfg: AppConfig,
@@ -38,9 +39,11 @@ export class CartcontrolComponent implements OnInit {
     ngOnInit() {
         this.downloadService.watchAnyFileDownloaded().subscribe(
             value => {
-                this.noFileDownloaded = !value;
-                if (value) {
-                    this.downloadService.setTotalFileDownloaded(this.downloadService.getTotalDownloadedFiles(this.dataFiles));
+                if(this.inBrowser){
+                    this.noFileDownloaded = !value;
+                    if (value) {
+                        this.downloadService.setTotalFileDownloaded(this.downloadService.getTotalDownloadedFiles(this.dataFiles));
+                    }
                 }
             }
         );
@@ -72,7 +75,9 @@ export class CartcontrolComponent implements OnInit {
 
     private detectScreenSize() {
         setTimeout(() => {
-            this.screenWidth = window.innerWidth;
+            if(this.inBrowser){
+                this.screenWidth = window.innerWidth;
+            }
         }, 0);
     }
 

--- a/angular/src/app/datacart/datacart.component.html
+++ b/angular/src/app/datacart/datacart.component.html
@@ -1,5 +1,5 @@
 <!-- Top banner -->
-<app-cartcontrol [dataFiles]="dataFiles"></app-cartcontrol>
+<app-cartcontrol [inBrowser]="inBrowser" [dataFiles]="dataFiles"></app-cartcontrol>
 
 <!-- Bundle plan -->
 <app-bundleplan [inBrowser]="inBrowser" [dataFiles]="dataFiles" [selectedData]="selectedData" [ediid]="ediid" (outputZipData)="updateZipDafa($event)" (outputOverallStatus)=updateOverallStatus($event)></app-bundleplan>

--- a/angular/src/app/datacart/datacart.component.html
+++ b/angular/src/app/datacart/datacart.component.html
@@ -1,8 +1,8 @@
 <!-- Top banner -->
-<app-cartcontrol [inBrowser]="inBrowser" [dataFiles]="dataFiles"></app-cartcontrol>
+<app-cartcontrol [dataFiles]="dataFiles"></app-cartcontrol>
 
 <!-- Bundle plan -->
-<app-bundleplan [inBrowser]="inBrowser" [dataFiles]="dataFiles" [selectedData]="selectedData" [ediid]="ediid" (outputZipData)="updateZipDafa($event)" (outputOverallStatus)=updateOverallStatus($event)></app-bundleplan>
+<app-bundleplan [dataFiles]="dataFiles" [selectedData]="selectedData" [ediid]="ediid" (outputZipData)="updateZipDafa($event)" (outputOverallStatus)=updateOverallStatus($event)></app-bundleplan>
 
 <!-- Tree table -->
-<app-treetable [ediid]="ediid" [inBrowser]="inBrowser" [zipData]="zipData" (outputDataFiles)="updateDafaFiles($event)" (outputSelectedData)="updateSelectedData($event)"></app-treetable>
+<app-treetable [ediid]="ediid" [zipData]="zipData" (outputDataFiles)="updateDafaFiles($event)" (outputSelectedData)="updateSelectedData($event)"></app-treetable>

--- a/angular/src/app/datacart/datacart.component.ts
+++ b/angular/src/app/datacart/datacart.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, PLATFORM_ID, Inject, ViewChild } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import 'rxjs/add/operator/map';
 import { TreeNode } from 'primeng/primeng';
 import { CartConstants } from './cartconstants';
@@ -37,6 +37,7 @@ export class DatacartComponent extends FormCanDeactivate implements OnInit {
      */
     constructor( 
         private route: ActivatedRoute,
+        private router: Router,
         public cartService: CartService,
         @Inject(PLATFORM_ID) private platformId: Object ) 
     {
@@ -50,8 +51,13 @@ export class DatacartComponent extends FormCanDeactivate implements OnInit {
      * Get the params OnInit
      */
     ngOnInit() {
+        let currentUrl = this.router.url;
+
         this.routerparams = this.route.params.subscribe(params => {
-            this.ediid = params['ediid'];
+            if(currentUrl.indexOf("ark:/88434") >= 0)
+                this.ediid = 'ark:/88434/' + params['ediid'];
+            else
+                this.ediid = params['ediid'];
         })
     }
 

--- a/angular/src/app/datacart/datacart.component.ts
+++ b/angular/src/app/datacart/datacart.component.ts
@@ -28,6 +28,8 @@ export class DatacartComponent extends FormCanDeactivate implements OnInit {
     CART_CONSTANTS: any;
     zipData: ZipData[] = [];
 
+    // overallStatus is used in can-deactivate component. If overallStatus is not 'completed'
+    // and user tried to close the tab, a warning dialog will pop up.
     @ViewChild('overallStatus')
     overallStatus: string = "";
 
@@ -82,6 +84,7 @@ export class DatacartComponent extends FormCanDeactivate implements OnInit {
      * @param zipData zipDta from bundlePlan component
      */
     updateZipDafa(zipData: ZipData[]){
+        console.log("Updating zipData...");
         this.zipData = zipData;
     }
 

--- a/angular/src/app/datacart/datacart.component.ts
+++ b/angular/src/app/datacart/datacart.component.ts
@@ -84,7 +84,6 @@ export class DatacartComponent extends FormCanDeactivate implements OnInit {
      * @param zipData zipDta from bundlePlan component
      */
     updateZipDafa(zipData: ZipData[]){
-        console.log("Updating zipData...");
         this.zipData = zipData;
     }
 

--- a/angular/src/app/datacart/datacart.module.ts
+++ b/angular/src/app/datacart/datacart.module.ts
@@ -13,6 +13,8 @@ import { TreeTableModule } from 'primeng/treetable';
 import { ButtonModule } from 'primeng/button';
 import { TooltipModule } from 'primeng/tooltip';
 import { TreetableComponent } from './treetable/treetable.component';
+import { CanDeactivateGuard } from '../can-deactivate/can-deactivate.guard';
+
 
 @NgModule({
   declarations: [ 
@@ -31,7 +33,10 @@ import { TreetableComponent } from './treetable/treetable.component';
     DownloadConfirmComponent
   ],
   providers: [
-    CartService
+    CartService,
+    CanDeactivateGuard
   ]
 })
-export class DatacartModule { }
+export class DatacartModule {
+
+ }

--- a/angular/src/app/datacart/datacart.routes.ts
+++ b/angular/src/app/datacart/datacart.routes.ts
@@ -5,8 +5,14 @@ import {CanDeactivateGuard} from '../can-deactivate/can-deactivate.guard';
 export const DatacartRoutes: Routes = [
 
   {
-    path: 'datacart/:ediid',
-    component: DatacartComponent,
-    canDeactivate: [CanDeactivateGuard]
+    path: 'datacart',
+    children: [
+        {   path: ':ediid',             
+            component: DatacartComponent,
+            canDeactivate: [CanDeactivateGuard]   },
+        {   path: 'ark:/88434/:ediid',  
+            component: DatacartComponent,
+            canDeactivate: [CanDeactivateGuard]   }
+    ]
   }
 ];

--- a/angular/src/app/datacart/download-confirm/download-confirm.component.ts
+++ b/angular/src/app/datacart/download-confirm/download-confirm.component.ts
@@ -28,7 +28,6 @@ export class DownloadConfirmComponent implements OnInit {
     ngOnInit() 
     {
         this.bundleSizeAlert = +this.cfg.get("bundleSizeAlert", "1000000000");
-        console.log('bundleSizeAlert', this.bundleSizeAlert);
     }
 
     /**

--- a/angular/src/app/datacart/download-confirm/download-confirm.component.ts
+++ b/angular/src/app/datacart/download-confirm/download-confirm.component.ts
@@ -31,8 +31,8 @@ export class DownloadConfirmComponent implements OnInit {
         console.log('bundleSizeAlert', this.bundleSizeAlert);
     }
 
-    /* 
-     *   Return true when user click on Continue Download
+    /**
+     * When user clicks on Continue Download, close the pop up dialog and continue downloading.
      */
     ContinueDownload() 
     {
@@ -40,8 +40,8 @@ export class DownloadConfirmComponent implements OnInit {
         this.activeModal.close('Close click');
     }
 
-    /* 
-     *   Return false when user click on Cancel button
+    /** 
+     * When user click on Cancel, close the pop up dialog and do nothing.
      */
     CancelDownload() 
     {

--- a/angular/src/app/datacart/treetable/treetable.component.html
+++ b/angular/src/app/datacart/treetable/treetable.component.html
@@ -1,6 +1,6 @@
 <div style="display: inline-block; margin: auto;">
     <div class="full-span" style="width: 94%;">
-        <p-treeTable *ngIf="isVisible" [resizableColumns]="true" selectionMode="checkbox" [value]="dataFiles"
+        <p-treeTable *ngIf="isVisible && inBrowser" [resizableColumns]="true" selectionMode="checkbox" [value]="dataFiles"
             (onNodeSelect)="dataFileCount()" (onNodeUnselect)="dataFileCount()" [(selection)]="selectedData"
             [style]="{'margin':'auto', 'padding-bottom':'3%', 'color':'black'}">
             <ng-template pTemplate="header">

--- a/angular/src/app/datacart/treetable/treetable.component.html
+++ b/angular/src/app/datacart/treetable/treetable.component.html
@@ -1,7 +1,7 @@
 <div style="display: inline-block; margin: auto;">
     <div class="full-span" style="width: 94%;">
         <p-treeTable *ngIf="isVisible && inBrowser" [resizableColumns]="true" selectionMode="checkbox" [value]="dataFiles"
-            (onNodeSelect)="dataFileCount()" (onNodeUnselect)="dataFileCount()" [(selection)]="selectedData"
+            (onNodeSelect)="selectedDataFileCount(true)" (onNodeUnselect)="selectedDataFileCount(true)" [(selection)]="selectedData"
             [style]="{'margin':'auto', 'padding-bottom':'3%', 'color':'black'}">
             <ng-template pTemplate="header">
                 <tr>

--- a/angular/src/app/datacart/treetable/treetable.component.html
+++ b/angular/src/app/datacart/treetable/treetable.component.html
@@ -14,8 +14,7 @@
                                 style="cursor: pointer;color: rgb(255, 255, 255);" data-toggle="tooltip"
                                 title="Collapse All"></i>
                         </span>
-                        <span (click)="showZipFilesNames = !showZipFilesNames" style="padding-right:0.5em;"
-                            *ngIf="zipData.length>0">
+                        <span (click)="showZipFilesNames = !showZipFilesNames" style="padding-right:0.5em;">
                             <i *ngIf="!showZipFilesNames" class="faa faa-eye faa-1x icon-white"
                                 style="cursor: pointer;color: rgb(255, 255, 255);" data-toggle="tooltip"
                                 title="Show Zip Files"></i>
@@ -25,11 +24,11 @@
                         </span>
                         Name
                     </th>
+                    <th [ngStyle]="headerStyle(typeWidth)" ttResizableColumn>Media Type</th>
+                    <th [ngStyle]="headerStyle(sizeWidth)" ttResizableColumn>Size</th>
                     <th [ngStyle]="headerStyle(actionWidth)" ttResizableColumn>
                         <i class="faa faa-cloud-download" aria-hidden="true" data-toggle="tooltip" title="Actions"></i>
                     </th>
-                    <th [ngStyle]="headerStyle(typeWidth)" ttResizableColumn>Media Type</th>
-                    <th [ngStyle]="headerStyle(sizeWidth)" ttResizableColumn>Size</th>
                     <th [ngStyle]="headerStyle(statusWidth)" ttResizableColumn>
                         Status
                         <div class="badge status-reset-button" (click)="clearDownloadStatus()" data-toggle="tooltip"
@@ -53,6 +52,12 @@
                         <span *ngIf="showZipFilesNames" style="color:grey;margin-left: 1em;font-style: italic;">
                             {{rowData.zipFile}}</span>
                     </td>
+                    <td [ngStyle]="bodyStyle(typeWidth)">
+                        <span>{{rowData.mediatype}}</span>
+                    </td>
+                    <td [ngStyle]="bodyStyle(sizeWidth)">
+                        <span *ngIf="rowData.isLeaf">{{formatBytes(rowData.fileSize)}}</span>
+                    </td>
                     <td [ngStyle]="bodyStyle(sizeWidth)">
                         <div *ngIf="rowData.isLeaf;else space_holder" style="display:inline;color: green;" >
                             <a *ngIf="rowData.downloadStatus != 'downloading'" href='{{rowData.downloadUrl}}' target='_blank' download="download" data-toggle="tooltip" 
@@ -69,12 +74,6 @@
                         <ng-template #space_holder>
                             <div style="display:inline;padding-right: 0.4em;">&nbsp;&nbsp;</div>
                         </ng-template>
-                    </td>
-                    <td [ngStyle]="bodyStyle(typeWidth)">
-                        <span>{{rowData.mediatype}}</span>
-                    </td>
-                    <td [ngStyle]="bodyStyle(sizeWidth)">
-                        <span *ngIf="rowData.isLeaf">{{formatBytes(rowData.fileSize)}}</span>
                     </td>
                     <td [ngStyle]="bodyStyle(statusWidth)">
                         <div id="downloadstatus" *ngIf="rowData.isLeaf" style="display:inline;"

--- a/angular/src/app/datacart/treetable/treetable.component.html
+++ b/angular/src/app/datacart/treetable/treetable.component.html
@@ -1,6 +1,6 @@
-<div style="display: inline-block; margin: auto;">
+<div *ngIf="inBrowser" style="display: inline-block; margin: auto;">
     <div class="full-span" style="width: 94%;">
-        <p-treeTable *ngIf="isVisible && inBrowser" [resizableColumns]="true" selectionMode="checkbox" [value]="dataFiles"
+        <p-treeTable *ngIf="isVisible" [resizableColumns]="true" selectionMode="checkbox" [value]="dataFiles"
             (onNodeSelect)="selectedDataFileCount(true)" (onNodeUnselect)="selectedDataFileCount(true)" [(selection)]="selectedData"
             [style]="{'margin':'auto', 'padding-bottom':'3%', 'color':'black'}">
             <ng-template pTemplate="header">

--- a/angular/src/app/datacart/treetable/treetable.component.ts
+++ b/angular/src/app/datacart/treetable/treetable.component.ts
@@ -477,7 +477,7 @@ export class TreetableComponent implements OnInit {
      * @param rowData - tree node that the file was downloaded
      */
     setFileDownloaded(rowData: any) {
-        // Google Analytics code to track download event
+            // Google Analytics code to track download event
         this.gaService.gaTrackEvent('download', undefined, rowData.ediid, rowData.downloadUrl);
 
         rowData.downloadStatus = 'downloaded';

--- a/angular/src/app/datacart/treetable/treetable.component.ts
+++ b/angular/src/app/datacart/treetable/treetable.component.ts
@@ -62,16 +62,18 @@ export class TreetableComponent implements OnInit {
         private ngZone: NgZone
     ) { 
         this.CART_CONSTANTS = CartConstants.cartConst;
-        this.mobHeight = (window.innerHeight);
-        this.mobWidth = (window.innerWidth);
-        this.setWidth(this.mobWidth);
-        window.onresize = (e) => {
-            ngZone.run(() => {
-                this.mobWidth = window.innerWidth;
-                this.mobHeight = window.innerHeight;
-                this.setWidth(this.mobWidth);
-            });
-        };
+        if(this.inBrowser){
+            this.mobHeight = (window.innerHeight);
+            this.mobWidth = (window.innerWidth);
+            this.setWidth(this.mobWidth);
+            window.onresize = (e) => {
+                ngZone.run(() => {
+                    this.mobWidth = window.innerWidth;
+                    this.mobHeight = window.innerHeight;
+                    this.setWidth(this.mobWidth);
+                });
+            };
+        }
 
         // Watch remote command from cartControl component
         // removeDownloaded - remove downloaded files from the data cart
@@ -143,7 +145,6 @@ export class TreetableComponent implements OnInit {
         this.dataFileCount();
         this.expandToLevel(this.dataFiles, true, 3);
         this.outputDataFiles.emit(this.dataFiles);
-        console.log('this.dataFiles', this.dataFiles);
 
         if (this.ediid != this.CART_CONSTANTS.GLOBAL_CART_NAME) {
             if(this.dataFiles[0])
@@ -447,7 +448,6 @@ export class TreetableComponent implements OnInit {
      * This is where dafaFiles get generated
      */
     createDataCartHierarchy() {
-        console.log('this.dataCart', this.dataCart);
         let arrayList = this.dataCart.getCartItems().reduce(function (result, current) {
             result[current.resTitle] = result[current.resTitle] || [];
             result[current.resTitle].push({data:current});

--- a/angular/src/app/datacart/treetable/treetable.component.ts
+++ b/angular/src/app/datacart/treetable/treetable.component.ts
@@ -596,8 +596,12 @@ export class TreetableComponent implements OnInit {
      * Make sure the width of popup dialog is less than 500px or 80% of the window width
      */
     getDialogWidth() {
-        var w = window.innerWidth > 500 ? 500 : window.innerWidth;
-        return w + 'px';
+        if(this.inBrowser){
+            var w = window.innerWidth > 500 ? 500 : window.innerWidth;
+            return w + 'px';
+        }else{
+            return '500px';
+        }
     }
 
     /**

--- a/angular/src/app/datacart/treetable/treetable.component.ts
+++ b/angular/src/app/datacart/treetable/treetable.component.ts
@@ -80,20 +80,22 @@ export class TreetableComponent implements OnInit {
         // removeSelected - remove selected files from the data cart
 
         this.cartService._watchRemoteCommand((command) => {
-            switch(command.command) { 
-                case 'removeDownloaded': { 
-                   this.removeAllDownloadedFiles();
-                   break; 
+            if(this.inBrowser){
+                switch(command.command) { 
+                    case 'removeDownloaded': { 
+                    this.removeAllDownloadedFiles();
+                    break; 
+                    } 
+                    case 'removeSelected': {
+                        this.removeSelectedData();
+                        break;
+                    }
+                    default: { 
+                    //statements; 
+                    break; 
+                    } 
                 } 
-                case 'removeSelected': {
-                    this.removeSelectedData();
-                    break;
-                }
-                default: { 
-                   //statements; 
-                   break; 
-                } 
-             } 
+            }
         });
     }
 
@@ -284,7 +286,7 @@ export class TreetableComponent implements OnInit {
         setTimeout(() => {
             this.expandToLevel(this.dataFiles, true, 1);
         }, 0);
-        this.refreTree();
+        this.refreshTree();
     }
     
     /**
@@ -400,13 +402,13 @@ export class TreetableComponent implements OnInit {
             }
         }
         this.isExpanded = option;
-        this.refreTree();
+        this.refreshTree();
     }
 
     /**
      * Refresh the tree table
      */
-    refreTree(){
+    refreshTree(){
         this.isVisible = false;
         setTimeout(() => {
             this.isVisible = true;

--- a/angular/src/app/directives/contenteditable-model.directive.ts
+++ b/angular/src/app/directives/contenteditable-model.directive.ts
@@ -66,7 +66,7 @@ export class ContenteditableModel implements OnInit, OnChanges {
     this.elRef.nativeElement.focus()
   }
 
-  /*
+  /**
    * Below will be triggered if source is modified in aside section
    */
   ngOnChanges(changes: SimpleChanges) {

--- a/angular/src/app/form-can-deactivate/form-can-deactivate.ts
+++ b/angular/src/app/form-can-deactivate/form-can-deactivate.ts
@@ -6,7 +6,6 @@ export abstract class FormCanDeactivate extends ComponentCanDeactivate{
  abstract get overallStatus():string;
  
  canDeactivate():boolean{
-     console.log('this.overallStatus', this.overallStatus);
      return (this.overallStatus != "downloading");
   }
 }

--- a/angular/src/app/landing/author/author.component.ts
+++ b/angular/src/app/landing/author/author.component.ts
@@ -123,7 +123,7 @@ export class AuthorComponent implements OnInit {
                 }
 
                 postMessage[this.fieldName] = JSON.parse(JSON.stringify(authors));
-                console.log("postMessage", postMessage);
+                // console.log("postMessage", postMessage);
 
                 this.mdupdsvc.update(this.fieldName, postMessage).then((updateSuccess) => {
                     // console.log("###DBG  update sent; success: "+updateSuccess.toString());

--- a/angular/src/app/landing/contact/contact.component.ts
+++ b/angular/src/app/landing/contact/contact.component.ts
@@ -82,7 +82,7 @@ export class ContactComponent implements OnInit {
             if (returnValue) {
                 var postMessage: any = {};
                 postMessage[this.fieldName] = returnValue[this.fieldName];
-                console.log("postMessage", JSON.stringify(postMessage));
+                // console.log("postMessage", JSON.stringify(postMessage));
 
                 this.mdupdsvc.update(this.fieldName, postMessage).then((updateSuccess) => {
                     // console.log("###DBG  update sent; success: "+updateSuccess.toString());

--- a/angular/src/app/landing/data-files/data-files.component.html
+++ b/angular/src/app/landing/data-files/data-files.component.html
@@ -1,5 +1,5 @@
 <!-- This bloack is for the data access session of landing page -->
-<div id="dataAccess">
+<div *ngIf="inBrowser" id="dataAccess">
     <div class="font14" [hidden]="metadata">
         <h3><b>Data Access</b></h3><br>
         
@@ -152,6 +152,8 @@
                                                 aria-hidden="true"></i>
                                             <span class="sr-only">Hidden text for 508 compliance</span>
                                         </a>
+                                        <p-progressSpinner *ngIf="rowData.downloadStatus == 'downloading'"
+                                        [style]="{width: '12px', height: '12px', 'margin-right': '.5em'}"></p-progressSpinner>
                                     </div>
                                     <ng-template #space_holder>
                                         <div style="padding-right: 0.4em;">&nbsp;&nbsp;</div>

--- a/angular/src/app/landing/data-files/data-files.component.html
+++ b/angular/src/app/landing/data-files/data-files.component.html
@@ -73,20 +73,25 @@
                                 data-toggle="tooltip" title="Download all files"
                                 [ngStyle]="{'color':getDownloadAllBtnColor(),'cursor':'pointer'}">
                                 <i class="faa faa-circle-thin faa-stack-2x" aria-hidden="true"></i>
-                                <i class="faa faa-download faa-stack-1x" aria-hidden="true"></i>
+                                <!-- <i class="faa faa-download faa-stack-1x" aria-hidden="true"></i> -->
+                                <i *ngIf="!addingToCart; else show_spinner1" class="faa faa-download faa-stack-1x"
+                                aria-hidden="true"></i>
+                                <ng-template #show_spinner1><i class="faa faa-spinner faa-spin faa-stack-1x"
+                                        style="color:#1E6BA1" aria-hidden="true"></i></ng-template>
                             </a>
                             <a id="routeToDatacart" target="_blank" [routerLink]="['/datacart', 'popup']"
                                 style="display:none"></a>
-                            <span *ngIf="!editEnabled" class="faa-stack fa-lg icon-cart addalltocart"
+                            <span *ngIf="!editEnabled" class="faa-stack fa-lg icon-cart"
                                 (click)="cartProcess(files)"
-                                [ngStyle]="{'color':getAddAllToDataCartBtnColor(),'cursor':'pointer','margin-right':'1em'}"
+                                [ngStyle]="{'color':getAddAllToDataCartBtnColor(), 'cursor': 'pointer',
+                                'margin-right': '1em'}"
                                 data-toggle="tooltip" [title]="getCartProcessTooltip()">
                                 <i class="faa faa-circle-thin faa-stack-2x" aria-hidden="true"></i>
                                 <i *ngIf="!isLocalProcessing; else show_spinner" class="faa faa-cart-plus faa-stack-1x"
                                     aria-hidden="true"></i>
                                 <ng-template #show_spinner><i class="faa faa-spinner faa-spin faa-stack-1x"
                                         style="color:#1E6BA1" aria-hidden="true"></i></ng-template>
-                                <span class="w3-badge badge-notify" style="margin-right:0.5em;">{{cartLength}}</span>
+                                <span class="w3-badge badge-notify" style="margin-right:0em;">{{cartLength}}</span>
                             </span>
                         </div>
                     </ng-template>

--- a/angular/src/app/landing/data-files/data-files.component.html
+++ b/angular/src/app/landing/data-files/data-files.component.html
@@ -1,5 +1,5 @@
 <!-- This bloack is for the data access session of landing page -->
-<div *ngIf="inBrowser" id="dataAccess">
+<div id="dataAccess">
     <div class="font14" [hidden]="metadata">
         <h3><b>Data Access</b></h3><br>
         

--- a/angular/src/app/landing/data-files/data-files.component.ts
+++ b/angular/src/app/landing/data-files/data-files.component.ts
@@ -66,6 +66,7 @@ export class DataFilesComponent {
     mobWidth: number = 800;   // default value used in server context
     mobHeight: number = 900;  // default value used in server context
     fontSize: string;
+    addingToCart: boolean = false;
     public CART_CONSTANTS: any = CartConstants.cartConst;
 
     /* Function to Return Keys object properties */
@@ -106,14 +107,6 @@ export class DataFilesComponent {
             };
         }
 
-        this.edstatsvc._watchForceDataFileTreeInit((start) => {
-            if (start && this.inBrowser) {
-                this.globalDataCart = DataCart.openCart(this.CART_CONSTANTS.GLOBAL_CART_NAME);
-                this.allSelected = this.updateAllSelectStatus(this.files);
-                this.cartLength = this.globalDataCart.size();
-            }
-        });
-
         this.cartService.watchCartLength().subscribe(value => {
             this.cartLength = value;
         });
@@ -128,6 +121,17 @@ export class DataFilesComponent {
             this.updateStatusFromCart();
 
             window.addEventListener("storage", this.cartChanged.bind(this));
+        }
+    }
+
+    /**
+     * Initialize data tree
+     */
+    initDataFileTree(){
+        if (this.inBrowser) {
+            this.globalDataCart = DataCart.openCart(this.CART_CONSTANTS.GLOBAL_CART_NAME);
+            this.allSelected = this.updateAllSelectStatus(this.files);
+            this.cartLength = this.globalDataCart.size();
         }
     }
 
@@ -698,20 +702,24 @@ export class DataFilesComponent {
      * Function to download all.
      */
     downloadFromRoot() {
+        this.addingToCart = true;
         this.cancelAllDownload = false;
         this.specialDataCart = DataCart.createCart(this.ediid);
 
         setTimeout(() => {
             // this.cartService.clearTheCart();
             this.addAllFilesToCart(this.files, true, this.ediid).then(function (result) {
-                // this.cartService.setCurrentCart(this.CART_CONSTANTS.GLOBAL_CART_NAME);
+                this.addingToCart = false;
                 window.open('/datacart/'+this.ediid, this.ediid);
                 this.updateStatusFromCart().then(function (result: any) {
-                    this.edstatsvc.forceDataFileTreeInit();
+                    // this.edstatsvc.forceDataFileTreeInit();
+                    this.initDataFileTree();
                 }.bind(this), function (err) {
+                    this.addingToCart = false;
                     alert("something went wrong while adding file to data cart.");
                 });
             }.bind(this), function (err) {
+                this.addingToCart = false;
                 alert("something went wrong while adding all files to cart");
             });
         }, 0);

--- a/angular/src/app/landing/data-files/data-files.component.ts
+++ b/angular/src/app/landing/data-files/data-files.component.ts
@@ -68,11 +68,6 @@ export class DataFilesComponent {
     addingToCart: boolean = false;
     public CART_CONSTANTS: any = CartConstants.cartConst;
 
-    /* Function to Return Keys object properties */
-    //   keys(): Array<string> {
-    //     return Object.keys(this.fileDetails);
-    //   }
-
     constructor(private cartService: CartService,
         private cdr: ChangeDetectorRef,
         private downloadService: DownloadService,
@@ -245,7 +240,6 @@ export class DataFilesComponent {
                 this.resetStatus(comp.children);
             } else {
                 comp.data.isIncart = false;
-                // comp.data.downloadStatus = null;
             }
         }
         return Promise.resolve(files);
@@ -427,7 +421,7 @@ export class DataFilesComponent {
                     this.isLocalProcessing = false;
                     this.allSelected = false;
                     this.downloadStatus = null;
-                    this.cartService.setCartLength(0);
+                    this.cartService.setCartLength(this.globalDataCart.size());
                     this.isLocalProcessing = false;
                 }.bind(this), function (err) {
                     alert("something went wrong while removing file from data cart.");
@@ -522,13 +516,11 @@ export class DataFilesComponent {
         }
         if(cartKey == '') {   // general data cart
             this.globalDataCart.addFile(rowData.resId, dataCartItem, isSelected);
-            // this.globalDataCart.save();
             this.cartService.setCartLength(this.globalDataCart.size());
             if (cartKey == '')
                 rowData.isIncart = true;
         }else{
             this.specialDataCart.addFile(rowData.resId, dataCartItem, isSelected);
-            // this.specialDataCart.save();
         }
 
         return Promise.resolve(true);
@@ -539,7 +531,6 @@ export class DataFilesComponent {
      * @param rowData - node in the file tree
      */
     removeFromNode(rowData: any) {
-        console.log("Remove from node...");
         this.removeCart(rowData);
         this.cartService.setCartLength(this.globalDataCart.size());
         this.allSelected = this.updateAllSelectStatus(this.files);
@@ -573,7 +564,6 @@ export class DataFilesComponent {
      * @param files - file tree
      */
     removeFilesFromCart(files: TreeNode[]) {
-        console.log("removeFilesFromCart...");
         this.globalDataCart.restore();
         this.globalDataCart.removeFromTree(files);
         this.globalDataCart.save();
@@ -581,24 +571,6 @@ export class DataFilesComponent {
         this.allSelected = this.updateAllSelectStatus(this.files);
         return Promise.resolve(files);
     }
-
-    /**
-     * Remove all files from cart - used by removeFilesFromCart()
-     * @param files - file tree
-     */
-    // removeFromCart(files: TreeNode[]) {
-    //     for (let comp of files) {
-    //         if (comp.children.length > 0) {
-    //             comp.data.isIncart = false;
-    //             this.removeFromCart(comp.children);
-    //         } else {
-    //             this.globalDataCart.removeFileById(comp.data.resId,comp.data.filePath);
-    //             // this.cartService.removeCartId(comp.data.cartId);
-    //             comp.data.isIncart = false;
-    //         }
-    //     }
-
-    // }
 
     /**
      * Update select status - Check if all chirldren nodes were selected
@@ -632,7 +604,6 @@ export class DataFilesComponent {
                 var status = this.updateDownloadStatus(comp.children);
                 if (status) {
                     comp.data.downloadStatus = 'downloaded';
-                    // this.cartService.updateCartItemDownloadStatus(comp.data.cartId, 'downloaded');
                     this.globalDataCart.setDownloadStatus(comp.data.resId, comp.data.filePath, comp.data.downloadStatus);
                 }
                 allDownloaded = allDownloaded && status;
@@ -685,7 +656,6 @@ export class DataFilesComponent {
      */
     setFileDownloaded(rowData: any) {
         rowData.downloadStatus = 'downloaded';
-        // this.cartService.updateCartItemDownloadStatus(rowData.cartId, 'downloaded');
         this.globalDataCart.restore();
 
         this.globalDataCart.setDownloadStatus(rowData.resId, rowData.filePath, rowData.downloadStatus);
@@ -722,7 +692,6 @@ export class DataFilesComponent {
         this.specialDataCart = DataCart.createCart(this.ediid);
 
         setTimeout(() => {
-            // this.cartService.clearTheCart();
             this.addAllFilesToCart(this.files, true, this.ediid).then(function (result) {
                 this.addingToCart = false;
                 window.open('/datacart/'+this.ediid, this.ediid);
@@ -751,24 +720,12 @@ export class DataFilesComponent {
                 this.setAllDownloaded(comp.children);
             } else {
                 comp.data.downloadStatus = 'downloaded';
-                // this.cartService.updateCartItemDownloadStatus(comp.data.cartId, 'downloaded');
                 this.globalDataCart.setDownloadStatus(comp.data.resId, comp.data.filePath, "downloaded");
             }
         }
 
         this.globalDataCart.save();
     }
-
-    /**
-     * Function to reset the download status of a file.
-     * @param rowData - tree node
-     */
-    // resetDownloadStatus(rowData) {
-    //     rowData.downloadStatus = null;
-    //     rowData.downloadProgress = 0;
-    //     this.globalDataCart.setDownloadStatus(rowData.resId, rowData.filePath);
-    //     this.allDownloaded = false;
-    // }
 
     /**
      * Return "download all" button color based on download status

--- a/angular/src/app/landing/data-files/data-files.component.ts
+++ b/angular/src/app/landing/data-files/data-files.component.ts
@@ -13,7 +13,6 @@ import { Router } from '@angular/router';
 import { CommonFunctionService } from '../../shared/common-function/common-function.service';
 import { GoogleAnalyticsService } from '../../shared/ga-service/google-analytics.service';
 import { NotificationService } from '../../shared/notification-service/notification.service';
-import { EditStatusService } from '../editcontrol/editstatus.service';
 import { NerdmComp } from '../../nerdm/nerdm';
 import { DataCart, DataCartItem } from '../../datacart/cart';
 import { DataCartStatus } from '../../datacart/cartstatus';
@@ -85,7 +84,6 @@ export class DataFilesComponent {
         private gaService: GoogleAnalyticsService,
         public router: Router,
         private notificationService: NotificationService,
-        private edstatsvc: EditStatusService,
         ngZone: NgZone) {
         this.cols = [
             { field: 'name', header: 'Name', width: '60%' },
@@ -712,7 +710,6 @@ export class DataFilesComponent {
                 this.addingToCart = false;
                 window.open('/datacart/'+this.ediid, this.ediid);
                 this.updateStatusFromCart().then(function (result: any) {
-                    // this.edstatsvc.forceDataFileTreeInit();
                     this.initDataFileTree();
                 }.bind(this), function (err) {
                     this.addingToCart = false;

--- a/angular/src/app/landing/data-files/data-files.component.ts
+++ b/angular/src/app/landing/data-files/data-files.component.ts
@@ -86,7 +86,7 @@ export class DataFilesComponent {
             { field: 'size', header: 'Size', width: 'auto' },
             { field: 'download', header: 'Status', width: 'auto' }];
 
-        if (typeof (window) !== 'undefined') {
+        if (this.inBrowser && typeof (window) !== 'undefined') {
             this.mobHeight = (window.innerHeight);
             this.mobWidth = (window.innerWidth);
             this.setWidth(this.mobWidth);
@@ -251,17 +251,15 @@ export class DataFilesComponent {
     updateStatusFromCart() {
         this.resetStatus(this.files);
 
-        if(this.inBrowser){
-            if(!this.globalDataCart)
-                this.globalDataCart = DataCart.openCart(this.CART_CONSTANTS.GLOBAL_CART_NAME);
+        if(!this.globalDataCart)
+            this.globalDataCart = DataCart.openCart(this.CART_CONSTANTS.GLOBAL_CART_NAME);
 
-            for (let key in this.globalDataCart.contents) {
-                this.setFilesDownloadStatus(this.files, this.globalDataCart.contents[key].resId, this.globalDataCart.contents[key].downloadStatus);
-                if (this.globalDataCart.contents[key].cartId != undefined) {
-                    let treeNode = this.searchTree(this.treeRoot[0], this.globalDataCart.contents[key].cartId);
-                    if (treeNode != null) {
-                        treeNode.data.isIncart = true;
-                    }
+        for (let key in this.globalDataCart.contents) {
+            this.setFilesDownloadStatus(this.files, this.globalDataCart.contents[key].resId, this.globalDataCart.contents[key].downloadStatus);
+            if (this.globalDataCart.contents[key].cartId != undefined) {
+                let treeNode = this.searchTree(this.treeRoot[0], this.globalDataCart.contents[key].cartId);
+                if (treeNode != null) {
+                    treeNode.data.isIncart = true;
                 }
             }
         }

--- a/angular/src/app/landing/data-files/data-files.component.ts
+++ b/angular/src/app/landing/data-files/data-files.component.ts
@@ -249,21 +249,22 @@ export class DataFilesComponent {
      * Function to sync the download status from data cart.
      */
     updateStatusFromCart() {
-        this.resetStatus(this.files);
+        if(this.inBrowser){
+            this.resetStatus(this.files);
 
-        if(!this.globalDataCart)
-            this.globalDataCart = DataCart.openCart(this.CART_CONSTANTS.GLOBAL_CART_NAME);
+            if(!this.globalDataCart)
+                this.globalDataCart = DataCart.openCart(this.CART_CONSTANTS.GLOBAL_CART_NAME);
 
-        for (let key in this.globalDataCart.contents) {
-            this.setFilesDownloadStatus(this.files, this.globalDataCart.contents[key].resId, this.globalDataCart.contents[key].downloadStatus);
-            if (this.globalDataCart.contents[key].cartId != undefined) {
-                let treeNode = this.searchTree(this.treeRoot[0], this.globalDataCart.contents[key].cartId);
-                if (treeNode != null) {
-                    treeNode.data.isIncart = true;
+            for (let key in this.globalDataCart.contents) {
+                this.setFilesDownloadStatus(this.files, this.globalDataCart.contents[key].resId, this.globalDataCart.contents[key].downloadStatus);
+                if (this.globalDataCart.contents[key].cartId != undefined) {
+                    let treeNode = this.searchTree(this.treeRoot[0], this.globalDataCart.contents[key].cartId);
+                    if (treeNode != null) {
+                        treeNode.data.isIncart = true;
+                    }
                 }
             }
         }
-
         return Promise.resolve(this.files);
     }
 
@@ -685,25 +686,27 @@ export class DataFilesComponent {
      * Function to download all.
      */
     downloadFromRoot() {
-        this.addingToCart = true;
-        this.cancelAllDownload = false;
-        this.specialDataCart = DataCart.createCart(this.ediid);
+        if(this.inBrowser){
+            this.addingToCart = true;
+            this.cancelAllDownload = false;
+            this.specialDataCart = DataCart.createCart(this.ediid);
 
-        setTimeout(() => {
-            this.addAllFilesToCart(this.files, true, this.ediid).then(function (result) {
-                this.addingToCart = false;
-                window.open('/datacart/'+this.ediid, this.ediid);
-                this.updateStatusFromCart().then(function (result: any) {
-                    this.initDataFileTree();
+            setTimeout(() => {
+                this.addAllFilesToCart(this.files, true, this.ediid).then(function (result) {
+                    this.addingToCart = false;
+                    window.open('/datacart/'+this.ediid, this.ediid);
+                    this.updateStatusFromCart().then(function (result: any) {
+                        this.initDataFileTree();
+                    }.bind(this), function (err) {
+                        this.addingToCart = false;
+                        alert("something went wrong while adding file to data cart.");
+                    });
                 }.bind(this), function (err) {
                     this.addingToCart = false;
-                    alert("something went wrong while adding file to data cart.");
+                    alert("something went wrong while adding all files to cart");
                 });
-            }.bind(this), function (err) {
-                this.addingToCart = false;
-                alert("something went wrong while adding all files to cart");
-            });
-        }, 0);
+            }, 0);
+        }
     }
 
     /**

--- a/angular/src/app/landing/downloadstatus/downloadstatus.component.ts
+++ b/angular/src/app/landing/downloadstatus/downloadstatus.component.ts
@@ -19,9 +19,9 @@ export class DownloadstatusComponent implements OnInit {
     }
 
     ngOnInit() {
-        this.dataCartStatus = DataCartStatus.openCartStatus();
-
         if(this.inBrowser){
+            this.dataCartStatus = DataCartStatus.openCartStatus();
+
             window.addEventListener("storage", this.cartChanged.bind(this));
         }
     }

--- a/angular/src/app/landing/downloadstatus/downloadstatus.component.ts
+++ b/angular/src/app/landing/downloadstatus/downloadstatus.component.ts
@@ -10,16 +10,26 @@ import { CartConstants } from '../../datacart/cartconstants';
 export class DownloadstatusComponent implements OnInit {
     dataCartStatus: DataCartStatus;
     public CART_CONSTANTS: any = CartConstants.cartConst;
+    inited: boolean = false;
 
     @Input() inBrowser: boolean;
 
-    constructor() { }
+    constructor() { 
+
+    }
 
     ngOnInit() {
+        this.dataCartStatus = DataCartStatus.openCartStatus();
+
         if(this.inBrowser){
-            this.dataCartStatus = DataCartStatus.openCartStatus();
             window.addEventListener("storage", this.cartChanged.bind(this));
         }
+    }
+
+    ngAfterViewInit(): void {
+        //Called after ngAfterContentInit when the component's view has been initialized. Applies to components only.
+        //Add 'implements AfterViewInit' to the class.
+        this.inited = true;
     }
 
     /**
@@ -28,8 +38,10 @@ export class DownloadstatusComponent implements OnInit {
      * @param ev Event - storage
      */
     cartChanged(ev){
-        if(ev.key == this.dataCartStatus.getName()){
-            this.dataCartStatus.restore();
+        if(this.inited){
+            if(ev.key == this.dataCartStatus.getName()){
+                this.dataCartStatus.restore();
+            }
         }
     }
 

--- a/angular/src/app/landing/editcontrol/editcontrol.component.ts
+++ b/angular/src/app/landing/editcontrol/editcontrol.component.ts
@@ -151,6 +151,8 @@ export class EditControlComponent implements OnInit, OnChanges {
     private detectScreenSize() {
         if(this.inBrowser)
             this.screenWidth = window.innerWidth;
+        else
+            this.screenWidth = 500; 
     }
 
     /**

--- a/angular/src/app/landing/editcontrol/editstatus.service.ts
+++ b/angular/src/app/landing/editcontrol/editstatus.service.ts
@@ -77,14 +77,6 @@ export class EditStatusService {
     }
 
     /**
-     * BehaviorSubject that force datacart to init data file tree
-     */
-    private _forceDataFileTreeInit : BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
-    _watchForceDataFileTreeInit(subscriber) {
-        this._forceDataFileTreeInit.subscribe(subscriber);
-    }
-
-    /**
      * the ID of the user currently logged in.  
      */
     get userID() : string { return this._userid; }
@@ -116,12 +108,5 @@ export class EditStatusService {
      */
     public startEditing(resID: string = "", nologin: boolean = false) : void {
         this._remoteStart.next({'resID':resID, 'nologin':nologin});
-    }
-
-    /**
-     * Force datacart to init data file tree
-     */
-    public forceDataFileTreeInit() : void {
-        this._forceDataFileTreeInit.next(true);
     }
 }

--- a/angular/src/app/landing/landing.module.ts
+++ b/angular/src/app/landing/landing.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { SharedModule } from '../shared/shared.module';
 import { TreeModule, FieldsetModule, DialogModule, OverlayPanelModule,
          ConfirmDialogModule, MenuModule } from 'primeng/primeng';
+import { ProgressSpinnerModule } from 'primeng/progressspinner';
 import { TreeTableModule } from 'primeng/treetable';
 
 import { LandingComponent } from './landing.component';
@@ -29,7 +30,7 @@ import { MetadataView } from './metadata/metadataview.component';
   ],
   imports: [
     CommonModule,SharedModule,TreeModule,FieldsetModule, DialogModule, OverlayPanelModule,
-      ConfirmDialogModule, MenuModule,TreeTableModule
+      ConfirmDialogModule, MenuModule,TreeTableModule, ProgressSpinnerModule
   ],
   exports:[
     LandingComponent, DataFilesComponent, TitleComponent, AuthorComponent, ContactComponent,

--- a/angular/src/app/landing/landingpage.component.ts
+++ b/angular/src/app/landing/landingpage.component.ts
@@ -120,7 +120,6 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
      * the Angular rendering infrastructure.
      */
     ngOnInit() {
-        console.log("initializing LandingPageComponent around id=" + this.reqId);
         var showError: boolean = true;
         let metadataError = "";
         this.displaySpecialMessage = false;
@@ -181,7 +180,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
                   {
                       if (this.routerParamEditEnabled) {
                           showError = false;
-                          console.log("Returning from authentication redirection (editmode="+this.routerParamEditEnabled+")");
+                        //   console.log("Returning from authentication redirection (editmode="+this.routerParamEditEnabled+")");
                           // Need to pass reqID (resID) because the resID in editControlComponent
                           // has not been set yet and the startEditing function relies on it.
                             this.edstatsvc.startEditing(this.reqId);

--- a/angular/src/app/landing/landingpage.component.ts
+++ b/angular/src/app/landing/landingpage.component.ts
@@ -229,8 +229,8 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
      * apply housekeeping after view has been initialized
      */
     ngAfterViewInit() {
-        this.useFragment();
         if (this.md && this.inBrowser) {
+            this.useFragment();
             window.history.replaceState({}, '', '/od/id/' + this.reqId);
         }
     }
@@ -278,8 +278,6 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
      * apply the URL fragment by scrolling to the proper place in the document
      */
     public useFragment() {
-        if (!this.inBrowser) return;
-
         this.router.events.subscribe(s => {
             if (s instanceof NavigationEnd) {
                 const tree = this.router.parseUrl(this.router.url);
@@ -320,6 +318,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
 
     /**
      * toggle the visibility of the citation pop-up window
+     * @param size 
      */
     toggleCitation(size: string) : void { 
         if(size == 'small')
@@ -339,6 +338,9 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
         return this.citetext;
     }
 
+    /**
+     * Set the message to display based on the edit mode.
+     */
     setMessage(){
         if(this.editMode == this.EDIT_MODES.DONE_MODE)
         {

--- a/angular/src/app/landing/search-service.resolve.ts
+++ b/angular/src/app/landing/search-service.resolve.ts
@@ -33,7 +33,6 @@ export class SearchResolve implements Resolve<any> {
     const recordid_KEY = makeStateKey<any>('record-' + recordid);
 
     if (this.transferState.hasKey(recordid_KEY)) {
-      console.log("1. Is it here @@@");
       const record = this.transferState.get<any>(recordid_KEY, null);
       this.transferState.remove(recordid_KEY);
       return of(record);

--- a/angular/src/app/shared/download-service/download-service.service.ts
+++ b/angular/src/app/shared/download-service/download-service.service.ts
@@ -121,7 +121,7 @@ export class DownloadService {
      * Return max download instances allowed at same time
      */
     getMaxConcurDownload() {
-        return this.max_concur_download-1;
+        return this.max_concur_download;
     }
 
     /**
@@ -162,11 +162,10 @@ export class DownloadService {
 
     /**
      * Download zip data
-     * @param ediid - 
-     * @param nextZip 
-     * @param zipdata 
-     * @param dataFiles 
-     * @param dataCart 
+     * @param nextZip - zip to be downloaded
+     * @param zipdata - zip queue. To check if all zips have been downloaded.
+     * @param dataFiles - data tree
+     * @param dataCart - data cart: update the download status so other tab can be updated.
      */
     download(nextZip: ZipData, zipdata: ZipData[], dataFiles: any, dataCart: DataCart) {
         let sub = this.zipFilesDownloadingDataCartSub;
@@ -181,7 +180,6 @@ export class DownloadService {
         this.setDownloadStatus(nextZip, dataFiles, "downloading", dataCart);
         this.increaseNumberOfDownloading();
 
-        // console.log('nextZip.bundleSize', nextZip.bundleSize);
         nextZip.downloadInstance = this.getBundle(nextZip.downloadUrl, JSON.stringify(nextZip.bundle)).subscribe(
             event => {
                 switch (event.type) {
@@ -260,8 +258,9 @@ export class DownloadService {
     }
 
     /**
-     * Decrease the number of current downloading by 1
-     **/
+     * Decrease the number of current downloading by 1. If it becomes -1 which means all downloadings
+     * are done, set the process status to done.
+     */
     decreaseNumberOfDownloading() {
         let sub = this.zipFilesDownloadingDataCartSub;
 
@@ -269,14 +268,14 @@ export class DownloadService {
             this.setDownloadingNumber(sub.getValue() - 1);
         }
 
-        if (sub.getValue() == 0) {
+        if (sub.getValue() == -1) {
             this.setDownloadProcessStatus(true);
         }
     }
 
     /**
-     * Increase the number of current downloading by 1
-     **/
+     * Increase the number of current downloading by 1. 
+     */
     increaseNumberOfDownloading() {
         let sub = this.zipFilesDownloadingDataCartSub;
 
@@ -287,7 +286,10 @@ export class DownloadService {
 
     /**
      * Download next available zip in the queue
-     **/
+     * @param zipData - zip queue
+     * @param dataFiles - the data tree. For updating the download status.
+     * @param dataCart - data cart: update the download status so other tab can be updated.
+     */
     downloadNextZip(zipData: ZipData[], dataFiles: any, dataCart: DataCart) {
         let sub = this.zipFilesDownloadingDataCartSub;
 
@@ -301,7 +303,8 @@ export class DownloadService {
 
     /**
      * Return next available zip in the queue
-     **/
+     * @param zipData - zip queue
+     */
     getNextZipInQueue(zipData: ZipData[]) {
         let zipQueue = zipData.filter(item => item.downloadStatus == null);
 
@@ -314,7 +317,9 @@ export class DownloadService {
 
     /**
      * Generate downloadData from a given file tree that will be used to create post message for bundle plan
-     **/
+     * @param files - input file tree
+     * @param downloadData - output download data
+     */
     getDownloadData(files: any, downloadData: any) {
         let existItem: any;
         for (let comp of files) {
@@ -336,24 +341,25 @@ export class DownloadService {
     }
 
     /**
-    * Set the number of downloading zip files
-    **/
+     * Watching the number of the zip files that are currently downloading 
+     */
     watchDownloadingNumber(): Observable<any> {
         let sub = this.zipFilesDownloadingDataCartSub;
         return sub.asObservable();
     }
 
     /**
-     * Set the number of downloading zip files
-     **/
+     * Set the number of the zip files that are currently downloading 
+     * @param value 
+     */
     setDownloadingNumber(value: number) {
         let sub = this.zipFilesDownloadingDataCartSub;
         sub.next(value);
     }
 
     /**
-    * Watch overall process status
-    **/
+     * Watch overall process status
+     */
     watchDownloadProcessStatus(): Observable<any> {
         let sub = this.zipFilesProcessedDataCartSub;
         return sub.asObservable();
@@ -361,15 +367,21 @@ export class DownloadService {
 
     /**
      * Set overall process status
-     **/
+     * @param value 
+     */
     setDownloadProcessStatus(value: boolean) {
         let sub = this.zipFilesProcessedDataCartSub;
         sub.next(value);
     }
 
     /**
-     * Set download status of given tree node
-     **/
+     * Set download status of given zip
+     * @param zip - input zip file that has download status in it's include files
+     * @param dataFiles - file tree that to be set the download status
+     * @param status - download status
+     * @param dataCart - data cart that to be set the download status - keep other tab in sync
+     * @param message - any message that need to be added to the tree 
+     */
     setDownloadStatus(zip: any, dataFiles: any, status: any, dataCart: DataCart, message: string = '') {
         let resFilePath: string;
 
@@ -399,20 +411,9 @@ export class DownloadService {
     }
 
     /**
-     * Check if all zip files are downloaded
-     **/
-    allDownloaded(zipData: any) {
-        for (let zip of zipData) {
-            if (zip.downloadStatus != 'downloaded') {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
      * Check if all doanload processes have finished
-     **/
+     * @param zipData 
+     */
     allDownloadFinished(zipData: any) {
         for (let zip of zipData) {
             if (zip.downloadStatus == null || zip.downloadStatus == 'downloading') {
@@ -423,16 +424,18 @@ export class DownloadService {
     }
 
     /**
-     * Search tree by given full path
-     **/
-    searchTreeByfilePath(element, resFilePath) {
-        if (element.data.isLeaf && element.data.resFilePath == resFilePath) {
-            return element;
-        } else if (element.children.length > 0) {
+     * Search a given tree by given full path
+     * @param tree 
+     * @param resFilePath 
+     */
+    searchTreeByfilePath(tree, resFilePath) {
+        if (tree.data.isLeaf && tree.data.resFilePath == resFilePath) {
+            return tree;
+        } else if (tree.children.length > 0) {
             var i;
             var result = null;
-            for (i = 0; result == null && i < element.children.length; i++) {
-                result = this.searchTreeByfilePath(element.children[i], resFilePath);
+            for (i = 0; result == null && i < tree.children.length; i++) {
+                result = this.searchTreeByfilePath(tree.children[i], resFilePath);
             }
             return result;
         }
@@ -440,8 +443,9 @@ export class DownloadService {
     }
 
     /**
-     * Return total downloaded zip files from a given zipData 
-     **/
+     * Return total downloaded zip files from a given zipData
+     * @param zipData 
+     */
     getDownloadedNumber(zipData: any) {
         let totalDownloadedZip: number = 0;
         for (let zip of zipData) {
@@ -454,7 +458,8 @@ export class DownloadService {
 
     /**
      * Reset element's zip files to null
-     **/
+     * @param element 
+     */
     resetZipName(element) {
         if (element.data != undefined) {
             element.data.zipFile = null;
@@ -468,33 +473,39 @@ export class DownloadService {
 
     /**
      * Set general download flag
-     **/
+     * @param value 
+     */
     setFileDownloadedFlag(value: boolean) {
         this.anyFileDownloadedFlagSub.next(value);
     }
 
     /**
      * Watch general download flag
-     **/
+     */
     watchAnyFileDownloaded(): Observable<any> {
         return this.anyFileDownloadedFlagSub.asObservable();
     }
 
-
     /**
      * Set the number of files downloaded
-     **/
+     * @param fileDownloadedCount 
+     */
     setTotalFileDownloaded(fileDownloadedCount: number) {
         this.totalFileDownloadedSub.next(fileDownloadedCount);
     }
 
+    /**
+     * Watch the number of files downloaded
+     * @param subscriber 
+     */
     watchTotalFileDownloaded(subscriber) {
         return this.totalFileDownloadedSub.subscribe(subscriber);
     }
 
     /**
      * Return total number of downloaded files in a given dataFiles (tree)
-     **/
+     * @param dataFiles 
+     */
     getTotalDownloadedFiles(dataFiles: any) {
         let totalDownloaded: number = 0;
         for (let comp of dataFiles) {
@@ -510,7 +521,7 @@ export class DownloadService {
     }
 
     /**
-     *  Cancel the download process of the given zip file
+     * Cancel the download process of the given zip file
      * @param zip - the zip file to be cancelled
      */
     cancelDownloadZip(zip: ZipData, dataFiles: TreeNode[], dataCart: DataCart) {

--- a/angular/src/app/shared/download-service/download-service.service.ts
+++ b/angular/src/app/shared/download-service/download-service.service.ts
@@ -21,7 +21,7 @@ export class DownloadService {
     anyFileDownloadedFlagSub = new BehaviorSubject<boolean>(false);
     totalFileDownloadedSub = new BehaviorSubject<number>(0);
 
-    private download_maximum: number = 2;
+    private max_concur_download: number = 2;
     _totalBundleSize = 0;
     _totalDownloaded = 0;
     _downloadSpeed = 0.00;
@@ -120,8 +120,8 @@ export class DownloadService {
     /**
      * Return max download instances allowed at same time
      */
-    getDownloadMaximum() {
-        return this.download_maximum;
+    getMaxConcurDownload() {
+        return this.max_concur_download-1;
     }
 
     /**
@@ -280,7 +280,7 @@ export class DownloadService {
     increaseNumberOfDownloading() {
         let sub = this.zipFilesDownloadingDataCartSub;
 
-        if (sub.getValue() < this.getDownloadMaximum()) {
+        if (sub.getValue() < this.getMaxConcurDownload()) {
             this.setDownloadingNumber(sub.getValue() + 1);
         }
     }
@@ -291,7 +291,7 @@ export class DownloadService {
     downloadNextZip(zipData: ZipData[], dataFiles: any, dataCart: DataCart) {
         let sub = this.zipFilesDownloadingDataCartSub;
 
-        if (sub.getValue() < this.getDownloadMaximum()) {
+        if (sub.getValue() < this.getMaxConcurDownload()) {
             let nextZip = this.getNextZipInQueue(zipData);
             if (nextZip != null) {
                 this.download(nextZip, zipData, dataFiles, dataCart);

--- a/angular/src/app/shared/ga-service/google-analytics.service.ts
+++ b/angular/src/app/shared/ga-service/google-analytics.service.ts
@@ -6,79 +6,77 @@
 
 import { Injectable } from '@angular/core';
 import { Router, NavigationEnd } from '@angular/router';
-declare var gas: Function;
-declare var _initAutoTracker: Function;
+declare let gas: Function;
+declare let _initAutoTracker: Function;
 
 @Injectable()
 export class GoogleAnalyticsService {
-  // Tracking pageview
-  gaTrackPageview(url: string, title: string) {
-    setTimeout(() => {
-      gas('send', 'pageview', url, title);
-    }, 1000);
-  }
+    // Tracking pageview
+    gaTrackPageview(url: string, title: string) {
+        setTimeout(() => {
+            gas('send', 'pageview', url, title);
+        }, 1000);
+    }
 
-  // Tracking events
-  gaTrackEvent(category: string, event?: any, label?: string, action?: string) {
-    console.log('category', category);
-    console.log('event', event);
-    console.log('label', label);
-    console.log('action', action);
-    if (action == undefined) {
-      console.log('event2', event);
-      // menu item
-      if (event.item != undefined) {
-        action = event.item.url;
-        label = event.item.label;
-      } else if (event.path != undefined) {
-        for (var i = 0; i < event.path.length; i++) {
-          if (event.path[i].href != undefined) {
-            action = event.path[i].href;
-            label = event.path[i].innerText;
-            if (label == '' || label == undefined)
-              label = event.path[i].hostname;
-            break;
-          }
+    // Tracking events
+    gaTrackEvent(category: string, event?: any, label?: string, action?: string) {
+        if (action == undefined) {
+        // menu item
+        if (event.item != undefined) {
+            action = event.item.url;
+            label = event.item.label;
+        } else if (event.path != undefined) {
+            for (var i = 0; i < event.path.length; i++) {
+                if (event.path[i].href != undefined) {
+                    action = event.path[i].href;
+                    label = event.path[i].innerText;
+                    if (label == '' || label == undefined)
+                    label = event.path[i].hostname;
+                    break;
+                }
+            }
+        } else
+            action = 'URL not catched';
         }
-      } else
-        action = 'URL not catched';
+        action = (action == undefined) ? "" : action;
+        label = (label == undefined) ? "" : label;
+
+        setTimeout(() => {
+            if(typeof gas === "function"){
+                gas('send', 'event', category, action, label, 1);
+            }
+        }, 1000);
+
     }
-    action = (action == undefined) ? "" : action;
-    label = (label == undefined) ? "" : label;
 
-    setTimeout(() => {
-      gas('send', 'event', category, action, label, 1);
-    }, 1000);
-  }
+    /** 
+     *   To hide the GA tracking code in config server, we need to move the script session here.
+     *   First we read the tracking code from the config server, then form the script src and add the script
+     *   to the top of current page. 
+     * 
+     *   This function takes GA tracking code as a parameter, constructs the script 
+     *   and adds it to the top of current page.
+     */
+    public appendGaTrackingCode(gaCode: string) {
+        try {
+            let scriptId = '_fed_an_ua_tag';
 
-  /** 
-  *   To hide the GA tracking code in config server, we need to move the script session here.
-  *   First we read the tracking code from the config server, then form the script src and add the script
-  *   to the top of current page. 
-  * 
-  *   This function takes GA tracking code as a parameter, constructs the script 
-  *   and adds it to the top of current page.
-  */
-  public appendGaTrackingCode(gaCode: string) {
-    try {
-      let scriptId = '_fed_an_ua_tag';
+            if (document.getElementById(scriptId)) {
+                console.log("Found GA id.");
+                document.getElementById(scriptId).remove();
+            }
 
-      if (document.getElementById(scriptId)) {
-        console.log("Found GA id.");
-        document.getElementById(scriptId).remove();
-      }
+            var s = document.createElement('script') as any;
+            s.type = "text/javascript";
+            s.id = scriptId;
+            s.src = "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=" + gaCode + "&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c";
 
-      var s = document.createElement('script') as any;
-      s.type = "text/javascript";
-      s.id = scriptId;
-      s.src = "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&subagency=NIST&pua=" + gaCode + "&exts=ppsx,pps,f90,sch,rtf,wrl,txz,m1v,xlsm,msi,xsd,f,tif,eps,mpg,xml,pl,xlt,c";
+            var h = document.getElementsByTagName("head");
+            document.getElementsByTagName("head")[0].appendChild(s);
 
-      var h = document.getElementsByTagName("head");
-      document.getElementsByTagName("head")[0].appendChild(s);
-
-    } catch (ex) {
-      console.error('Error appending google analytics');
-      console.error(ex);
+        } catch (ex) {
+            console.error('Error appending google analytics');
+            console.error(ex);
+        }
     }
-  }
 }


### PR DESCRIPTION
http://mml.nist.gov:8080/browse/ODD-955
http://mml.nist.gov:8080/browse/ODD-956
http://mml.nist.gov:8080/browse/ODD-957

This check in addresses above three tickets. 
For ODD-955 - Unable to Download-All on mds2-2253, it was caused by Google Analytics script because it takes too long to analyze the datacart page. Fixed this issue by moving GA call to after user confirm downloading. This is logically correct and solved timeing issue.

ODD-956 - server side error: fixed by adding inBrowser flag to non-server-side calls.

ODD-957 - remove dependency on EditStatusService in DataFilesComponent: the service was originally designed for other component but later on the design changed. Used a function call instead of doing a round-trip call. The un-used service was also removed.

Test it in local docker or deploy to oardev.