### PR TITLE
mdserver: fix renaming of files downloaded from publishing platform

### DIFF
--- a/python/nistoar/pdr/publish/midas3/mdwsgi.py
+++ b/python/nistoar/pdr/publish/midas3/mdwsgi.py
@@ -362,7 +362,7 @@ class Handler(object):
         self.set_response(200, "Data file found")
         self.add_header('Content-Type', mtype)
         self.add_header('Content-Disposition',
-                        'inline; filname="%s"' % os.path.basename(filepath)) 
+                        'inline; filename="%s"' % os.path.basename(filepath)) 
         if xsend:
             self.add_header('X-Accel-Redirect', xsend)
         self.end_headers()

--- a/python/nistoar/pdr/publish/midas3/mdwsgi.py
+++ b/python/nistoar/pdr/publish/midas3/mdwsgi.py
@@ -361,7 +361,8 @@ class Handler(object):
 
         self.set_response(200, "Data file found")
         self.add_header('Content-Type', mtype)
-        self.add_header('Content-Disposition', os.path.basename(filepath))
+        self.add_header('Content-Disposition',
+                        'inline; filname="%s"' % os.path.basename(filepath)) 
         if xsend:
             self.add_header('X-Accel-Redirect', xsend)
         self.end_headers()


### PR DESCRIPTION
This PR addresses ODD-953 ("Datapub direct file download") which observes that files downloaded via the proto-landing page on the publishing platform (`datapub`) are being saved with names of the form, `download.`*.  A related symptom is that files with a comma in the name fail to download with the browser reporting a "Network error".  This is due to an incorrect format for the value being set for the `Content-Disposition` HTTP Header by the metadata server.  This corrects the value by setting it to `inline; filename="`_filename_`"`.  
