### PR TITLE
Display no matrics available if nothing was downloaded

### DIFF
--- a/angular/src/app/landing/tools/toolmenu.component.ts
+++ b/angular/src/app/landing/tools/toolmenu.component.ts
@@ -223,7 +223,7 @@ export class ToolMenuComponent implements OnChanges {
             let totalDownloadSize = this.recordLevelMetrics.DataSetMetrics[0] != undefined?
                 this.commonFunctionService.formatBytes(this.recordLevelMetrics.DataSetMetrics[0].total_size, 2) : 0;
     
-            if(this.recordLevelMetrics.DataSetMetrics.length > 0){
+            if(this.recordLevelMetrics.DataSetMetrics.length > 0 && totalDownload > 0){
                 subitems = [
                     this.createMenuItem(totalDownload>1?totalDownload.toString() + ' files downloaded.':totalDownload.toString() + ' file downloaded.', null,null, null),
                     this.createMenuItem(totalUsers > 1?totalUsers.toString() + ' users.':totalUsers.toString() + ' user.', null,null, null),


### PR DESCRIPTION
No Jira ticket associate to this quick fix.

This fix is to display "Metrics not available" in the green menu in landing page if no file was downloaded regardless how many users were recorded in the metrics data.

Attached files show how the menu look like before and after the change.

![01-before](https://user-images.githubusercontent.com/44069356/124024234-ec82b480-d9bc-11eb-8f52-c5c01065a72f.png)
![02-after](https://user-images.githubusercontent.com/44069356/124024235-ec82b480-d9bc-11eb-9688-46f7a7bb8c4d.png)


