### PR TITLE
Remove 'More' from metrics menu; Made other items clickable; Removed …

### DIFF
--- a/angular/src/app/landing/tools/toolmenu.component.ts
+++ b/angular/src/app/landing/tools/toolmenu.component.ts
@@ -225,10 +225,10 @@ export class ToolMenuComponent implements OnChanges {
     
             if(this.recordLevelMetrics.DataSetMetrics.length > 0 && totalDownload > 0){
                 subitems = [
-                    this.createMenuItem(totalDownload>1?totalDownload.toString() + ' files downloaded.':totalDownload.toString() + ' file downloaded.', null,null, null),
-                    this.createMenuItem(totalUsers > 1?totalUsers.toString() + ' users.':totalUsers.toString() + ' user.', null,null, null),
-                    this.createMenuItem(totalDownloadSize.toString() + ' downloaded.', null,null, null),
-                    this.createMenuItem('More ...', null,null, this.metricsUrl, "_self")
+                    this.createMenuItem(totalDownload>1?totalDownload.toString() + ' files downloaded':totalDownload.toString() + ' file downloaded', null,null, this.metricsUrl, "_self"),
+                    this.createMenuItem(totalUsers > 1?totalUsers.toString() + ' users':totalUsers.toString() + ' user', null,null, this.metricsUrl, "_self"),
+                    this.createMenuItem(totalDownloadSize.toString() + ' downloaded', null,null, this.metricsUrl, "_self")
+                    // this.createMenuItem('More ...', null,null, this.metricsUrl, "_self")
                 ];
 
                 hasMetrics = true;
@@ -237,7 +237,7 @@ export class ToolMenuComponent implements OnChanges {
     
         if(!hasMetrics){
             subitems = [
-                this.createMenuItem('Metrics not available.', null,null, null)
+                this.createMenuItem('Metrics not available', null,null, null)
             ]; 
         }
 

--- a/angular/src/app/landing/tools/toolmenu.component.ts
+++ b/angular/src/app/landing/tools/toolmenu.component.ts
@@ -226,7 +226,7 @@ export class ToolMenuComponent implements OnChanges {
             if(this.recordLevelMetrics.DataSetMetrics.length > 0 && totalDownload > 0){
                 subitems = [
                     this.createMenuItem(totalDownload>1?totalDownload.toString() + ' files downloaded':totalDownload.toString() + ' file downloaded', null,null, this.metricsUrl, "_self"),
-                    this.createMenuItem(totalUsers > 1?totalUsers.toString() + ' users':totalUsers.toString() + ' user', null,null, this.metricsUrl, "_self"),
+                    this.createMenuItem(totalUsers > 1?totalUsers.toString() + ' unique users':totalUsers.toString() + ' unique user', null,null, this.metricsUrl, "_self"),
                     this.createMenuItem(totalDownloadSize.toString() + ' downloaded', null,null, this.metricsUrl, "_self")
                     // this.createMenuItem('More ...', null,null, this.metricsUrl, "_self")
                 ];


### PR DESCRIPTION
This branch made the following changes:

1. Removed periods at the end of metrics summaries.
2. Removed "More..." menu item from the green metrics menu.
3. Made metrics summaries clickable and link to the metrics page.