### PR TITLE
Get total file downloaded from record level metrics; check file level…

### DIFF
--- a/angular/src/app/landing/landingpage.component.html
+++ b/angular/src/app/landing/landingpage.component.html
@@ -22,6 +22,7 @@
         <app-downloadstatus [inBrowser]="inBrowser"></app-downloadstatus>  
         
         <tools-menu #menu3  [record]="md" 
+        [hasCurrentMetrics]="hasCurrentMetrics"
         [recordLevelMetrics]="recordLevelMetrics"
         [metricsUrl]="metricsUrl"
         [isPopup]="true"
@@ -58,6 +59,7 @@
 
                 <tools-menu #menu2  [record]="md" 
                 [recordLevelMetrics]="recordLevelMetrics"
+                [hasCurrentMetrics]="hasCurrentMetrics"
                 [metricsUrl]="metricsUrl"
                 [isPopup]="false"
                 (toggle_citation)="toggleCitation('large')"

--- a/angular/src/app/landing/tools/toolmenu.component.ts
+++ b/angular/src/app/landing/tools/toolmenu.component.ts
@@ -35,6 +35,9 @@ export class ToolMenuComponent implements OnChanges {
     // Record level metrics data
     @Input() recordLevelMetrics : RecordLevelMetrics|null = new RecordLevelMetrics();
 
+    // flag if there is file level metrics data
+    @Input() hasCurrentMetrics : boolean|null = false;
+
     // Record level metrics data
     @Input() metricsUrl : string|null = "";
 
@@ -85,6 +88,7 @@ export class ToolMenuComponent implements OnChanges {
     updateMenu() {
         var mitems : MenuItem[] = [];
         var subitems : MenuItem[] = [];
+        let hasMetrics: boolean = false;
 
         let mdService: string;
         mdService = this.cfg.get("locations.mdService", "/unconfigured");
@@ -198,43 +202,46 @@ export class ToolMenuComponent implements OnChanges {
 
         // Dataset Metrics
         // First check if there is any file in the dataset. If not, do not display metrics.
-        let hasFile = false;
-        let hasMetrics: boolean = false;
-
-        if(this.record.components && this.record.components.length > 0){
-            this.record.components.forEach(element => {
-                if(element.filepath){
-                    hasFile = true;
-                    return;
-                }
-            });
-        }
-
-        if(hasFile){
-            //Now check if there is any metrics data
-            let totalDownload = this.recordLevelMetrics.DataSetMetrics[0] != undefined? this.recordLevelMetrics.DataSetMetrics[0].success_get : 0;
-
-            totalDownload = totalDownload == undefined? 0 : totalDownload;
+        if(this.hasCurrentMetrics){
+            let hasFile = false;
     
-            let totalUsers = this.recordLevelMetrics.DataSetMetrics[0] != undefined? this.recordLevelMetrics.DataSetMetrics[0].number_users : 0;
-    
-            totalUsers = totalUsers == undefined? 0 : totalUsers;
-    
-            let totalDownloadSize = this.recordLevelMetrics.DataSetMetrics[0] != undefined?
-                this.commonFunctionService.formatBytes(this.recordLevelMetrics.DataSetMetrics[0].total_size, 2) : 0;
-    
-            if(this.recordLevelMetrics.DataSetMetrics.length > 0 && totalDownload > 0){
-                subitems = [
-                    this.createMenuItem(totalDownload>1?totalDownload.toString() + ' files downloaded':totalDownload.toString() + ' file downloaded', null,null, this.metricsUrl, "_self"),
-                    this.createMenuItem(totalUsers > 1?totalUsers.toString() + ' unique users':totalUsers.toString() + ' unique user', null,null, this.metricsUrl, "_self"),
-                    this.createMenuItem(totalDownloadSize.toString() + ' downloaded', null,null, this.metricsUrl, "_self")
-                    // this.createMenuItem('More ...', null,null, this.metricsUrl, "_self")
-                ];
-
-                hasMetrics = true;
+            if(this.record.components && this.record.components.length > 0){
+                this.record.components.forEach(element => {
+                    if(element.filepath){
+                        hasFile = true;
+                        return;
+                    }
+                });
             }
-        }
+
+            if(hasFile){
+                //Now check if there is any metrics data
+                let totalFileDownload = this.recordLevelMetrics.DataSetMetrics[0] != undefined? this.recordLevelMetrics.DataSetMetrics[0].success_get : 0;
     
+                totalFileDownload = totalFileDownload == undefined? 0 : totalFileDownload;
+        
+                let totalUsers = this.recordLevelMetrics.DataSetMetrics[0] != undefined? this.recordLevelMetrics.DataSetMetrics[0].number_users : 0;
+        
+                totalUsers = totalUsers == undefined? 0 : totalUsers;
+        
+                let totalDownloadSize = this.recordLevelMetrics.DataSetMetrics[0] != undefined?
+                    this.commonFunctionService.formatBytes(this.recordLevelMetrics.DataSetMetrics[0].total_size, 2) : 0;
+        
+                if(this.recordLevelMetrics.DataSetMetrics.length > 0 && totalFileDownload > 0){
+                    subitems = [
+                        this.createMenuItem(totalFileDownload>1?totalFileDownload.toString() + ' files downloaded':totalFileDownload.toString() + ' file downloaded', null,null, this.metricsUrl, "_self"),
+                        this.createMenuItem(totalUsers > 1?totalUsers.toString() + ' unique users':totalUsers.toString() + ' unique user', null,null, this.metricsUrl, "_self"),
+                        this.createMenuItem(totalDownloadSize.toString() + ' downloaded', null,null, this.metricsUrl, "_self")
+                        // this.createMenuItem('More ...', null,null, this.metricsUrl, "_self")
+                    ];
+    
+                    hasMetrics = true;
+                }
+            }
+        }else{
+            hasMetrics = false;
+        }
+        
         if(!hasMetrics){
             subitems = [
                 this.createMenuItem('Metrics not available', null,null, null)

--- a/angular/src/app/metrics/metrics.component.ts
+++ b/angular/src/app/metrics/metrics.component.ts
@@ -125,7 +125,7 @@ export class MetricsComponent implements OnInit {
                             this.handleSum(this.files);
 
                             // Get metrics details (file level)
-                            this.metricsService.getDatasetMetrics(this.ediid).subscribe(async (event) => {
+                            this.metricsService.getFileLevelMetrics(this.ediid).subscribe(async (event) => {
                                 // Some large dataset might take a while to download. Only handle the response
                                 // when it finishes downloading
                                 if(event.type == HttpEventType.Response){
@@ -183,7 +183,9 @@ export class MetricsComponent implements OnInit {
                             console.log("Record level metrics", this.recordLevelData);
 
                             if(this.recordLevelData.DataSetMetrics != undefined && this.recordLevelData.DataSetMetrics.length > 0){
-                                this.firstTimeLogged = this.datePipe.transform(this.recordLevelData.DataSetMetrics[0].first_time_logged, "MMM d, y")
+                                this.firstTimeLogged = this.datePipe.transform(this.recordLevelData.DataSetMetrics[0].first_time_logged, "MMM d, y");
+
+                                this.recordLevelTotalDownloads = this.recordLevelData.DataSetMetrics[0].success_get;
 
                                 // this.xAxisLabel = "Total Downloads Since " + this.firstTimeLogged;
                                 this.datasetSubtitle = "Metrics Since " + this.firstTimeLogged;
@@ -359,7 +361,7 @@ export class MetricsComponent implements OnInit {
      */
     get TotalDatasetDownloads() {
         if(this.recordLevelData.DataSetMetrics[0] != undefined){
-            return this.recordLevelData.DataSetMetrics[0].success_get;
+            return this.recordLevelData.DataSetMetrics[0].record_download;
         }else{
             return ""
         }
@@ -484,8 +486,8 @@ export class MetricsComponent implements OnInit {
             }
         }
 
-        var sum = this.chartData.reduce((sum, current) => sum + current[1], 0);
-        this.recordLevelTotalDownloads = sum;
+        // var sum = this.chartData.reduce((sum, current) => sum + current[1], 0);
+        // this.recordLevelTotalDownloads = sum;
     }
 
     /**

--- a/angular/src/app/metrics/metrics.ts
+++ b/angular/src/app/metrics/metrics.ts
@@ -27,6 +27,8 @@ export class DataSetMetrics {
     total_size : number;
     success_get : number;
     number_users : number;
+    record_download: number;
+
 
     constructor(        
         ediid : string = null,
@@ -34,12 +36,14 @@ export class DataSetMetrics {
         last_time_logged : string = null,
         total_size : number = null,
         success_get : number = null,
-        number_users : number = null) {
+        number_users : number = null,
+        record_download : number = null) {
             this.ediid = ediid;
             this.first_time_logged = first_time_logged;
             this.last_time_logged = last_time_logged;
             this.total_size = total_size;
             this.success_get = success_get;
-            this.number_users = number_users;            
+            this.number_users = number_users;   
+            this.record_download = record_download;         
     }
 }

--- a/angular/src/app/shared/metrics-service/metrics.service.ts
+++ b/angular/src/app/shared/metrics-service/metrics.service.ts
@@ -16,7 +16,7 @@ export class MetricsService {
         this.metricsBackend = cfg.get("metricsAPI", "/unconfigured");
     }
 
-    getDatasetMetrics(ediid: string): Observable<any> {
+    getFileLevelMetrics(ediid: string): Observable<any> {
         let url = this.metricsBackend + "files?exclude=_id&include=ediid,filepath,success_get,download_size&ediid=" + ediid;
 
         const request = new HttpRequest(


### PR DESCRIPTION
Two changes in this check in:
1. Read "Total file downloads" from "success_get" in dataset level metrics. "Total dataset downloads" from "record_download";
2. In landing page, if no metrics data for current dataset, display "Metrics not available".