### PR TITLE
Provide a README auto-generation capability for use by MIDAS

### DIFF
--- a/docker/pdrtest/Dockerfile
+++ b/docker/pdrtest/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y python-yaml nginx curl wget less sudo \
                                          uwsgi uwsgi-plugin-python zip \
                                          p7zip-full git
 RUN pip install --upgrade pip 'setuptools==44.0.0'
-RUN pip install funcsigs 'bagit>=1.6.3,<2.0' 'fs>=2.0.21'
+RUN pip install funcsigs 'bagit>=1.6.3,<2.0' 'fs>=2.0.21' mako
 
 # install multibag from source
 RUN curl -L -o multibag-py.zip \

--- a/etc/mako/readme/data_overview.txt
+++ b/etc/mako/readme/data_overview.txt
@@ -42,24 +42,40 @@
         lines[0] = lines[0][len(indent):]
         return lines
 
-    def is_datacmp(c, tp):
+    def is_datacmp(c, tp=None):
         if not c.get('filepath'):
             return False
+        if not tp:
+            return True
         for t in c.get('@type',[]):
             if ':'+tp in t:
                 return True
         return False
 
-%>
+    def is_accessible(c, tp=None):
+        if not c.get('accessURL'):
+            return False
+        for t in c.get('@type',[]):
+            if tp and ':'+tp in t:
+                return True
+            if ':Hidden' in t:
+               return False
+        return not bool(tp)
+
+%>\
 ##
 ## 
 <%def name="list_data_components(components)">
 ${"\n".join(render_data_components([c for c in components if c.get('filepath')],
                                    (_prompts and caller.body()) or ''))}
-</%def>
+</%def>\
 ##
 ##
-% if not _brief or _prompts:
+<%
+    accessibles = [c for c in nrd.get('components',[]) if is_accessible(c)]
+    downloadables = [c for c in nrd.get('components',[]) if is_datacmp(c)]
+%>\
+% if not _brief or _prompt or len(accessibles):
 -------------
 Data Overview
 -------------
@@ -84,7 +100,7 @@ This data was derived from the following sources:
   *  [## description, repository, or data identifier ##]
 
 % endif
-% if not _brief and nrd.get('components',[]):
+% if not _brief and len(downloadables) > 0:
   % if _prompts:
 ${'##'}
 # In the file listing below, consider adding useful information like:
@@ -95,5 +111,20 @@ ${'##'}
   % endif
 Files included in this publication:
 ${"\n".join(list_data_components(nrd.get('components',[]), _prompts))}
+% endif
+% if len(accessibles) > 0:
+% for cmp in accessibles:
+% if 'title' in cmp:
+${textwrap.fill(cmp['title'])} is available at:
+% else:
+Access to additional data/information is available via:
+% endif
+  ${cmp['accessURL']}
+
+% if 'description' in cmp:
+  ${"  \n".join(textwrap.wrap(cmp['description'], 78))}
+
+% endif
+% endfor
 % endif
 % endif

--- a/etc/mako/readme/data_overview.txt
+++ b/etc/mako/readme/data_overview.txt
@@ -1,0 +1,99 @@
+<%!
+    import textwrap, re
+
+    FILE_DESC_PROMPT = "[## add'l info about this file (see recommendations above) ##]"
+
+    def list_data_components(components, prompting=True):
+        cmps = [c for c in components if c.get('filepath') and
+                                         not any([':ChecksumFile' in t for t in c.get('@type',[])])]
+        return render_data_components(cmps, (prompting and FILE_DESC_PROMPT) or '')
+
+    def render_data_components(components, fileprompt, collpath='', prefix='  ', indent='  '):
+        out = []
+        for cmp in components:
+            if '/' not in cmp.get('filepath','')[len(collpath):]:
+                if is_datacmp(cmp, 'Subcollection'):
+                    out.append(prefix + cmp.get('filepath','')[len(collpath):])
+                    nxtcollpath = cmp['filepath'] + '/'
+                    out.extend(render_data_components([c for c in components
+                                                         if c.get('filepath') and
+                                                            c['filepath'].startswith(nxtcollpath)],
+                                                      fileprompt, nxtcollpath, prefix+indent, indent))
+
+                elif is_datacmp(cmp, 'DataFile'):
+                    lines = [prefix + cmp.get('filepath','')[len(collpath):]]
+                    if cmp.get('title'):
+                        lines.extend(hang(cmp['title'], prefix+indent, indent))
+                    if cmp.get('description'):
+                        lines.extend(hang(cmp['description'], prefix+indent, indent))
+                    if cmp.get('format',{}).get('description'):
+                        lines.extend(hang("Format: "+cmp['format']['description'], prefix+indent, indent))
+                    if fileprompt:
+                        lines.append(prefix+indent+fileprompt)
+                    if len(lines) > 1:
+                        lines.insert(1, '')
+                        lines.append('')
+                    out.extend(lines)
+        return out
+
+    def hang(text, prefix, indent):
+        lines = textwrap.wrap(text, max(40, 80-len(prefix+indent)))
+        lines = [prefix+indent+ln for ln in lines]
+        lines[0] = lines[0][len(indent):]
+        return lines
+
+    def is_datacmp(c, tp):
+        if not c.get('filepath'):
+            return False
+        for t in c.get('@type',[]):
+            if ':'+tp in t:
+                return True
+        return False
+
+%>
+##
+## 
+<%def name="list_data_components(components)">
+${"\n".join(render_data_components([c for c in components if c.get('filepath')],
+                                   (_prompts and caller.body()) or ''))}
+</%def>
+##
+##
+% if not _brief or _prompts:
+-------------
+Data Overview
+-------------
+
+% if _prompts:
+${'##'}
+# Describe any special standards used to encode or document the data
+# in this collection.  Examples could include: 
+#
+# - FGDC-CSDGM (Federal Geographic Data Committee's Content Standard for
+#   Digital Geospatial Metadata (https://www.fgdc.gov/metadata)  
+# - MIBBI - Minimum Information for Biological and Biomedical Investigations
+#   (https://fairsharing.org/collection/MIBBI) 
+${'##'}
+
+${'##'}
+#  Was data derived from another source? (example, Open FEMA)
+#  If yes, list source(s) below
+${'##'}
+
+This data was derived from the following sources:
+  *  [## description, repository, or data identifier ##]
+
+% endif
+% if not _brief and nrd.get('components',[]):
+  % if _prompts:
+${'##'}
+# In the file listing below, consider adding useful information like:
+#  * description of the file contents
+#  * defintion of variables (or table columns)
+#  * format details
+${'##'}
+  % endif
+Files included in this publication:
+${"\n".join(list_data_components(nrd.get('components',[]), _prompts))}
+% endif
+% endif

--- a/etc/mako/readme/data_overview.txt
+++ b/etc/mako/readme/data_overview.txt
@@ -110,6 +110,7 @@ ${'##'}
 ${'##'}
   % endif
 Files included in this publication:
+
 ${"\n".join(list_data_components(nrd.get('components',[]), _prompts))}
 % endif
 % if len(accessibles) > 0:

--- a/etc/mako/readme/data_use.txt
+++ b/etc/mako/readme/data_use.txt
@@ -1,0 +1,66 @@
+<%!
+    import textwrap, re
+
+    def get_citation(n):
+        if n.get('citation'):
+           return n['citation']
+
+        out = ""
+        if 'authors' in n:
+            for i, auth in enumerate(n['authors']):
+                if auth.get('familyName'):
+                    out += auth['familyName']+','
+                if auth.get('givenName'):
+                    out += ' '+auth['givenName']
+                if auth.get('middleName'):
+                    out += ' '+auth['middleName']
+                if i != len(n['authors'])-1:
+                    out += ', '
+
+        elif n.get('contactPoint',{}).get('fn'):
+            out += n['contactPoint']['fn']
+        elif n.get('publisher', {}).get('name'):
+            out += n['publisher']['name']
+        else:
+            out += "National Institute of Standards and Technology"
+
+        date = n.get('issued')
+        if not date:
+            date = n.get('modified')
+        if date:
+            out += ' (' + date.split('-', 1)[0] + ')'
+
+        if n.get('title'):
+            out += ', ' + n['title'].strip()
+        if n.get('version'):
+            out += ', Version ' + n['version']
+        if n.get('publisher',{}).get('name'):
+            out += ', ' + n['publisher']['name']
+
+        if n.get('doi'):
+            out += ', ' + re.sub(r'^doi:','https://doi.org/', n['doi'])
+        elif n.get('landingPage'):
+            out += ', ' + n['landingPage']
+
+        out += " (Accessed: [give download date])"
+        return out
+%>\
+--------------
+Data Use Notes
+--------------
+
+% if dataAccess != 'private':
+This data is publically available according to the NIST statements of
+copyright, fair use and licensing; see
+https://www.nist.gov/director/copyright-fair-use-and-licensing-statements-srd-data-and-software
+
+% else:
+This data is not publically available and is made available to you
+under the follow restrictions:
+
+${textwrap.fill(nrd.get('rights','[## List restrictions here ##]'), 80)}
+
+% endif
+You may cite the use of this data as follows:
+${textwrap.fill(get_citation(nrd), 80)}
+

--- a/etc/mako/readme/front_matter.txt
+++ b/etc/mako/readme/front_matter.txt
@@ -18,6 +18,11 @@
 %>NIST ${resource_type_label(nrd['@type'])}:
 ${textwrap.fill(title, 80)}
 Version ${version}
+% if nrd.get('doi'):
+DOI: ${re.sub(r'^doi:','https://doi.org/', doi)}
+% elif nrd.get('landingPage'):
+Home Page: ${landingPage}
+% endif
 
 % if _prompts:
 ${'###'}

--- a/etc/mako/readme/front_matter.txt
+++ b/etc/mako/readme/front_matter.txt
@@ -1,0 +1,94 @@
+<%!
+    import textwrap, re
+
+    labels = {
+        "SRD": "Standard Reference Dataset",
+        "SRM": "Standard Reference Material",
+        "PublicDataResource": "Public Data Resource",
+        "DataPublication": "Data Publication"
+    }
+
+    def resource_type_label(types):
+        for tp in types:
+            tp = tp.split(':', 1)[-1]
+            if tp in labels:
+                return labels[tp]
+        return "Data Resource"
+
+%>NIST ${resource_type_label(nrd['@type'])}:
+${textwrap.fill(title, 80)}
+Version ${version}
+
+% if _prompts:
+${'###'}
+# Attention Submitter:
+#
+# This prototype README file was automatically generated based on metadata
+# entered via MIDAS.  You may edit this file however you wish; however, it
+# includes prompts for recommended information to include.  Before submitting
+# this file as part of your publication, please edit the contents:
+# 
+#  o  replace [## ... ##] with prompted information as desired
+#  o  remove prompts you do not wish to include
+#  o  remove comments lines starting with # (like the lines in this note)
+#
+# Be sure to use an editor capable of saving plain text (e.g. Notepad on 
+# Windows, TextEdit on Macs, vi or emacs on Linux).  Use of MS-Word is not
+# recommended.
+#
+# All information is optional; delete or expand on any of the information seeded
+# here as desired.
+${'##'}
+
+% endif
+% if 'authors' in nrd:
+Authors:
+  % for auth in authors:
+  ${auth['fn']}
+    % for affil in auth.get('affiliation',[]):
+      % if 'title' in affil:
+    ${"\n    ".join(textwrap.wrap(affil['title'], 80))}
+      % endif
+      % for su in affil.get('subunits',[]):
+    ${"\n    ".join(textwrap.wrap(su, 80))}
+      % endfor
+    % endfor
+  % endfor
+% endif
+
+Contact:
+  ${contactPoint.get('fn','[## Contact name ##]')}
+    ${re.sub('^mailto:', '', contactPoint.get('hasEmail','[## Contact email addess ##]'))}
+
+% if not _brief:
+Description:
+
+  % for para in description:
+${textwrap.fill(re.sub(r'(\n|\\n)',' ',para), 80)}
+
+  % endfor
+% elif _prompts:
+Description:
+
+${'##'}
+# Summarize the contents of this data collection here
+${'##'}
+
+% endif
+<%
+    supto = [r for r in nrd.get('references',[]) if 'refType' in r and r['refType'] == 'IsSupplementTo']
+    docby = [r for r in nrd.get('references',[]) if 'refType' in r and r['refType'] == 'IsDocumentedBy']
+%>\
+% if supto:
+This collection is a supplement to:
+% for r in supto:
+  ${"  \n".join(textwrap.wrap(r.get('citation','[## citation for '+r.get('location','??')+' ##]'), 80))}
+% endfor
+% endif
+% if supto:
+This collection is documented in:
+% for r in supto:
+  ${"  \n".join(textwrap.wrap(r.get('citation','[## citation for '+r.get('location','??')+' ##]'), 80))}
+% endfor
+% endif
+

--- a/etc/mako/readme/general_info.txt
+++ b/etc/mako/readme/general_info.txt
@@ -1,0 +1,17 @@
+<%!
+    import textwrap, re
+%>\
+% if _prompts:
+-------------------
+General Information
+-------------------
+
+This data was [## created/collected ##]: [## single date, approximate, or date
+range ##].
+
+Geographical coverage: [## description of coverage, including LAT/LONG if
+relevent ##]
+
+Key funding sources: [## Relevent sources of Non-NIST funding ##]
+
+% endif

--- a/etc/mako/readme/methods.txt
+++ b/etc/mako/readme/methods.txt
@@ -1,0 +1,39 @@
+% if _prompts:
+--------------------------
+Methodological Information
+--------------------------
+
+${'##'}
+# Describe the methods used for collection/generation of data.  Include links
+# or references to publications or other documentation containing experimental
+# design or protocols used in data collection
+${'##'}
+
+${'##'}
+# Describe the methods used to process the data.  
+${'##'}
+
+${'##'}
+# Describe the instrument- or software-specific information that is useful to
+# interpret the data
+${'##'}
+
+${'##'}
+# Provide any relevant standards or calibration information
+${'##'}
+
+${'##'}
+# Describe the relevant environmental/experimental conditions during data
+# collection
+${'##'}
+
+${'##'}
+# Describe any quality-assurance procedures performed on the data
+${'##'}
+
+${'##'}
+# List additional people involved with sample collection, processing, analysis
+# and/or submission
+${'##'}
+
+% endif

--- a/etc/mako/readme/references.txt
+++ b/etc/mako/readme/references.txt
@@ -14,6 +14,6 @@ ${textwrap.fill(r.get('citation','[## citation for '+r.get('location','??')+' ##
 ${'##'}
 # List any other relevant references, including related data publications
 # and ancillary data.
-${'##'}\
+${'##'}
 % endif 
 % endif

--- a/etc/mako/readme/references.txt
+++ b/etc/mako/readme/references.txt
@@ -1,0 +1,19 @@
+<%!
+    import textwrap, re
+%>\
+% if nrd['references'] or _prompts:
+----------
+References
+----------
+
+% for r in nrd.get('references',[]):
+${textwrap.fill(r.get('citation','[## citation for '+r.get('location','??')+' ##]'), 80)}
+
+% endfor
+% if _prompts:
+${'##'}
+# List any other relevant references, including related data publications
+# and ancillary data.
+${'##'}\
+% endif 
+% endif

--- a/etc/mako/readme/references.txt
+++ b/etc/mako/readme/references.txt
@@ -1,7 +1,7 @@
 <%!
     import textwrap, re
 %>\
-% if nrd['references'] or _prompts:
+% if nrd.get('references') or _prompts:
 ----------
 References
 ----------

--- a/etc/mako/readme/version_history.txt
+++ b/etc/mako/readme/version_history.txt
@@ -1,0 +1,28 @@
+<%!
+    import textwrap, re
+%>\
+---------------
+Version History
+---------------
+
+% if nrd.get('versionHistory',[]):
+% for i, his in enumerate(reversed(nrd.get('versionHistory',[]))):
+% if his.get('version','??') == nrd.get('version'):
+Version ${his.get('version','??')} (this version)
+% else:
+Version ${his.get('version','??')}
+% endif
+% if _prompts and i != len(nrd['versionHistory'])-1:
+  ${"  \n".join(textwrap.wrap(his.get('description','')+" [## elaborate if useful ##]", 80))}
+% else:
+  ${"  \n".join(textwrap.wrap(his.get('description',''), 80))}
+% endif
+
+% endfor
+% else:
+${nrd.get('version','1.0')} (this version)
+  initial release
+% if _prompt:
+  [## elaborate if useful ##]
+% endif
+% endif

--- a/etc/mako/readme/version_history.txt
+++ b/etc/mako/readme/version_history.txt
@@ -25,4 +25,5 @@ ${nrd.get('version','1.0')} (this version)
 % if _prompt:
   [## elaborate if useful ##]
 % endif
+
 % endif

--- a/python/nistoar/pdr/publish/cmd/__init__.py
+++ b/python/nistoar/pdr/publish/cmd/__init__.py
@@ -23,7 +23,7 @@ def load_into(subparser, as_cmd=None):
     :param argparser.ArgumentParser subparser:  the argument parser instance to define this command's 
                                                 interface into it 
     """
-    from . import prepupd, servenerd, fix, validate, setver, author
+    from . import prepupd, servenerd, fix, validate, setver, author, readme
     
     subparser.description = description
 
@@ -32,6 +32,7 @@ def load_into(subparser, as_cmd=None):
     out = cli.CommandSuite(as_cmd, subparser)
     out.load_subcommand(prepupd)
     out.load_subcommand(author)
+    out.load_subcommand(readme)
     out.load_subcommand(setver)
     out.load_subcommand(validate)
     out.load_subcommand(servenerd)

--- a/python/nistoar/pdr/publish/cmd/readme.py
+++ b/python/nistoar/pdr/publish/cmd/readme.py
@@ -1,0 +1,181 @@
+"""
+package that enables README file generation from the command-line.
+See nistoar.pdr.cli and the pdr script for info on the general CLI infrastructure.
+
+This module defines a set of subcommands to a command called (by default) "author".  These subcommands
+include
+  - add:  creates a README.txt file and adds it to the bag
+  - gen:  generate a README.txt file based on the NERDm metadata and stream it to standard out
+  - show: stream the existing README.txt file to standard out
+"""
+from __future__ import print_function
+import sys, os, logging, re
+from collections import OrderedDict
+from copy import deepcopy
+
+from nistoar.pdr import cli
+from nistoar.pdr.preserv.bagit import NISTBag
+from nistoar.pdr.publish.readme import ReadmeGenerator
+from nistoar.pdr.utils import read_nerd, NERDError
+from nistoar.nerdm import PUB_SCHEMA_URI
+from . import validate as vald8, define_pub_opts, determine_bag_path
+
+default_name = "readme"
+help = "generate, add, and display the dataset's README text"
+description = """
+  This command provides a suite of subcommands to generate, add, or display a bag's README file based on 
+  its NERDm metadata.
+"""
+
+def load_into(subparser, as_cmd=None):
+    """
+    load this command into a CLI by defining the command's arguments and options.
+    :param argparser.ArgumentParser subparser:  the argument parser instance to define this command's 
+                                                interface into it 
+    """
+    p = subparser
+    p.description = description
+
+    if not as_cmd:
+        as_cmd = default_name
+    out = cli.CommandSuite(as_cmd, p)
+    out.load_subcommand( GenReadmeCmd())
+#    out.load_subcommand( AddReadmeCmd())
+#    out.load_subcommand(ShowReadmeCmd())
+    return out
+
+class ReadmeCmd(object):
+    """
+    a base class for readme commands.  An instance of this class serves the same role as a command
+    submodule in the PDRCLI framework.
+    """
+
+    def __init__(self, cmdname, logger=None):
+        self.name = cmdname
+        if not logger:
+            logger = logging.getLogger(self.default_name)
+        self.deflog = logger
+
+    @property
+    def default_name(self):
+        """
+        the name this command get invoked by.   This property is part of the standard PDRCLI interface
+        """
+        return self.name
+
+    def define_common_opts(self, subparser):
+        """
+        Add arguments to the parser that are common across all commands
+        :param ArgumentParser subparser:   the argparse subparser instance to add options to 
+        """
+        return define_pub_opts(subparser)
+
+    def define_gen_opts(self, subparser):
+        """
+        Add arguments to the parser that control the creation of README text from the NERDm metadata
+        """
+        g = subparser
+        g.add_argument("-B", "--brief", action="store_true", dest="brief",
+                       help="create a brief version of the README (omit file listing)")
+        g.add_argument("-P", "--without-prompts", action="store_false", dest="withprompts",
+                       help="do not include editing prompts within the generated README")
+        g.add_argument("-N", "--from-nerdm-file", metavar="FILE", type=str, dest="srcfile",
+                       help="read the NERDm metadata from the given FILE rather from the metadata in the bag")
+        g.add_argument("-T", "--template-dir", metavar="DIR", type=str, dest="tmpldir",
+                       help="look for README template files in DIR")
+
+    def _fail(self, message, exitcode=1):
+        raise cli.PDRCommandFailure(self.default_name, message, exitcode)
+
+class GenReadmeCmd(ReadmeCmd):
+    """
+    a CLI command for generating README text.  By default, it is printed to standard out.
+    """
+    _default_name = "gen"
+    description = """
+       this command generated README text and prints it (by default) to standard out.
+    """
+    help = "generate README text"
+    usage = "[-b DIR] [-B] [-P] [-T DIR] [-o FILE] AIPID | -N FILE | -h"
+
+    def __init__(self, cmdname=None):
+        if not cmdname:
+            cmdname = self._default_name
+        super(GenReadmeCmd, self).__init__(cmdname)
+
+    def load_into(self, subparser):
+        """
+        load the command-line arguments into the subparser
+        """
+        p = subparser
+        p.usage = self.usage
+        p.add_argument("aipid", metavar="AIPID", type=str, nargs='?',
+                       help="the AIP-ID for the bag to examine or the file path to the bag's root directory")
+        p.add_argument("-b", "--bag-parent-dir", metavar="DIR", type=str, dest='bagparent',
+                       help="the directory to look for the specified bag; if not specified, it will either "+
+                       "set to the metadata_bag_dir config or otherwise to the working directory.  Ignored "+
+                       "if AIPID is given as a path.")
+
+        self.define_gen_opts(p)
+        p.add_argument("-o", "--output-file", metavar="FILE", type=str, dest="outfile", default="-",
+                       help="write the README contents to FILE (instead of standard out)")
+        
+        return self
+
+    def execute(self, args, config=None, log=None):
+        if not log:
+            log = self.log
+        if not config:
+            config = {}
+
+        if isinstance(args, list):
+            # cmd-line arguments not parsed yet
+            p = argparse.ArgumentParser()
+            self.load_into(p)
+            args = p.parse_args(args)
+
+        nerdm = None
+        if args.srcfile:
+            if not os.path.isfile(args.srcfile):
+                self._fail("Input bag does not exist (as a file): "+args.srcfile, 1)
+            try:
+                nerdm = read_nerd(args.srcfile)
+            except NERDError as ex:
+                self._fail(str(ex), 2)
+
+        else: 
+            if not args.aipid:
+                raise PDRCommandFailure(default_name, "AIP ID not specified", 1)
+            args.aipid = args.aipid[0]
+            usenm = args.aipid
+            if len(usenm) > 11:
+                usenm = usenm[:4]+"..."+usenm[-4:]
+            log = log.getChild(usenm)
+
+            # find the input bag
+            workdir, bagparent, bagdir = determine_bag_path(args, config)
+            if not os.path.isdir(bagdir):
+                self._fail("Input bag does not exist (as a dir): "+bagdir, 2)
+            log.info("Found input bag at "+bagdir)
+
+            bag = NISTBag(bagdir)
+            nerdm = bag.nerdm_record(True)
+
+        if not args.outfile or args.outfile == "-":
+            out = sys.stdout
+
+        else:
+            if os.path.isdir(args.outfile):
+                args.outfile = os.join(args.outfile, "README.txt")
+            elif not os.path.isdir(os.path.dirname(args.outfile)):
+                self._fail("Output directory does not exist (as a directory): "+
+                           os.path.dirname(args.outfile), 2)
+            out = open(args.outfile, 'w')
+
+        try:
+            genr8tr = ReadmeGenerator(args.tmpldir)
+            genr8tr.generate(nerdm, out, args.withprompts, args.brief)
+
+        finally:
+            if args.outfile and args.outfile != "-":
+                out.close()

--- a/python/nistoar/pdr/publish/midas3/mdwsgi.py
+++ b/python/nistoar/pdr/publish/midas3/mdwsgi.py
@@ -208,6 +208,7 @@ class Handler(object):
                 if any([auto_is_true(a) for a in qs.get('auto',[])]):
                     # support auto-generated README file requests
                     flags = "".join(qs.get('flags',[''])).upper()
+                    log.info("Auto-generating a README.txt for id=%s", dsid)
                     return self.send_auto_readme(dsid, 'P' not in flags, 'B' in flags)
                 else:
                     return self.send_datafile(dsid, filepath)
@@ -314,7 +315,7 @@ class Handler(object):
         self.add_header('Content-Type', 'text/plain')
         self.add_header('Content-Length', str(len(out.getvalue())))
         self.end_headers()
-        return out.getvalue().split("\n")
+        return [ln+"\n" for ln in out.getvalue().split("\n")]
 
         
     def send_metadata(self, dsid):

--- a/python/nistoar/pdr/publish/readme.py
+++ b/python/nistoar/pdr/publish/readme.py
@@ -5,6 +5,7 @@ import textwrap, os
 from mako.template import Template
 
 from nistoar.pdr.exceptions import StateException
+from nistoar import pdr
 
 class ReadmeGenerator(object):
 
@@ -27,6 +28,8 @@ class ReadmeGenerator(object):
             return os.path.join(os.environ['OAR_MAKO_TEMPLATES_DIR'], "readme")
         if 'OAR_ETC_DIR' in os.environ:
             return os.path.join(os.environ['OAR_ETC_DIR'], "mako", "readme")
+        if pdr.def_etc_dir:
+            return os.path.join(pdr.def_etc_dir, "mako", "readme")
         if 'OAR_HOME' in os.environ:
             return os.path.join(os.environ['OAR_HOME'], "etc", "mako", "readme")
         return None

--- a/python/nistoar/pdr/publish/readme.py
+++ b/python/nistoar/pdr/publish/readme.py
@@ -1,0 +1,101 @@
+"""
+a module for converting a NERDm record into a plain-text README document.  
+"""
+import textwrap, os
+from mako.template import Template
+
+from nistoar.pdr.exceptions import StateException
+
+class ReadmeGenerator(object):
+
+    def __init__(self, templatedir=None):
+        """
+        create the generator
+        """
+        if not templatedir:
+            templatedir = self.find_default_templatedir()
+        self.templatedir = templatedir
+
+        if not self.templatedir:
+            raise StateException("Unable to locate template dir (please specify)")
+        if not os.path.isdir(templatedir):
+            raise StateException("README template directory does not exist as a directory: "+templatedir)
+
+    @classmethod
+    def find_default_templatedir(cls):
+        if 'OAR_MAKO_TEMPLATES_DIR' in os.environ:
+            return os.path.join(os.environ['OAR_MAKO_TEMPLATES_DIR'], "readme")
+        if 'OAR_ETC_DIR' in os.environ:
+            return os.path.join(os.environ['OAR_ETC_DIR'], "mako", "readme")
+        if 'OAR_HOME' in os.environ:
+            return os.path.join(os.environ['OAR_HOME'], "etc", "mako", "readme")
+        return None
+        
+
+    def _get_tmpl8(self, name):
+        target = os.path.join(self.templatedir, name+".txt")
+        return Template(filename=target)
+
+    class Writer(object):
+        def __init__(self, ngn, nerdm, ostrm, templated=False, brief=False):
+            self.ngn = ngn  # the ReadmeGenerator
+            self.nerdm = nerdm
+            self.out = ostrm
+            self._withprompts = templated
+            self._brief = brief
+
+        def _render_tmpl8(self, tmpl8, data, withprompts=None, brief=None):
+            if withprompts is None:
+                withprompts = self._withprompts
+            if brief is None:
+                brief = self._brief
+            self.out.write(tmpl8.render(_prompts=withprompts, _brief=brief, nrd=data, **data))
+
+        def apply(self, tmpl8name, data, withprompts=None, brief=None):
+            tmpl8 = self.ngn._get_tmpl8(tmpl8name)
+            self._render_tmpl8(tmpl8, data)
+
+        def write_front_matter(self):
+            self.apply("front_matter", self.nerdm)
+
+        def write_general_info(self):
+            self.apply("general_info", self.nerdm)
+
+        def write_data_use(self):
+            self.apply("data_use", self.nerdm)
+
+        def write_references(self):
+            self.apply("references", self.nerdm)
+
+        def write_version_history(self):
+            self.apply("version_history", self.nerdm)
+
+        def write_methods(self):
+            self.apply("methods", self.nerdm)
+
+        def write_data_overview(self):
+            self.apply("data_overview", self.nerdm)
+
+        def write_readme(self):
+            self.write_front_matter()
+            self.write_general_info()
+            self.write_data_use()
+            self.write_references()
+            self.write_data_overview()
+            self.write_version_history()
+            self.write_methods()
+
+        
+    def generate(self, nerdm, ostrm, templated=False, brief=False):
+        """
+        create the README and write it to the given output file stream
+        :param dict nerdm:      the NERDm Resource metadata to convert
+        :param file ostrm:      the file object to write the README document to.
+        :param bool templated:  if true, include prompts where one can edit the document and 
+                                  insert additional information
+        :param bool brief:      write out an abbreviated version that does not list all of the files
+        """
+        wrtr = self.Writer(self, nerdm, ostrm, templated, brief)
+        wrtr.write_readme()
+
+    

--- a/python/nistoar/pdr/publish/readme.py
+++ b/python/nistoar/pdr/publish/readme.py
@@ -52,7 +52,7 @@ class ReadmeGenerator(object):
                 withprompts = self._withprompts
             if brief is None:
                 brief = self._brief
-            self.out.write(tmpl8.render(_prompts=withprompts, _brief=brief, nrd=data, **data))
+            self.out.write(tmpl8.render(_prompts=withprompts, _brief=brief, nrd=data, **data).encode('utf8'))
 
         def apply(self, tmpl8name, data, withprompts=None, brief=None):
             tmpl8 = self.ngn._get_tmpl8(tmpl8name)

--- a/python/tests/nistoar/pdr/preserv/bagit/tools/test_enchance.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/tools/test_enchance.py
@@ -271,6 +271,7 @@ class TestEnrichReferences(test.TestCase):
         # setup
         doid = "10.1126/science.169.3946.635"
         doiu = "https://doi.org/"+doid
+        pdb.set_trace()
         enh.merge_enhanced_ref("doi:"+doid)
         self.assertEqual(len(enh.refs), 2)
 

--- a/python/tests/nistoar/pdr/preserv/bagit/tools/test_enchance.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/tools/test_enchance.py
@@ -271,7 +271,6 @@ class TestEnrichReferences(test.TestCase):
         # setup
         doid = "10.1126/science.169.3946.635"
         doiu = "https://doi.org/"+doid
-        pdb.set_trace()
         enh.merge_enhanced_ref("doi:"+doid)
         self.assertEqual(len(enh.refs), 2)
 

--- a/python/tests/nistoar/pdr/publish/midas3/test_mdwsgi.py
+++ b/python/tests/nistoar/pdr/publish/midas3/test_mdwsgi.py
@@ -336,7 +336,7 @@ class TestApp(test.TestCase):
         }
         body = self.svc(req, self.start)
         self.assertIn("200", self.resp[0])
-        body = "\n".join(body)
+        body = "".join(body)
         self.assertIn("Version ", body)
         self.assertIn("Version History", body)
         self.assertIn("trial1.json", body)
@@ -350,7 +350,7 @@ class TestApp(test.TestCase):
         }
         body = self.svc(req, self.start)
         self.assertIn("200", self.resp[0])
-        body = "\n".join(body)
+        body = "".join(body)
         self.assertIn("Version ", body)
         self.assertIn("Version History", body)
         self.assertIn("trial1.json", body)
@@ -364,7 +364,7 @@ class TestApp(test.TestCase):
         }
         body = self.svc(req, self.start)
         self.assertIn("200", self.resp[0])
-        body = "\n".join(body)
+        body = "".join(body)
         self.assertIn("Version ", body)
         self.assertIn("Version History", body)
         self.assertNotIn("trial1.json", body)
@@ -378,7 +378,7 @@ class TestApp(test.TestCase):
         }
         body = self.svc(req, self.start)
         self.assertIn("200", self.resp[0])
-        body = "\n".join(body)
+        body = "".join(body)
         self.assertIn("Version ", body)
         self.assertIn("Version History", body)
         self.assertNotIn("trial1.json", body)

--- a/python/tests/nistoar/pdr/publish/midas3/test_mdwsgi.py
+++ b/python/tests/nistoar/pdr/publish/midas3/test_mdwsgi.py
@@ -293,6 +293,98 @@ class TestApp(test.TestCase):
         self.svc = wsgi.app(self.config)
         self.assertIsNotNone(self.svc._midascl)
 
+    def test_no_readme(self):
+        req = {
+            'PATH_INFO': '/3A1EE2F169DD3B8CE0531A570681DB5D1491/README.txt',
+            'REQUEST_METHOD': 'GET'
+        }
+        body = self.svc(req, self.start)
+        self.assertIn("404", self.resp[0])
+
+        self.resp = []
+        req = {
+            'PATH_INFO': '/3A1EE2F169DD3B8CE0531A570681DB5D1491/README.txt',
+            'REQUEST_METHOD': 'GET',
+            'QUERY_STRING': "auto="
+        }
+        body = self.svc(req, self.start)
+        self.assertIn("404", self.resp[0])
+
+        self.resp = []
+        req = {
+            'PATH_INFO': '/3A1EE2F169DD3B8CE0531A570681DB5D1491/README.txt',
+            'REQUEST_METHOD': 'GET',
+            'QUERY_STRING': "auto=false"
+        }
+        body = self.svc(req, self.start)
+        self.assertIn("404", self.resp[0])
+
+        self.resp = []
+        req = {
+            'PATH_INFO': '/3A1EE2F169DD3B8CE0531A570681DB5D1491/README.txt',
+            'REQUEST_METHOD': 'GET',
+            'QUERY_STRING': "auto=0"
+        }
+        body = self.svc(req, self.start)
+        self.assertIn("404", self.resp[0])
+
+    def test_auto_readme(self):
+        req = {
+            'PATH_INFO': '/3A1EE2F169DD3B8CE0531A570681DB5D1491/README.txt',
+            'REQUEST_METHOD': 'GET',
+            'QUERY_STRING': "auto=true"
+        }
+        body = self.svc(req, self.start)
+        self.assertIn("200", self.resp[0])
+        body = "\n".join(body)
+        self.assertIn("Version ", body)
+        self.assertIn("Version History", body)
+        self.assertIn("trial1.json", body)
+        self.assertIn("###", body)
+
+        self.resp = []
+        req = {
+            'PATH_INFO': '/3A1EE2F169DD3B8CE0531A570681DB5D1491/README.txt',
+            'REQUEST_METHOD': 'GET',
+            'QUERY_STRING': "auto=false&auto=1"
+        }
+        body = self.svc(req, self.start)
+        self.assertIn("200", self.resp[0])
+        body = "\n".join(body)
+        self.assertIn("Version ", body)
+        self.assertIn("Version History", body)
+        self.assertIn("trial1.json", body)
+        self.assertIn("###", body)
+
+    def test_brief_auto_readme(self):
+        req = {
+            'PATH_INFO': '/3A1EE2F169DD3B8CE0531A570681DB5D1491/README.txt',
+            'REQUEST_METHOD': 'GET',
+            'QUERY_STRING': "auto=true&flags=b&flags="
+        }
+        body = self.svc(req, self.start)
+        self.assertIn("200", self.resp[0])
+        body = "\n".join(body)
+        self.assertIn("Version ", body)
+        self.assertIn("Version History", body)
+        self.assertNotIn("trial1.json", body)
+        self.assertIn("###", body)
+
+    def test_auto_readme_noprompts(self):
+        req = {
+            'PATH_INFO': '/3A1EE2F169DD3B8CE0531A570681DB5D1491/README.txt',
+            'REQUEST_METHOD': 'GET',
+            'QUERY_STRING': "auto=true&flags=b&flags=P"
+        }
+        body = self.svc(req, self.start)
+        self.assertIn("200", self.resp[0])
+        body = "\n".join(body)
+        self.assertIn("Version ", body)
+        self.assertIn("Version History", body)
+        self.assertNotIn("trial1.json", body)
+        self.assertNotIn("###", body)
+        
+
 
 if __name__ == '__main__':
     test.main()

--- a/python/tests/nistoar/pdr/publish/test_readme.py
+++ b/python/tests/nistoar/pdr/publish/test_readme.py
@@ -72,6 +72,7 @@ class TestReadmeGenerator(test.TestCase):
         self.assertGreater(len(txt), 5)
         self.assertIn(self.nerdm['title'][:50], txt)
         self.assertIn('Version '+self.nerdm['version'], txt)
+        self.assertIn('DOI: https://doi.org/'+self.nerdm['doi'][4:], txt)
         self.assertIn('##', txt)
                          
         txt = StringIO()
@@ -215,6 +216,7 @@ class TestReadmeGenerator(test.TestCase):
         self.assertIn('  trial3\n', txt)
         self.assertIn('    trial3a.json', txt)
         self.assertIn('[##', txt)
+        self.assertNotIn('is accessible', txt)
                          
         txt = StringIO()
         wrtr = self.gen.Writer(self.gen, self.nerdm, txt, False)
@@ -226,7 +228,43 @@ class TestReadmeGenerator(test.TestCase):
         self.assertIn('  trial3\n', txt)
         self.assertIn('    trial3a.json', txt)
         self.assertNotIn('##', txt)
+        self.assertNotIn('is accessible', txt)
 
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, False, True)
+        wrtr.write_data_overview()
+        txt = txt.getvalue()
+        self.assertEqual(len(txt), 0)
+
+        self.nerdm['components'].append({
+            "@type": ["dcat:Distribution"],
+            "accessURL": "https://doi.org/"+self.nerdm['doi'][4:],
+            "title": "DOI Access for \""+self.nerdm['title']+"\"",
+            "description": "This URL is just another way to get to the landing page."
+        })
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, False, True)
+        wrtr.write_data_overview()
+        txt = txt.getvalue()
+        self.assertGreater(len(txt), 5)
+        self.assertIn('Data Overview', txt)
+        self.assertNotIn('trial1.json', txt)
+        self.assertNotIn('trial3', txt)
+        self.assertIn('is available', txt)
+        self.assertIn('DOI Access', txt)
+        self.assertIn('another way', txt)
+
+        self.nerdm['components'][-1]['@type'] = ["nrd:Hidden", "dcat:Distribution"]
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, True, False)
+        wrtr.write_data_overview()
+        txt = txt.getvalue()
+        self.assertGreater(len(txt), 5)
+        self.assertIn('Data Overview', txt)
+        self.assertIn('trial1.json', txt)
+        self.assertIn('trial3', txt)
+        self.assertNotIn('is available', txt)
+        
     def test_generate(self):
         self.nerdm['references'][0]['citation'] = "Curry & Levine 2016"
 
@@ -257,9 +295,10 @@ class TestReadmeGenerator(test.TestCase):
         self.assertIn('General Information', txt)
         self.assertIn('Data Use Notes', txt)
         self.assertIn('References', txt)
-        self.assertIn('Data Overview', txt)
+        self.assertNotIn('Data Overview', txt)
         self.assertNotIn('trial1.json', txt)
         self.assertNotIn('trial3', txt)
+        self.assertNotIn('is accessible', txt)
         self.assertIn('Version History', txt)
         self.assertIn('Methodological Information', txt)
         self.assertIn('##', txt)
@@ -295,7 +334,6 @@ class TestReadmeGenerator(test.TestCase):
         self.assertIn('Version History', txt)
         self.assertNotIn('Methodological Information', txt)
         self.assertNotIn('##', txt)
-
 
 
 

--- a/python/tests/nistoar/pdr/publish/test_readme.py
+++ b/python/tests/nistoar/pdr/publish/test_readme.py
@@ -35,6 +35,8 @@ class TestReadmeGenerator(test.TestCase):
         for key in "OAR_HOME OAR_ETC_DIR OAR_MAKO_TEMPLATES_DIR".split():
             if key in os.environ:
                 del os.environ[key]
+        if not nistoar.pdr.def_etc_dir:
+            nistoar.pdr.def_etc_dir = nistoar.pdr.find_etc_dir()
 
         bag = NISTBag(metabagdir)
         self.nerdm = bag.nerdm_record()

--- a/python/tests/nistoar/pdr/publish/test_readme.py
+++ b/python/tests/nistoar/pdr/publish/test_readme.py
@@ -8,6 +8,7 @@ from nistoar.pdr.preserv.bagit import NISTBag
 from nistoar.pdr.publish import readme
 import nistoar.pdr.exceptions as exceptions
 from nistoar.pdr.utils import read_nerd
+import nistoar.pdr
 
 utestdir = os.path.dirname(os.path.abspath(__file__))
 pdrdir = os.path.dirname(utestdir)
@@ -46,6 +47,7 @@ class TestReadmeGenerator(test.TestCase):
         self.assertIn("Version ", out)
 
     def test_find_default_templatedir(self):
+        nistoar.pdr.def_etc_dir = None
         self.assertIsNone(readme.ReadmeGenerator.find_default_templatedir())
 
         os.environ['OAR_HOME'] = "goob"

--- a/python/tests/nistoar/pdr/publish/test_readme.py
+++ b/python/tests/nistoar/pdr/publish/test_readme.py
@@ -1,0 +1,303 @@
+import os, sys, pdb, shutil, logging, json, re
+import unittest as test
+from collections import OrderedDict
+from StringIO import StringIO
+
+from nistoar.testing import *
+from nistoar.pdr.preserv.bagit import NISTBag
+from nistoar.pdr.publish import readme
+import nistoar.pdr.exceptions as exceptions
+from nistoar.pdr.utils import read_nerd
+
+utestdir = os.path.dirname(os.path.abspath(__file__))
+pdrdir = os.path.dirname(utestdir)
+datadir = os.path.join( os.path.dirname(utestdir), "preserv", "data" )
+bagdir = os.path.join(datadir, "samplembag")
+metabagdir = os.path.join(datadir, "metadatabag")
+basedir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(pdrdir))))
+etcdir = os.path.join(basedir, "etc")
+assert os.path.isdir(etcdir)
+tmpldir = os.path.join(etcdir, "mako", "readme")
+
+stdreclim = sys.getrecursionlimit()
+# def setUpModule():
+#     sys.setrecursionlimit(200)
+
+# def tearDownModule():
+#     global stdreclim
+#     sys.setrecursionlimit(stdreclim)
+    
+
+class TestReadmeGenerator(test.TestCase):
+
+    def setUp(self):
+        for key in "OAR_HOME OAR_ETC_DIR OAR_MAKO_TEMPLATES_DIR".split():
+            if key in os.environ:
+                del os.environ[key]
+
+        bag = NISTBag(metabagdir)
+        self.nerdm = bag.nerdm_record()
+        self.gen = readme.ReadmeGenerator(tmpldir)
+
+    def test_get_tmpl8(self):
+        t = self.gen._get_tmpl8("front_matter")
+        out = t.render(_prompts=True, _brief=False, nrd=self.nerdm, **self.nerdm)
+        self.assertGreater(len(out), 5)
+        self.assertIn("Version ", out)
+
+    def test_find_default_templatedir(self):
+        self.assertIsNone(readme.ReadmeGenerator.find_default_templatedir())
+
+        os.environ['OAR_HOME'] = "goob"
+        self.assertEqual(readme.ReadmeGenerator.find_default_templatedir(),
+                         os.path.join("goob", "etc", "mako", "readme"))
+    
+        os.environ['OAR_ETC_DIR'] = "goob"
+        self.assertEqual(readme.ReadmeGenerator.find_default_templatedir(),
+                         os.path.join("goob", "mako", "readme"))
+    
+        os.environ['OAR_MAKO_TEMPLATES_DIR'] = "goob"
+        self.assertEqual(readme.ReadmeGenerator.find_default_templatedir(),
+                         os.path.join("goob", "readme"))
+    
+        os.environ['OAR_MAKO_TEMPLATES_DIR'] = os.path.join(etcdir, "mako")
+        t = readme.ReadmeGenerator()
+        self.assertEqual(t.templatedir, os.path.join(etcdir, "mako", "readme"))
+
+    def test_write_front_matter(self):
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, True)
+        wrtr.write_front_matter()
+        txt = txt.getvalue()
+        self.assertGreater(len(txt), 5)
+        self.assertIn(self.nerdm['title'][:50], txt)
+        self.assertIn('Version '+self.nerdm['version'], txt)
+        self.assertIn('##', txt)
+                         
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, False)
+        wrtr.write_front_matter()
+        txt = txt.getvalue()
+        self.assertGreater(len(txt), 5)
+        self.assertIn(self.nerdm['title'][:50], txt)
+        self.assertIn('Version '+self.nerdm['version'], txt)
+        self.assertNotIn('##', txt)
+
+    def test_write_general_info(self):
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, True)
+        wrtr.write_general_info()
+        txt = txt.getvalue()
+        self.assertGreater(len(txt), 5)
+        self.assertIn('General Information', txt)
+        self.assertIn('Geographical ', txt)
+        self.assertIn('[##', txt)
+                         
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, False)
+        wrtr.write_general_info()
+        txt = txt.getvalue()
+        self.assertEqual(len(txt), 0)
+
+    def test_write_data_use(self):
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, True)
+        wrtr.write_data_use()
+        txt = txt.getvalue()
+        self.assertGreater(len(txt), 5)
+        self.assertIn('Data Use Notes', txt)
+        self.assertIn('Levine', txt)
+        self.assertNotIn('##', txt)
+                         
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, False)
+        wrtr.write_data_use()
+        txt = txt.getvalue()
+        self.assertGreater(len(txt), 5)
+        self.assertIn('Data Use Notes', txt)
+        self.assertIn('Levine', txt)
+        self.assertNotIn('##', txt)
+
+    def test_write_references(self):
+        self.nerdm['references'][0]['citation'] = "Curry & Levine 2016"
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, True)
+        wrtr.write_references()
+        txt = txt.getvalue()
+        self.assertGreater(len(txt), 5)
+        self.assertIn('References', txt)
+        self.assertIn("Curry & Levine 2016", txt)
+        self.assertIn('##', txt)
+                         
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, False)
+        wrtr.write_references()
+        txt = txt.getvalue()
+        self.assertGreater(len(txt), 5)
+        self.assertIn('References', txt)
+        self.assertIn("Curry & Levine 2016", txt)
+        self.assertNotIn('##', txt)
+
+    def test_write_version_history(self):
+        
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, True)
+        wrtr.write_version_history()
+        txt = txt.getvalue()
+        self.assertGreater(len(txt), 5)
+        self.assertIn('Version History', txt)
+        self.assertIn("1.0.0 (this version)", txt)  
+        self.assertNotIn('[##', txt)
+
+        del self.nerdm['version']
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, True)
+        wrtr.write_version_history()
+        txt = txt.getvalue()
+        self.assertGreater(len(txt), 5)
+        self.assertIn('Version History', txt)
+        self.assertNotIn("1.0.0", txt)  
+        self.assertIn("1.0 (this version)", txt)  
+        self.assertNotIn('[##', txt)
+
+        self.nerdm['version'] = "2.0.0"
+        self.nerdm['versionHistory'] = [{
+            "version": "1.0.0",
+            "description": "initial version"
+        },{
+            "version": "2.0.0",
+            "description": "updated after reanalysis"
+        }]
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, True)
+        wrtr.write_version_history()
+        txt = txt.getvalue()
+        self.assertGreater(len(txt), 5)
+        self.assertIn('Version History', txt)
+        self.assertIn("1.0.0", txt)
+        self.assertIn("2.0.0 (this version)", txt)
+        self.assertIn('[##', txt)
+
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, False)
+        wrtr.write_version_history()
+        txt = txt.getvalue()
+        self.assertGreater(len(txt), 5)
+        self.assertIn('Version History', txt)
+        self.assertIn("1.0.0", txt)
+        self.assertIn("2.0.0", txt)
+        self.assertIn("(this version)", txt)
+        self.assertNotIn('[##', txt)
+
+    def test_write_methods(self):
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, True)
+        wrtr.write_methods()
+        txt = txt.getvalue()
+        self.assertGreater(len(txt), 5)
+        self.assertIn('Methodological', txt)
+        self.assertIn('##', txt)
+                         
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, False)
+        wrtr.write_methods()
+        txt = txt.getvalue()
+        self.assertEqual(len(txt), 0)
+
+    def test_write_data_summary(self):
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, True)
+        wrtr.write_data_overview()
+        txt = txt.getvalue()
+        self.assertGreater(len(txt), 5)
+        self.assertIn('Data Overview', txt)
+        self.assertIn('  trial1.json', txt)
+        self.assertIn('  trial3\n', txt)
+        self.assertIn('    trial3a.json', txt)
+        self.assertIn('[##', txt)
+                         
+        txt = StringIO()
+        wrtr = self.gen.Writer(self.gen, self.nerdm, txt, False)
+        wrtr.write_data_overview()
+        txt = txt.getvalue()
+        self.assertGreater(len(txt), 5)
+        self.assertIn('Data Overview', txt)
+        self.assertIn('  trial1.json', txt)
+        self.assertIn('  trial3\n', txt)
+        self.assertIn('    trial3a.json', txt)
+        self.assertNotIn('##', txt)
+
+    def test_generate(self):
+        self.nerdm['references'][0]['citation'] = "Curry & Levine 2016"
+
+        txt = StringIO()
+        self.gen.generate(self.nerdm, txt, True)
+        txt = txt.getvalue()
+        self.assertIn(self.nerdm['title'][:50], txt)
+        self.assertIn('Version '+self.nerdm['version'], txt)
+        self.assertIn('###', txt)
+        self.assertIn('General Information', txt)
+        self.assertIn('Data Use Notes', txt)
+        self.assertIn('References', txt)
+        self.assertIn('Data Overview', txt)
+        self.assertIn('  trial1.json', txt)
+        self.assertIn('  trial3\n', txt)
+        self.assertIn('    trial3a.json', txt)
+        self.assertIn('Version History', txt)
+        self.assertIn('Methodological Information', txt)
+        self.assertIn('##', txt)
+        self.assertIn('[##', txt)
+                         
+        txt = StringIO()
+        self.gen.generate(self.nerdm, txt, True, True)
+        txt = txt.getvalue()
+        self.assertIn(self.nerdm['title'][:50], txt)
+        self.assertIn('Version '+self.nerdm['version'], txt)
+        self.assertIn('###', txt)
+        self.assertIn('General Information', txt)
+        self.assertIn('Data Use Notes', txt)
+        self.assertIn('References', txt)
+        self.assertIn('Data Overview', txt)
+        self.assertNotIn('trial1.json', txt)
+        self.assertNotIn('trial3', txt)
+        self.assertIn('Version History', txt)
+        self.assertIn('Methodological Information', txt)
+        self.assertIn('##', txt)
+        self.assertIn('[##', txt)
+                         
+        txt = StringIO()
+        self.gen.generate(self.nerdm, txt, False)
+        txt = txt.getvalue()
+        self.assertIn(self.nerdm['title'][:50], txt)
+        self.assertIn('Version '+self.nerdm['version'], txt)
+        self.assertNotIn('General Information', txt)
+        self.assertIn('Data Use Notes', txt)
+        self.assertIn('References', txt)
+        self.assertIn('Data Overview', txt)
+        self.assertIn('  trial1.json', txt)
+        self.assertIn('  trial3\n', txt)
+        self.assertIn('    trial3a.json', txt)
+        self.assertIn('Version History', txt)
+        self.assertNotIn('Methodological Information', txt)
+        self.assertNotIn('##', txt)
+                         
+        txt = StringIO()
+        self.gen.generate(self.nerdm, txt, False, True)
+        txt = txt.getvalue()
+        self.assertIn(self.nerdm['title'][:50], txt)
+        self.assertIn('Version '+self.nerdm['version'], txt)
+        self.assertNotIn('General Information', txt)
+        self.assertIn('Data Use Notes', txt)
+        self.assertIn('References', txt)
+        self.assertNotIn('Data Overview', txt)
+        self.assertNotIn('trial1.json', txt)
+        self.assertNotIn('trial3', txt)
+        self.assertIn('Version History', txt)
+        self.assertNotIn('Methodological Information', txt)
+        self.assertNotIn('##', txt)
+
+
+
+
+if __name__ == '__main__':
+    test.main()


### PR DESCRIPTION
This PR adds a new service to the publishing metadata service that automatically creates a README file for a submission constructed out of its NERDm metadata.  Users can download the file, edit it, and then submit it to MIDAS as a normal distribution file.   

The auto-generation is accessed via the URL, `/midas/`_id_`/README.txt?auto=1`.  This will return the generated README text file; by default, this text will include prompts to the use to aid in editing file.  An additional parameter to the URL, `flags`, modifies the output.  If the value includes a `P`, editing prompts will be excluded.  If `B` (mnuemonic: "brief") is included, the README will not list the files in the collection (helpful when the collection is large).  

This was tested by a user testing group via midastraining and dataputest; see the [GitLab feedback repo](https://gitlab.nist.gov/gitlab/oar/user-testing/-/issues) for feedback.