### PR TITLE
Support changes to revision policy

### DIFF
--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -2081,14 +2081,36 @@
       }
     },
     "browserslist": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
-      "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000960",
-        "electron-to-chromium": "^1.3.124",
-        "node-releases": "^1.1.14"
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.71"
+      },
+      "dependencies": {
+        "caniuse-lite": {
+          "version": "1.0.30001228",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
+          "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.737",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.737.tgz",
+          "integrity": "sha512-P/B84AgUSQXaum7a8m11HUsYL8tj9h/Pt5f7Hg7Ty6bm5DxlFq+e5+ouHUoNQMsKDJ7u4yGfI8mOErCmSH9wyg==",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.72",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+          "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
+          "dev": true
+        }
       }
     },
     "browserstack": {
@@ -2469,6 +2491,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colorette": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
     "colors": {
@@ -3100,9 +3128,9 @@
       "dev": true
     },
     "dns-packet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
+      "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
       "dev": true,
       "requires": {
         "ip": "^1.1.0",
@@ -3185,12 +3213,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-    },
-    "electron-to-chromium": {
-      "version": "1.3.127",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.127.tgz",
-      "integrity": "sha512-1o25iFRf/dbgauTWalEzmD1EmRN3a2CzP/K7UVpYLEBduk96LF0FyUdCcf4Ry2mAWJ1VxyblFjC93q6qlLwA2A==",
-      "dev": true
     },
     "elliptic": {
       "version": "6.5.3",
@@ -3354,6 +3376,12 @@
       "requires": {
         "es6-promise": "^4.0.3"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -6940,15 +6968,6 @@
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         }
-      }
-    },
-    "node-releases": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.17.tgz",
-      "integrity": "sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==",
-      "dev": true,
-      "requires": {
-        "semver": "^5.3.0"
       }
     },
     "node-sass": {

--- a/docs/PreservationService.md
+++ b/docs/PreservationService.md
@@ -1,5 +1,7 @@
 # The Preservation Service
 
+*Note:* _This needs to be revised for the MIDAS Mark III convention._
+
 The Preservation Service is a service that operates inside the NIST
 internal network.  Its general purpose to turn Submission Information
 Packages (SIPs) into Archive Information Packages--or bags, ingest

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -1,0 +1,290 @@
+# Identifiers and Version Tracking in the PDR
+
+The NIST Public Data Repository (PDR) supports revision of resource
+publicaitons after the initial publication.  Each edition is given a
+sequential version to distinguish them.  So that the specific versions
+can be referred to in a linked data context, versions are built into
+the PDR's identifier conventions.  This document explains the version
+and associated identifier conventions used by the PDR generally and
+then explains how it is supported specifically in the publishing
+pipelines.
+
+## Version Conventions
+
+In general, the PDR assigns a three-level numeric version of the form:
+
+_X.Y.Z_
+
+where _X_, _Y_, and _Z_ are each integers and reflect the levels
+reflect the significance of the revision (analagous to the Semantic
+Versioning, or SemVer, convention common to software release
+versioning):
+
+  _Z_ -- reflects an update to the publication's metadata only.  These
+         changes usually affect content and formatting of the
+         landing page.  For publications where the PDR houses the data
+         files that make up the publication, content of the these
+         files have not changed.
+
+  _Y_ -- reflects a change in the data files that comprise the
+         resource publication (as well as possibly the associated
+         metadata).  This includes changes to previously
+         published files, the addition of new files, or the removal
+         files.  When this value is incremented, the _Z_ value is set
+         to "0".  
+
+  _Z_ -- reflects a major reissue of the resource including both
+         file content and metadata.  Currently, this is incremented
+         only upon special request by the author.  When it is incremented,
+         the _Y_ and _Z_ values are each set to "0".  
+
+The publishing pipelines in general will detect if the resource has
+been published before.  If it has not, the initial version will be set
+to "1.0.0".  As with the SemVer convention, the sequence of assigned
+versions assigned to a resource reflect the time order that the
+revisions were released.  The assigned version can be customized by
+the author (usually by special request); this is usually done to match
+the version conventions used by the author.  Customized versions,
+however, must follow the PDR's sequencing convention.
+
+The version string is stored in the NERDm metadata via its "version"
+property.  In addition, the "releaseHistory" property lists brief
+descriptions of all the versions that are part of the sequence of
+revisions; each includes a comment briefly describing what changed.  
+
+In some contexts, the version displayed to PDR visitors may only
+display the _X_ and _Y_ fields.
+
+## Resource Identifier Conventions
+
+Each resource in the PDR is assigned an internal identifier with an
+ARK format [1] with the form,
+
+`ark:/`_ARKNAAN_/_CONV_-_LOCALID_
+
+where,
+
+  _ARKNAAN_ -- the ARK Naming Assigning Authority Number; for NIST,
+               this is "88434".
+  _PIPE_ -- is a publisher-unique namespace (often called a "shoulder")
+               that reflect publishing pipeline that was used when the
+               resource was first published.  Resource published
+               through MIDAS have the form "mds_N_", where _N_ is the
+               major version of the publishing pipeline.  (Within the
+               PDR, this is often refered to as the "SIP type".)
+  _LOCALID_ -- a local identifier assigned by the publishing
+               pipeline.  Often this is a sequence number (e.g. "2303").
+
+Once this PDR-ID is assigned, it does not change across the
+different revisions and assigned versions.  If two resources have
+different PDR-IDs they are treated as distinct in the PDR with
+separate evolutions.  The authors, however, can declare ad hoc
+relationships between them (like one deprecates another).
+
+When this PDR-ID is resolved (e.g. to a landing page or to metadata),
+it should resolve by default to the latest version of the resource.
+
+### Version-tracking Identifiers
+
+The PDR supports a related set of identifiers used to track and refer
+to specific versions of the resource.  Generally, these are not seen
+by casual users of the repository.
+
+A version-specific identifier appends a suffix of ".vX_Y_Z" to the
+general form described above.  It will resolve to to the "X.Y.Z"
+version of the resource.  An example would be,
+"ark:/88434/mds2-2303.v1_0_0".
+
+The PDR supports a special type of collection called a "release
+sequence".  This assembles all of the published versions of a resource
+into a logical collection representing the release history of the
+resource.  The identifier for this collection has a suffix of ".rel"
+appended to the general ID form, as in "ark:/88434/mds2-2303.rel".
+This identifier will resolve to a description of the release history
+of the resource.
+
+## Dates associated with Revisions
+
+The resource publication's metadata includes several dates that assist
+in tracking the evolution of the resource with in the repository.
+These are as follows:
+
+## Other Resource Identifers
+
+The PDR assigns additional identifiers to resources.  Some of these
+are exported external users via metadata; these include an EDI
+identifier and (usually) a DOI.  Others, like the SIP and AIP
+identifiers, are applied implicitly and are used internally only.  All
+of these can be lexigraphically distinct but bear similarities by
+convention.  
+
+### Enterprise Data Inventory (EDI) Identifier
+
+The EDI ID serves a purpose specific to US government agencies.  Each
+agency is mandated to support an Enterpris Data Inventory that lists
+metadata descriptions of the data holdings of the agency.  The
+descriptions of data resources that are considered public are exported
+to data.gov in the Project Open Data (POD) catalog format.  The EDI ID
+is the identifier that is applied to the POD resource description
+within the catalog.
+
+At NIST, the EDI predates the PDR.  Initially, the EDI (via MIDAS)
+assigned identifiers composed of a random 32-character string plus a
+sequence number.  Subsequently, MIDAS adopted the use of PDR-compliant
+ARK identifiers with the "mdsN" shoulder and a local id matching the
+MIDAS-assigned sequence or "record" number
+(e.g. "ark:/88434/mds2-2303").  The PDR uses the EDI-ID as the PDR-ID
+when the resource if first published (via the MIDAS publishing
+pipeline).  The EDI-ID is captured within the PDR's NERDm schema via
+the "ediid" property.  
+
+NIST policy for revisions mandates that when a revision updates a
+previously published file (which would trigger an increment in the _Y_
+version field in the PDR), the resource must be assigned a new
+EDI ID. MIDAS implements this by assigning a new record number to the
+record.  When this occurs the PDR ID is _not_ changed; thus, the the
+PDR-ID and and EDI-ID will not be the same.
+
+### The Digital Object Identifier (DOI)
+
+The DOI is a globally unique and resolvable ID that used by external
+users to cite a data publication.  In the PDR, not all resources are
+guaranteed to have a DOI assigned; however, NIST policy now requires
+all new publications to be assigned a DOI.  For historical reasons,
+some resources do not have a DOI assigned.
+
+Currently, PDR pipelines assign DOIs; though, this was formerly
+handled by MIDAS.  As with the EDI-ID, NIST policy requires that
+revisions involve changes in data files to be assigned a new DOI.  In
+the MIDAS publishing pipeline, the PDR assigns a DOI that uses the
+EDI's ARK shoulder-local-id combination as the DOI local ID (as in,
+"doi:10.80443/mds2-2303").
+
+The DOI is captured in the NERDm metadata via the "doi" property.
+
+### The Submission Information Package (SIP) identifier
+
+The SIP ID is an identifier used internally by a PDR publishing
+pipeline to process a submission to the PDR for publication.  Its form
+depends on the publishing pipeline; with MIDAS SIPs, it matched the
+EDI-ID.  
+
+### The Archive Information Package (AIP) identifier
+
+The AIP ID is an identifier for locating preservation packages in
+long-term storage.  While assigned by the publishing pipeline, it
+plays a key role in the implementation of the distribution service.  
+
+## Support for versions within NIST-specific Publlishing Pipelines
+
+PDR Publishing pipelines are designed in general to support a specific
+convention for Submission Information Packages (SIPs in the OAIS
+repository model).  Different pipelines have different ID shoulders
+associated with them.  
+
+### MIDAS (mds)
+
+The latest MIDAS publishing pipeline adheres to the so-called Mark III
+conventions (which itself has been subject to some evolution),
+characterized generally by the following:
+
+  * MIDAS pushes metadata to the PDR as POD records via the
+    /pdr/latest and /pdr/draft service endpoints.
+  * The resources have a local id of the form "mds2-RECNUM", where
+    RECNUM is the MIDAS record number.
+  * On revsion, if the author (i.e. MIDAS user) updates a previously
+    published file, MIDAS assigns it a new record number; the POD
+    record sent to the PDR will include a "replaces" property giving
+    the EDI-ID of the record the new one deprecates.
+  * If the author opts for a PDR-generated home page, the landing page
+    URL will be set to the form of "https://data.nist.gov/od/id/MIDAS_ID"
+  * A file's download URL will be set to the form of
+    "https://data.nist.gov/od/ds/MIDAS_ID" 
+
+Note that under a major revision that changes the EDI-ID, the URLs to
+the resource will change, too.
+
+The PDR-MIDAS pipeline has three pieces to it:
+  * MIDAS, the user interface for creating publications and entering
+    metadata
+  * the PDR Publishing Service, used by MIDAS to preview and customize
+    landing pages (via the /pdr/latest and /pdr/draft endpoints)
+  * the PDR Preservation Service, used to push a completed publication
+    to the PDR.
+
+As the publication author uses MIDAS to create a data publication,
+MIDAS feeds thd metadata to the PDR Publishing Service.  This service
+uses this metadata to create and update a draft preservation bag that
+contains only metadata.  It uses the EDI-ID along with the associated
+"replaces" property to determine if the resource has been published
+before.  If it has, a metadata bag is created using the previous
+publication's head bag as a starting point and the POD metadata is
+merged into it; if not, a prototype is created based on just the POD
+metadata.  
+
+If the resource has not been published before, a PDR-ID is assigned to
+the SIP that matches the ARK-based EDI-ID, and the version is
+initialized to "1.0.0".  It uses the follow process to set the draft
+metadata bag and set the IDs and version:
+
+  * the PDR determines the ID of the previously published
+    edition of the resource.  If the POD record has a "replaces" property,
+    that is taken as the EDI-ID of the previous edition; otherwise,
+    the POD's "identifier" property is taken as the previous EDI-ID.
+  * From the previous EDI-ID, the AIP-ID is determined.  It uses the
+    PDR's distribution service is used to find the last published head
+    bag for that AIP-ID.
+  * If a previous bag is not found, the resource is a first time publication:
+      * a draft bag created solely on the input POD metadata
+      * the version is set to "1.0.0"
+      * the PDR-ID is set to the EDI-ID
+  * If the previous bag does exist, the resource is a revision:
+      * that bag is unpacked and used as the starting point for a
+        revision metadata bag
+      * the PDR-ID is retained from the previous publication
+      * the EDI-ID is set to that of POD record's "identifier"
+      * the "replaces" property is copied to the new resources
+        metadata
+      * the version is set to the value of the previous publication
+        but with "+ (edit)" as indicator that the final version string
+        has not been determined, yet.
+        
+Once a draft metadata bag is established in the PDR's publishing
+space, it is just updated with new metadata from MIDAS until it is
+ready to publish.
+
+The preservation service is responsible for converting a draft
+metadata bag into a final bag ready for preservation.  To trigger
+preservation, MIDAS sends the final POD to the preservation service.
+The PDR that metadata into the metadata bag and finalizes it for
+preservation.  In particular, any data files provided by MIDAS are
+added to the bag.  A revision will be considered a major change
+(requiring an increment to the version's _Y_ field) if either:
+  * the bag contains new, deleted, or revised data files, or
+  * the bag was given a new EDI-ID
+Based on this assessment the version property is replace with an
+appropriately incremented version string.  The "releaseHistory"
+property will be extended to describe the new version. 
+
+Also part of the finalization is an update to key dates described
+above:
+  * if the resource is being published for the first time, the
+    "firstIssued" date is set to the current time.
+  * if the resource the _X_ or _Y_ version fields was incremented,
+    the "revised" date is set to the current time.
+  * the "annotated" date is set to the current time.
+
+The preservation service is also responsible for issuing a DOI or
+updating the associated metadata.  On the initial publication, the DOI
+is set with a local ID comprised of the PDR-ID's shoulder-local-id
+combination (as in, "doi:10.80443/mds2-2303").  If on revision the
+EDI-ID has changed, the NERDm metadata will include a new DOI-ID in
+its "doi" property; this will cause a new DOI to be issued for the
+record.  
+
+### Programmatic Data Publishing (pdp)
+
+
+
+
+   

--- a/python/nistoar/pdr/__init__.py
+++ b/python/nistoar/pdr/__init__.py
@@ -4,6 +4,8 @@ Provide functionality for the Public Data Repository
 import os
 from abc import ABCMeta, abstractmethod, abstractproperty
 
+from .constants import *
+
 try:
     from .version import __version__
 except ImportError:

--- a/python/nistoar/pdr/constants.py
+++ b/python/nistoar/pdr/constants.py
@@ -1,0 +1,13 @@
+"""
+some constants for the PDR
+"""
+PDR_PUBLIC_SERVER_PROD = "data.nist.gov"
+PDR_PUBLIC_SERVER_TEST = "testdata.nist.gov"
+PDR_PUBLIC_SERVER = PDR_PUBLIC_SERVER_PROD
+PDR_PUBLISH_SERVER_PROD = "datapub.nist.gov"
+PDR_PUBLISH_SERVER_TEST = "datapubtest.nist.gov"
+PDR_PUBLISH_SERVER = PDR_PUBLISH_SERVER_PROD
+
+from ..id import NIST_ARK_NAAN
+ARK_NAAN = NIST_ARK_NAAN
+

--- a/python/nistoar/pdr/distrib/bagclient.py
+++ b/python/nistoar/pdr/distrib/bagclient.py
@@ -3,7 +3,8 @@ This distrib submodule provides a client interface to the part of the PDR
 Distribution Service that provides access to preservation bags. 
 """
 import os
-from .client import RESTServiceClient
+from .client import (RESTServiceClient, DistribResourceNotFound, DistribServiceException,
+                     DistribClientError, DistribServiceException)
 
 class BagDistribClient(object):
     """

--- a/python/nistoar/pdr/preserv/bagger/midas.py
+++ b/python/nistoar/pdr/preserv/bagger/midas.py
@@ -20,7 +20,7 @@ from . import utils as bagutils
 from ..bagit.builder import BagBuilder, NERDMD_FILENAME, FILEMD_FILENAME
 from ..bagit import NISTBag
 from ..bagit.tools import synchronize_enhanced_refs
-from ....id import PDRMinter, NIST_ARK_NAAN
+from ....id import PDRMinter
 from ... import def_merge_etcdir, utils
 from .. import (SIPDirectoryError, SIPDirectoryNotFound, AIPValidationError,
                 ConfigurationException, StateException, PODError,
@@ -28,6 +28,9 @@ from .. import (SIPDirectoryError, SIPDirectoryNotFound, AIPValidationError,
 from .prepupd import UpdatePrepService
 from .datachecker import DataChecker
 from nistoar.nerdm.merge import MergerFactory
+
+from .... import pdr
+ARK_NAAN = pdr.ARK_NAAN
 
 # _sys = PreservationSystem()
 log = logging.getLogger(_sys.system_abbrev)   \
@@ -50,7 +53,7 @@ _DATA_UPDATE  = 2
 def _midadid_to_dirname(midasid, log=None):
     out = midasid
 
-    if midasid.startswith("ark:/"+NIST_ARK_NAAN+"/"):
+    if midasid.startswith("ark:/"+ARK_NAAN+"/"):
         # new ARK-based MIDAS identifiers: chars. after shoulder is the
         # record number and name of directory
         out = re.sub(r'^ark:/\d+/(mds\d+\-)?', '', midasid)
@@ -393,7 +396,7 @@ class MIDASMetadataBagger(SIPBagger):
         if not os.path.exists(self.bagdir):
             self.bagbldr.ensure_bag_structure()
 
-            if self.midasid.startswith("ark:/"+NIST_ARK_NAAN+"/"):
+            if self.midasid.startswith("ark:/"+ARK_NAAN+"/"):
                 # new-style EDI ID is a NIST ARK identifier; use it as our SIP id
                 id = self.midasid
             else:
@@ -1123,7 +1126,11 @@ class PreservationBagger(SIPBagger):
         else:
             adata = OrderedDict()
         adata['version'] = newver
-        verhist = mdata.get('versionHistory', [])
+        relhist = mdata.get('releaseHistory')
+        if relhist is None:
+            relhist = bagutils.create_release_history_for(mdata['@id'])
+            relhist['hasRelease'] = mdata.get('versionHistory', [])
+        verhist = relhist['hasRelease']
 
         if uptype != _NO_UPDATE and newver != mdata['version'] and \
            ('issued' in mdata or 'modified' in mdata) and \
@@ -1134,7 +1141,8 @@ class PreservationBagger(SIPBagger):
                 ('version', newver),
                 ('issued', issued),
                 ('@id', mdata['@id']),
-                ('location', 'https://data.nist.gov/od/id/'+mdata['@id'])
+                ('location', 'https://'+pdr.PDR_PUBLIC_SERVER+ \
+                             re.sub(r'\.rel$', ".v"+re.sub(r'\.','_', adata['version']), relhist['@id']))
             ]))
             if update_reason is None:
                 if uptype == _MDATA_UPDATE:
@@ -1144,7 +1152,7 @@ class PreservationBagger(SIPBagger):
                 else:
                     update_reason = ''
             verhist[-1]['description'] = update_reason
-            adata['versionHistory'] = verhist
+            adata['releaseHistory'] = relhist
         
         utils.write_json(adata, annotf)
 

--- a/python/nistoar/pdr/preserv/bagger/midas.py
+++ b/python/nistoar/pdr/preserv/bagger/midas.py
@@ -604,7 +604,7 @@ class MIDASMetadataBagger(SIPBagger):
                                                  not self.fileExaminer)
 
             if self.fileExaminer:
-                md["_status"] = "in progress"
+                md["__status"] = "in progress"
                 
                 # the file examiner will calculate the file's checksum
                 # asynchronously; for now though, see if there is an associated
@@ -749,12 +749,12 @@ class MIDASMetadataBagger(SIPBagger):
             
                 md = self.bagger.bagbldr.describe_data_file(location, filepath,
                                                             True, ct)
-                if '_status' in md:
-                    md['_status'] = "updated"
+                if '__status' in md:
+                    md['__status'] = "updated"
                 md = self.bagger.bagbldr.update_metadata_for(filepath, md, ct,
                                    "async metadata update for file, "+filepath)
-                if '_status' in md:
-                    del md['_status']
+                if '__status' in md:
+                    del md['__status']
                     self.bagger.bagbldr.replace_metadata_for(filepath, md, '')
                 self.bagger._mark_filepath_synced(filepath)
 

--- a/python/nistoar/pdr/preserv/bagger/midas3.py
+++ b/python/nistoar/pdr/preserv/bagger/midas3.py
@@ -739,7 +739,7 @@ class MIDASMetadataBagger(SIPBagger):
                               "publication.")
                 if self.previd:
                     self.bagbldr.update_annotations_for("", {"replaces": self.previd}, message="")
-                    self.update_bagger_metadata_for('', {"replacedEDI": self.previd})
+                    # self.update_bagger_metadata_for('', {"replacedEDI": self.previd})
 
         if not os.path.exists(self.bagdir):
             self.bagbldr.ensure_bag_structure()
@@ -1091,7 +1091,7 @@ class MIDASMetadataBagger(SIPBagger):
             md = self.bagbldr.describe_data_file(inpath, destpath, examine)
 
             if self.fileExaminer:
-                md["_status"] = "in progress"
+                md["__status"] = "in progress"
                 
                 # the file examiner will calculate the file's checksum;
                 # for now though, see if there is an associated checksum file 
@@ -1360,8 +1360,8 @@ class MIDASMetadataBagger(SIPBagger):
             
                 md = self.bagger.bagbldr.describe_data_file(location, filepath,
                                                             True, ct)
-                if '_status' in md:
-                    md['_status'] = "updated"
+                if '__status' in md:
+                    md['__status'] = "updated"
 
                 # it's possible that this file has been deleted while this
                 # thread was launched; make sure it still exists
@@ -1373,8 +1373,8 @@ class MIDASMetadataBagger(SIPBagger):
 
                 md = self.bagger.bagbldr.update_metadata_for(filepath, md, ct,
                                    "async metadata update for file, "+filepath)
-                if '_status' in md:
-                    del md['_status']
+                if '__status' in md:
+                    del md['__status']
                     self.bagger.bagbldr.replace_metadata_for(filepath, md, '')
                 self.bagger._mark_filepath_synced(filepath)
 
@@ -1927,7 +1927,7 @@ class PreservationBagger(SIPBagger):
         # remove non-standard, administrative metadata from pod
         if os.path.exists(self.bagbldr.bag.pod_file()):
             md = self.bagbldr.bag.pod_record()
-            rmkeys = [k for k in md.keys() if k.startswith('_')]
+            rmkeys = [k for k in md.keys() if k.startswith('__')]
             if len(rmkeys) > 0:
                 for key in rmkeys:
                     del md[key]
@@ -1939,7 +1939,7 @@ class PreservationBagger(SIPBagger):
                 if mdfile in files:
                     nf = os.path.join(root, mdfile)
                     md = utils.read_json(nf)
-                    rmkeys = [k for k in md.keys() if k.startswith('_')]
+                    rmkeys = [k for k in md.keys() if k.startswith('__')]
                     if len(rmkeys) > 0:
                         for key in rmkeys:
                             del md[key]

--- a/python/nistoar/pdr/preserv/bagger/midas3.py
+++ b/python/nistoar/pdr/preserv/bagger/midas3.py
@@ -1231,7 +1231,7 @@ class MIDASMetadataBagger(SIPBagger):
                     ver.append(0)
 
                 bmd = self.baggermd_for('')
-                if self.sip.nerd.get('') != "removed" and \
+                if self.sip.nerd.get('status') != "removed" and \
                    (len(self.datafiles) > 0 or bmd.get('replacedEDI')):
                     # either there're data files waiting to be included; it's a data update
                     uptype = _DATA_UPDATE
@@ -1279,7 +1279,7 @@ class MIDASMetadataBagger(SIPBagger):
             relhist['hasRelease'].append(OrderedDict([
                 ('version', self.sip.nerd['version']),
                 ('issued', issued),
-                ('@id', self.sip.nerd['@id']),
+                ('@id', self.sip.nerd['@id']+".v"+re.sub(r'\.','_',self.sip.nerd['version'])),
                 ('location', 'https://'+PDR_PUBLIC_SERVER+'/od/id/'+ \
                           re.sub(r'\.rel$',
                                  ".v"+re.sub(r'\.','_', self.sip.nerd['version']),
@@ -1287,7 +1287,7 @@ class MIDASMetadataBagger(SIPBagger):
             ]))
             if self.sip.nerd.get('status', 'available') == 'removed':
                 # need to deprecate all previous minor versions
-                self._set_history_deactivated(relhist)
+                self._set_history_deactivated(relhist['hasRelease'])
             elif self.sip.nerd.get('status', 'available') != 'available':
                 verhist[-1]['status'] = self.sip.nerd.get('status')
             if update_reason is None:
@@ -1309,9 +1309,9 @@ class MIDASMetadataBagger(SIPBagger):
     def _set_history_deactivated(self, relhist):
         # Note: possible error mode: if files were added without triggering an edi-id change,
         # those major versions will not get marked as removed.  
-        lastver = verhist[-1].get('version','1.0.0')
+        lastver = relhist[-1].get('version','1.0.0')
         lastmaj = re.sub(r'\.\d+$', '', lastver)
-        for rel in verhist:
+        for rel in relhist:
             if rel.get('version', '').startswith(lastmaj):
                 rel['status'] = 'removed'
         return relhist

--- a/python/nistoar/pdr/preserv/bagger/midas3.py
+++ b/python/nistoar/pdr/preserv/bagger/midas3.py
@@ -1225,7 +1225,9 @@ class MIDASMetadataBagger(SIPBagger):
                 ('issued', issued),
                 ('@id', self.sip.nerd['@id']),
                 ('location', 'https://'+PDR_PUBLIC_SERVER+'/od/id/'+ \
-                             re.sub(r'\.rel$', re.sub(r'\.','_', self.sip.nerd['version']), relhist['@id']))
+                          re.sub(r'\.rel$',
+                                 ".v"+re.sub(r'\.','_', self.sip.nerd['version']),
+                                 relhist['@id']))
             ]))
             if update_reason is None:
                 if uptype == _MDATA_UPDATE:

--- a/python/nistoar/pdr/preserv/bagger/midas3.py
+++ b/python/nistoar/pdr/preserv/bagger/midas3.py
@@ -798,6 +798,8 @@ class MIDASMetadataBagger(SIPBagger):
         replaces = self.previd
         if replaces == self.midasid:
             replaces = None
+        if replaces:
+            replaces = re.sub(r'^ark:/\d+/', '', replaces)
         return self.prepsvc.prepper_for(self.name, replaces=replaces, log=self.log.getChild("prepper"))
                 
     def ensure_res_metadata(self):

--- a/python/nistoar/pdr/preserv/bagger/midas3.py
+++ b/python/nistoar/pdr/preserv/bagger/midas3.py
@@ -1817,7 +1817,7 @@ class PreservationBagger(SIPBagger):
         if len(self.datafiles) > 0 or bmd.get('replacedEDI') or firstpub:
             dates['revised'] = now
         ## by default, keep the issued data passed in from MIDAS
-        if 'issued' not in self.sip.nerd:
+        if not self.sip.nerd.get('issued'):
             dates['issued'] = now
         if self.sip.nerd.get('version','1.0.0') == "1.0.0":
             dates['firstIssued'] = self.sip.nerd.get('issued', now)

--- a/python/nistoar/pdr/preserv/bagger/midas3.py
+++ b/python/nistoar/pdr/preserv/bagger/midas3.py
@@ -1810,6 +1810,7 @@ class PreservationBagger(SIPBagger):
         self.prepare(nodata=False)
 
         # update a few dates in the metadata
+        firstpub = self.sip.nerd.get('version','1.0.0') == "1.0.0"
         now = datetime.fromtimestamp(time.time()).isoformat()
         bmd = self.baggermd_for('')
         dates = OrderedDict()
@@ -1819,7 +1820,7 @@ class PreservationBagger(SIPBagger):
         ## by default, keep the issued data passed in from MIDAS
         if not self.sip.nerd.get('issued'):
             dates['issued'] = now
-        if self.sip.nerd.get('version','1.0.0') == "1.0.0":
+        if firstpub:
             dates['firstIssued'] = self.sip.nerd.get('issued', now)
         self.bagbldr.update_annotations_for('', dates, message="setting publishing dates")
 

--- a/python/nistoar/pdr/preserv/bagger/midas3.py
+++ b/python/nistoar/pdr/preserv/bagger/midas3.py
@@ -1223,7 +1223,7 @@ class MIDASMetadataBagger(SIPBagger):
             if prepr:
                 lastver = prepr.latest_version(["bag-cache", "bag-store", "repo"])
             if lastver == "0":
-                self.log.debug("finalizing version: dataset has never been published; setting version to 1.0.0")
+                self.log.info("finalizing version: dataset has never been published; setting version to 1.0.0")
                 self.sip.nerd['version'] = "1.0.0"
 
             else:

--- a/python/nistoar/pdr/preserv/bagger/prepupd.py
+++ b/python/nistoar/pdr/preserv/bagger/prepupd.py
@@ -603,12 +603,18 @@ class UpdatePrepper(object):
 
     def _latest_version_from_nerdcache(self):
         nerdf = os.path.join(self.mdcache, self.aipid+".json")
+        if not os.path.exists(nerdf) and self._prevaipid:
+            nerdf = os.path.join(self.mdcache, self._prevaipid+".json")
         return self._latest_version_from_nerdmfile(nerdf)
 
     def _latest_version_from_dir(self, bagparent):
         foraip = [f for f in os.listdir(bagparent)
                     if f.startswith(self.aipid+'.') and
                        not f.endswith('.sha256')        ]
+        if self._prevaipid and not foraip:
+            foraip = [f for f in os.listdir(bagparent)
+                        if f.startswith(self._prevaipid+'.') and
+                           not f.endswith('.sha256')        ]
         if not foraip:
             return "0"
         latest = bagutils.find_latest_head_bag(foraip)

--- a/python/nistoar/pdr/preserv/bagger/prepupd.py
+++ b/python/nistoar/pdr/preserv/bagger/prepupd.py
@@ -13,6 +13,7 @@ from .base import sys as _sys
 from .. import (ConfigurationException, StateException, CorruptedBagError,
                 NERDError)
 from . import utils as bagutils
+from ...config import merge_config
 from ...describe import rmm
 from ... import distrib
 from ...exceptions import IDNotFound
@@ -406,9 +407,9 @@ class UpdatePrepper(object):
         bgrmdf = os.path.join(inbag, self._bgrmdf)
         if os.path.exists(bgrmdf):
             md = utils.read_json()
-            md = merge_config(mdates, md)
         else:
             md = OrderedDict()
+        md = merge_config(mdata, md)
         self._baggermd_replace(md, inbag)
         
 

--- a/python/nistoar/pdr/preserv/bagger/prepupd.py
+++ b/python/nistoar/pdr/preserv/bagger/prepupd.py
@@ -615,7 +615,7 @@ class UpdatePrepper(object):
         foraip = [f for f in os.listdir(bagparent)
                     if f.startswith(self.aipid+'.') and
                        not f.endswith('.sha256')        ]
-        if self._prevaipid and not foraip:
+        if not foraip and self._prevaipid and self._prevaipid != self.aipid:
             foraip = [f for f in os.listdir(bagparent)
                         if f.startswith(self._prevaipid+'.') and
                            not f.endswith('.sha256')        ]

--- a/python/nistoar/pdr/preserv/bagger/utils.py
+++ b/python/nistoar/pdr/preserv/bagger/utils.py
@@ -238,6 +238,8 @@ class BagName(object):
     a list of bag names.  In particular, the constructor can be used as a key function
     passed to the sort function.  
     """
+    _todotre = re.compile(r'_')
+
     def __init__(self, bagname):
         """
         wrap a bag name
@@ -263,7 +265,7 @@ class BagName(object):
         also be part of later versions of the AIP.)  If the version is an empty string,
         it can be taken as version 0 or version 1.
         """
-        return self.fields[1]
+        return self._todotre.sub('.', self.fields[1])
 
     @property
     def multibag_profile(self):

--- a/python/nistoar/pdr/preserv/bagit/builder.py
+++ b/python/nistoar/pdr/preserv/bagit/builder.py
@@ -2124,7 +2124,7 @@ class BagBuilder(PreservationSystem):
         else:
             initdata['External-Description'] = \
 "This collection contains data for the NIST data resource entitled, {0}". \
-format(nerdm['title'])
+format(nerdm['title'].replace('\n', ' '))
 
         initdata['External-Identifier'] = [self.id]
         if nerdm.get('doi'):
@@ -2261,8 +2261,8 @@ format(nerdm['title'])
                 for val in vals:
                     # WARNING: when cvting to python3, careful with encoding
                     out = u"{0}: {1}".format(name, val)
-                    if len(out) > 79:
-                        out = textwrap.fill(out, 79, subsequent_indent=' ')
+                    # Not only wrap text, but also gets rid of embedded newlines, tabs, etc.
+                    out = textwrap.fill(out, 79, subsequent_indent=' ', expand_tabs=False)
                     print(out.encode('utf-8'), file=fd)
 
     def write_mbag_files(self, overwrite=False):

--- a/python/nistoar/pdr/preserv/bagit/builder.py
+++ b/python/nistoar/pdr/preserv/bagit/builder.py
@@ -17,7 +17,7 @@ from .exceptions import (BagProfileError, BagWriteError, BadBagRequest,
 from ....nerdm.exceptions import (NERDError, NERDTypeError)
 from ....nerdm.convert import PODds2Res
 from ....nerdm.constants import core_schema_base, schema_versions
-from ....id import PDRMinter, NIST_ARK_NAAN
+from ....id import PDRMinter
 from ...utils import (build_mime_type_map, checksum_of, measure_dir_size,
                       read_nerd, read_pod, write_json)
 
@@ -34,6 +34,7 @@ NORM=15  # Log Level for recording normal activity
 logging.addLevelName(NORM, "NORMAL")
 # log = logging.getLogger(__name__)
 
+from ... import ARK_NAAN, PDR_PUBLIC_SERVER
 DEF_BAGLOG_FORMAT = "%(asctime)s %(levelname)s: %(message)s"
 
 POD_FILENAME = "pod.json"
@@ -66,10 +67,8 @@ CHECKSUMFILE_TYPE = NERDPUB_PRE + ":ChecksumFile"
 DOWNLOADABLEFILE_TYPE = NERDPUB_PRE + ":DownloadableFile"
 SUBCOLL_TYPE = NERDPUB_PRE + ":Subcollection"
 NERDM_CONTEXT = "https://data.nist.gov/od/dm/nerdm-pub-context.jsonld"
-DISTSERV = "https://data.nist.gov/od/ds/"
+DISTSERV = "https://" + PDR_PUBLIC_SERVER + "/od/ds/"
 DEF_MERGE_CONV = "midas0"
-
-ARK_NAAN = NIST_ARK_NAAN
 
 class BagBuilder(PreservationSystem):
     """
@@ -346,6 +345,7 @@ class BagBuilder(PreservationSystem):
             hdlrs = [h for h in self.plog.handlers if self._handles_logfile(h,lf)]
             for h in hdlrs:
                 self.plog.removeHandler(h)
+                h.flush()
                 h.close()
             self._log_handlers[lf] = None
         

--- a/python/nistoar/pdr/preserv/bagit/builder.py
+++ b/python/nistoar/pdr/preserv/bagit/builder.py
@@ -2128,7 +2128,7 @@ format(nerdm['title'])
 
         initdata['External-Identifier'] = [self.id]
         if nerdm.get('doi'):
-            initdata['External-Identifier'].append("doi:"+nerdm['doi'])
+            initdata['External-Identifier'].append(nerdm['doi'])
 
         # Calculate the payload Oxum
         oxum = self._measure_oxum(self._bag._datadir)

--- a/python/nistoar/pdr/preserv/service/service.py
+++ b/python/nistoar/pdr/preserv/service/service.py
@@ -121,6 +121,9 @@ class PreservationService(object):
         else:
             log.warning("repo_access not configured; can't support updates!")
 
+    def _get_def_siptype(self):
+        return 'midas3'
+
     def preserve(self, sipid, siptype=None, timeout=None):
         """
         request that an SIP with a given ID is preserved into long-term 
@@ -142,6 +145,8 @@ class PreservationService(object):
         :return dict:  a dictionary with metadata describing the status of 
                        preservation effort.
         """
+        if not siptype:
+            siptype = self._get_def_siptype()
         if siptype not in self.siptypes:
             raise ConfigurationException("No support configured for SIP type: "+
                                          siptype)
@@ -224,6 +229,8 @@ class PreservationService(object):
         :return dict:  a dictionary wiht metadata describing the status of 
                        preservation effort.
         """
+        if not siptype:
+            siptype = self._get_def_siptype()
         if siptype not in self.siptypes:
             raise ConfigurationException("No support configured for SIP type: "+
                                          siptype)
@@ -308,6 +315,8 @@ class PreservationService(object):
         :return dict:  a dictionary wiht metadata describing the status of 
                        preservation effort.
         """
+        if not siptype:
+            siptype = self._get_def_siptype()
         log.debug("Checking status of SIP=%s by request", sipid)
         try:
             hdlr = self._make_handler(sipid, siptype)
@@ -376,7 +385,7 @@ class PreservationService(object):
         create an SIPHandler of the given type for the given ID.
         """
         if not siptype:
-            siptype = 'midas3'
+            siptype = self._get_def_siptype()
         cls = None
         if siptype == hndlr.MIDASSIPHandler.key or siptype == hndlr.MIDASSIPHandler.name:
             # key = "midas"

--- a/python/nistoar/pdr/preserv/service/siphandler.py
+++ b/python/nistoar/pdr/preserv/service/siphandler.py
@@ -1139,7 +1139,8 @@ class MIDAS3SIPHandler(SIPHandler):
         # the bags/versions found locally.
         pfx = aipid+"."
         localbags = [bagutils.BagName(b) for b in os.listdir(destdir)
-                                         if b.startswith(pfx) and bagutils.is_legal_bag_name(b)]
+                                         if b.startswith(pfx) and bagutils.is_legal_bag_name(b)
+                                                              and not b.endswith(".sha256")]
         rmvers.update([b.version for b in localbags if b.version.startswith(majver)])
 
         def touch_file(filepath):

--- a/python/nistoar/pdr/preserv/service/siphandler.py
+++ b/python/nistoar/pdr/preserv/service/siphandler.py
@@ -1145,7 +1145,7 @@ class MIDAS3SIPHandler(SIPHandler):
         if distsvc:
             try:
                 rmvers.update([v for v in distsvc.list_versions() if v.startswith(majver)])
-            except DistrbResourceNotFound as ex:
+            except distrib.DistribResourceNotFound as ex:
                 log.warn("Note: %s not yet found in via dist service (%s)", self.bagname, str(ex))
             except Exception as ex:
                 log.warn("Problem querying distribution service for %s* versions: %s", majver, str(ex))

--- a/python/nistoar/pdr/publish/cmd/prepupd.py
+++ b/python/nistoar/pdr/publish/cmd/prepupd.py
@@ -25,7 +25,9 @@ def load_into(subparser):
     p = subparser
     p.description = description
     p.add_argument("aipid", metavar="AIPID", type=str, nargs=1, help="the AIP-ID for the dataset to prep")
-    p.add_argument("-r", "--repo-url-base", metavar='BASEURL', type=str, dest='repourl',
+    p.add_argument("-r", "--replaces", metavar='AIPID', type=str, dest='replaces',
+                   help="the ID of a previously published AIP that the new AIP will replace/deprecate")
+    p.add_argument("-u", "--repo-url-base", metavar='BASEURL', type=str, dest='repourl',
                    help="the base URL to use for PDR data access services")
     p.add_argument("-d", "--output-dir", "-b", "--bag-parent-dir", metavar='DIR', type=str, dest='outdir',
                    help="the directory to cache write the bag into; if not provided, defaults to the "+
@@ -106,7 +108,7 @@ def execute(args, config=None, log=None):
     try:
         
         svc = UpdatePrepService(cfg)
-        if not prepare_update_bag(svc, args.aipid, outbag, log=log):
+        if not prepare_update_bag(svc, args.aipid, outbag, args.replaces, log=log):
             raise PDRCommandFailure(default_name, args.aipid + ": AIP was not previously published", 3)
         log.info("Working bag initialized with metadata from previous publication")
         
@@ -120,18 +122,20 @@ def execute(args, config=None, log=None):
         if cdir:
             shutil.rmtree(cdir)
 
-def prepare_update_bag(updsvc, aipid, destbag, log=None):
+def prepare_update_bag(updsvc, aipid, destbag, replaces=None, log=None):
     """
     create a base metadata bag to update a dataset based on its last published version.  The output 
     bag's name will match the provided aipid.
     :param UpdatePrepService updsvc:   the update service to use
     :param str                aipid:   the AIP ID of the dataset to create the bag for
     :param str              destbag:   the full path to the root directory of the metadata bag to create
+    :param str             replaces:   the AIP ID of a previously published dataset that this SIP should 
+                                       replace
     :param Logger               log:   the Logger to use for messages
     :rtype bool:
     :return:  False if the AIP was not previously published
     """
-    return updsvc.prepper_for(aipid, log=log).create_new_update(destbag)
+    return updsvc.prepper_for(aipid, replaces=replaces, log=log).create_new_update(destbag)
 
 
     

--- a/python/nistoar/pdr/publish/mdserv/serv.py
+++ b/python/nistoar/pdr/publish/mdserv/serv.py
@@ -7,13 +7,14 @@ import os, logging, re, json, copy
 from collections import Mapping, OrderedDict
 
 from .. import PublishSystem
+from ... import ARK_NAAN
 from ...exceptions import (ConfigurationException, StateException,
                            SIPDirectoryNotFound, IDNotFound, PDRServiceException)
 from ...preserv.bagger import (MIDASMetadataBagger, UpdatePrepService,
                                midasid_to_bagname)
 from ...preserv.bagit import NISTBag, BagBuilder
 from ...utils import build_mime_type_map, read_nerd
-from ....id import PDRMinter, NIST_ARK_NAAN
+from ....id import PDRMinter
 from ....nerdm import validate_nerdm
 from ....nerdm.convert import Res2PODds
 from .... import pdr
@@ -21,6 +22,7 @@ from . import midasclient as midas
 
 log = logging.getLogger(PublishSystem().subsystem_abbrev)
 DEF_MERGE_CONV = "midas1"
+ark_naan = ARK_NAAN
 
 class PrePubMetadataService(PublishSystem):
     """
@@ -266,7 +268,7 @@ class PrePubMetadataService(PublishSystem):
              not starting with "ark:/" is assumed to be of this form.
         """
         if len(id) < 32 and not id.startswith("ark:/"):
-            naan = self.cfg.get('id_minter',{}).get('naan', NIST_ARK_NAAN)
+            naan = self.cfg.get('id_minter',{}).get('naan', ark_naan)
             id = "ark:/{}/{}".format(naan, id)
         return id
 

--- a/python/nistoar/pdr/publish/mdserv/wsgi.py
+++ b/python/nistoar/pdr/publish/mdserv/wsgi.py
@@ -13,7 +13,7 @@ from .. import PublishSystem
 from .serv import (PrePubMetadataService, SIPDirectoryNotFound, IDNotFound,
                    ConfigurationException, StateException, InvalidRequest)
 from . import midasclient as midas
-from ....id import NIST_ARK_NAAN
+from ... import ARK_NAAN
 
 log = logging.getLogger(PublishSystem().subsystem_abbrev).getChild("mdserv")
 
@@ -153,7 +153,7 @@ class Handler(object):
 
         if parts[0] == "ark:":
             # support full ark identifiers
-            if len(parts) > 2 and parts[1] == NIST_ARK_NAAN:
+            if len(parts) > 2 and parts[1] == ARK_NAAN:
                 dsid = parts[2]
             else:
                 dsid = '/'.join(parts[:3])
@@ -368,7 +368,7 @@ class Handler(object):
 
         if parts[0] == "ark:":
             # support full ark identifiers
-            if len(parts) > 2 and parts[1] == NIST_ARK_NAAN:
+            if len(parts) > 2 and parts[1] == ARK_NAAN:
                 dsid = parts[2]
             else:
                 dsid = '/'.join(parts[:3])

--- a/python/nistoar/pdr/publish/midas3/mdwsgi.py
+++ b/python/nistoar/pdr/publish/midas3/mdwsgi.py
@@ -17,7 +17,7 @@ from ...exceptions import (SIPDirectoryNotFound, IDNotFound,
 from ...utils import read_json, build_mime_type_map
 from . import midasclient as midas
 from ...preserv.bagger.midas3 import MIDASSIP
-from ....id import NIST_ARK_NAAN
+from ... import ARK_NAAN
 
 pdrsys = PublishSystem()
 log = logging.getLogger(pdrsys.system_abbrev)   \
@@ -165,7 +165,7 @@ class Handler(object):
 
         if parts[0] == "ark:":
             # support full ark identifiers
-            if len(parts) > 2 and parts[1] == NIST_ARK_NAAN:
+            if len(parts) > 2 and parts[1] == ARK_NAAN:
                 dsid = parts[2]
             else:
                 dsid = '/'.join(parts[:3])
@@ -210,7 +210,7 @@ class Handler(object):
 
         if parts[0] == "ark:":
             # support full ark identifiers
-            if len(parts) > 2 and parts[1] == NIST_ARK_NAAN:
+            if len(parts) > 2 and parts[1] == ARK_NAAN:
                 dsid = parts[2]
             else:
                 dsid = '/'.join(parts[:3])

--- a/python/nistoar/pdr/publish/midas3/service.py
+++ b/python/nistoar/pdr/publish/midas3/service.py
@@ -1263,7 +1263,8 @@ class MIDAS3PublishingService(PublishSystem):
             # in other words, data files must appear in the review directory to be
             # considered part of this version of the dataset.  
             usebagger = MIDASMetadataBagger(self.bagger.midasid, self.bagger.bagparent,
-                                            self.bagger.sip.revdatadir, config=self.bagger.cfg)
+                                            self.bagger.sip.revdatadir, replaces=self.bagger.previd,
+                                            config=self.bagger.cfg)
             return usebagger.finalize_version()
 
         def full_wait(self, timeout):

--- a/python/nistoar/pdr/publish/midas3/service.py
+++ b/python/nistoar/pdr/publish/midas3/service.py
@@ -405,7 +405,7 @@ class MIDAS3PublishingService(PublishSystem):
                                                               message="setting new EDI-ID for major update")
                 if not re.search(r'\+ \([\w\s]+\)', version):
                     replworker.bagger.bagbldr.update_annotations_for("", {"version": version+"+ (in edit)"},
-                                                                     message="")
+                                                                     message="setting version to in-edit mode")
                 replworker.bagger.update_bagger_metadata_for('', {"replacedEDI": oldworker.id})
                 replworker.bagger.ensure_res_metadata()
 

--- a/python/nistoar/pdr/publish/midas3/service.py
+++ b/python/nistoar/pdr/publish/midas3/service.py
@@ -399,9 +399,13 @@ class MIDAS3PublishingService(PublishSystem):
             # fix the EDI-ID for the new bag
             replworker.bagger.ensure_filelock()
             with replworker.bagger.lock:
-                replworker.bagger.ensure_base_bag()
-                replworker.bagger.bagbldr.update_metadata_for("", {"ediid": replworker.bagger.midasid},
+                replworker.bagger.ensure_res_metadata()
+                version = replworker.bagger.sip.nerd.get("version", "1.0.0")
+                replworker.bagger.bagbldr.update_metadata_for("", {"ediid": replworker.bagger.midasid}, 
                                                               message="setting new EDI-ID for major update")
+                if not re.search(r'\+ \([\w\s]+\)', version):
+                    replworker.bagger.bagbldr.update_annotations_for("", {"version": version+"+ (in edit)"},
+                                                                     message="")
                 replworker.bagger.update_bagger_metadata_for('', {"replacedEDI": oldworker.id})
                 replworker.bagger.ensure_res_metadata()
 

--- a/python/nistoar/pdr/publish/midas3/service.py
+++ b/python/nistoar/pdr/publish/midas3/service.py
@@ -18,7 +18,7 @@ from ...preserv.service import status as ps
 from ...preserv.service.service import MultiprocPreservationService
 from ...utils import build_mime_type_map, read_nerd, write_json, read_pod
 from ... import config as _configmod
-from ....id import PDRMinter, NIST_ARK_NAAN
+from ....id import PDRMinter
 from ....nerdm.convert import Res2PODds, topics2themes
 from ....nerdm.taxonomy import ResearchTopicsTaxonomy
 from ....nerdm import validate
@@ -146,7 +146,7 @@ class MIDAS3PublishingService(PublishSystem):
         self._podvalid8r = None
         if self.cfg.get('require_valid_pod', True):
             if not self._schemadir:
-                raise ConfigurationException("'reuqire_valid_pod' is set but cannot find schema dir")
+                raise ConfigurationException("'require_valid_pod' is set but cannot find schema dir")
             self._podvalid8r = validate.create_validator(self._schemadir, "_")
 
 
@@ -286,7 +286,7 @@ class MIDAS3PublishingService(PublishSystem):
         else:
             self.log.warning("Unable to validate submitted POD data")
 
-    def _create_bagger(self, id):
+    def _create_bagger(self, id, replaces=None):
         cfg = self.cfg.get('bagger', {})
         if 'store_dir' not in cfg and 'store_dir' in self.cfg:
             cfg['store_dir'] = self.cfg['store_dir']
@@ -302,14 +302,14 @@ class MIDAS3PublishingService(PublishSystem):
             raise StateException("Working directory path not a directory: " +
                                  self.workdir)
 
-        bagger = MIDASMetadataBagger.fromMIDAS(id, self.mddir, self.reviewdir,
-                                               self.uploaddir, cfg, self._minter)
+        bagger = MIDASMetadataBagger.fromMIDAS(id, self.mddir, self.reviewdir, self.uploaddir, 
+                                               cfg, replaces=replaces, minter=self._minter)
         return bagger
 
-    def _get_bagging_worker(self, id):
+    def _get_bagging_worker(self, id, replaces=None):
         worker = self._bagging_workers.get(id)
         if not worker:
-            bagger = self._create_bagger(id)
+            bagger = self._create_bagger(id, replaces)
             # bagger.prepare()
             worker = self.BaggingWorker(self, id, bagger, self.log)
             self._bagging_workers[id] = worker
@@ -355,7 +355,15 @@ class MIDAS3PublishingService(PublishSystem):
             # shouldn't happen since identifier is required for validity
             raise ValueError("POD record is missing required identifier")
 
-        worker = self._get_bagging_worker(id)
+        # is this an update that generated a new EDI-ID?
+        replaces = pod.get('replaces')
+        worker = self._get_bagging_worker(id, replaces=replaces)
+        if replaces and not os.path.exists(worker.bagger.bagdir):
+            oldworker = self._get_bagging_worker(replaces)
+            if oldworker.is_working() or os.path.exists(oldworker.bagger.bagdir):
+                # make a copy of the bag being replaced, but wait for it to finish its work
+                self._copy_oldbag_when_done(oldworker, worker)
+
         if not os.path.exists(worker.bagger.bagdir):
             # prep the bag synchronously (in case there's an issue)
             worker.bagger.prepare()
@@ -368,6 +376,41 @@ class MIDAS3PublishingService(PublishSystem):
             else:
                 worker.run("sync")
         return worker.bagger
+
+    def _copy_oldbag_when_done(self, oldworker, replworker):
+        # wait for worker to finish its work
+        try:
+            oldworker.full_wait(4)
+        except RuntimeException as ex:
+            # should not happen
+            self.log.error("Unexpected error while waiting for worker for %s: %s" %
+                           (oldworker.bagger.midasid, str(ex)))
+
+        try: 
+            # prevent updates to new worker's bag
+            replworker.halt_pod_processing("EDI-swapping")
+
+            # lock the old worker
+            oldworker.bagger.ensure_filelock()
+            with oldworker.bagger.lock:
+                # copy the bag
+                shutil.copytree(oldworker.bagger.bagdir, replworker.bagger.bagdir)
+
+            # fix the EDI-ID for the new bag
+            replworker.bagger.ensure_filelock()
+            with replworker.bagger.lock:
+                replworker.bagger.ensure_base_bag()
+                replworker.bagger.bagbldr.update_metadata_for("", {"ediid": replworker.bagger.midasid},
+                                                              message="setting new EDI-ID for major update")
+                replworker.bagger.update_bagger_metadata_for('', {"replacedEDI": oldworker.id})
+                replworker.bagger.ensure_res_metadata()
+
+        except OSError as ex:
+            self.log.exception("Trouble copying bag during EDI-ID update: "+str(ex))
+            raise PDRServiceException("Failed to shift to new EDI-ID during bag copy: "+str(e), cause=ex)
+
+        finally:
+            replworker.resume_pod_processing()
 
 
     def serve_nerdm(self, nerdm, name=None):
@@ -795,7 +838,7 @@ class MIDAS3PublishingService(PublishSystem):
         one for publishing so that it can be queued for preservation.  The bag worker will see 
         the mark and take responsibility for starting the preservation process.
 
-        :param str ediid:   the EDI ID for the dataset to be preserved.
+        :param dict pod:    the final version of the POD record for the SIP to preserve
         :param bool async:  if True (default), process any pending PODs asynchronously.  Note that this 
                             only affects POD processing, not the actual preservation.
         :rtype dict:  a status JSON object giving the status of the preservation.  
@@ -861,7 +904,7 @@ class MIDAS3PublishingService(PublishSystem):
         one for publishing so that it can be queued for preservation.  The bag worker will see 
         the mark and take responsibility for starting the preservation process.
 
-        :param str ediid:   the EDI ID for the dataset to be preserved.
+        :param dict pod:    the final version of the POD record for the SIP to preserve
         :param bool async:  if True (default), process any pending PODs asynchronously.  Note that this 
                             only affects POD processing, not the actual preservation.
         :rtype dict:  a status JSON object giving the status of the preservation.  
@@ -1057,6 +1100,7 @@ class MIDAS3PublishingService(PublishSystem):
                         pod = None
                         with self.qlock:
                             pod = read_pod(self.working_pod)
+
                         self.bagger.apply_pod(pod, False)
                         self.service.serve_nerdm(self.bagger.bagbldr.bag.nerdm_record(True))
 
@@ -1143,7 +1187,7 @@ class MIDAS3PublishingService(PublishSystem):
 
                 # assign next version to this submission
                 nerd = self.finalize_version()
-                nerd['_preserve'] = True
+                nerd['__preserve'] = True
                 self.service.serve_nerdm(nerd)
 
                 # copy the metadata bag to the preservation queue
@@ -1221,6 +1265,12 @@ class MIDAS3PublishingService(PublishSystem):
             usebagger = MIDASMetadataBagger(self.bagger.midasid, self.bagger.bagparent,
                                             self.bagger.sip.revdatadir, config=self.bagger.cfg)
             return usebagger.finalize_version()
+
+        def full_wait(self, timeout):
+            if self.is_working() and worker._thread is not threading.current_thread():
+                self._thread.join()
+            if self.bagger.fileExaminer and self.bagger.fileExaminer.running():
+                self.bagger.fileExaminer.waitForCompletion(timeout)
 
 
 

--- a/python/nistoar/pdr/publish/midas3/wsgi.py
+++ b/python/nistoar/pdr/publish/midas3/wsgi.py
@@ -17,9 +17,9 @@ from .service import (MIDAS3PublishingService, SIPDirectoryNotFound, IDNotFound,
 from ...preserv.service import status as ps
 from ...preserv.service.service import RerequestException, PreservationStateError
 from .webrecord import WebRecorder
-from ....id import NIST_ARK_NAAN
 from ejsonschema import ValidationError
 from ... import config as cfgmod
+from ... import ARK_NAAN
 
 from .. import sys as pdrsys
 log = logging.getLogger(pdrsys.system_abbrev)   \
@@ -27,7 +27,7 @@ log = logging.getLogger(pdrsys.system_abbrev)   \
              .getChild('wsgi')
 
 DEF_BASE_PATH = "/pod/"
-ARK_NAAN = NIST_ARK_NAAN
+ark_naan = ARK_NAAN
 
 class MIDAS3PublishingApp(object):
     """
@@ -111,7 +111,7 @@ class MIDAS3PublishingApp(object):
 app = MIDAS3PublishingApp
 
 _badidre = re.compile(r"[<>\s/]")
-_arkidre = re.compile(r"^ark:/"+ARK_NAAN+"/")
+_arkidre = re.compile(r"^ark:/"+ark_naan+"/")
 _arklocalre = re.compile(r"^mds\d+\-\d{3}\d+")
 
 class Handler(object):
@@ -257,7 +257,7 @@ class DraftHandler(Handler):
                     return self.send_error(400, "Bad identifier syntax")
             else:
                 # assume new style identifier and convert to ark: syntax
-                midasid = "ark:/"+ARK_NAAN+"/"+midasid
+                midasid = "ark:/"+ark_naan+"/"+midasid
         if midasid.startswith("ark:") and not _arkidre.search(path):
             return self.send_error(400, "Bad identifier syntax")
         
@@ -306,7 +306,7 @@ class DraftHandler(Handler):
                         return self.send_error(400, "Bad identifier syntax")
                 else:
                     # assume new style identifier and convert to ark: syntax
-                    midasid = "ark:/"+ARK_NAAN+"/"+midasid
+                    midasid = "ark:/"+ark_naan+"/"+midasid
             if midasid.startswith("ark:") and not _arkidre.search(path):
                 return self.send_error(400, "Bad identifier syntax")
         
@@ -373,7 +373,7 @@ class DraftHandler(Handler):
                     return self.send_error(400, "Bad identifier syntax")
             else:
                 # assume new style identifier and convert to ark: syntax
-                midasid = "ark:/"+ARK_NAAN+"/"+midasid
+                midasid = "ark:/"+ark_naan+"/"+midasid
         if midasid.startswith("ark:") and not _arkidre.search(path):
             return self.send_error(400, "Bad identifier syntax")
         
@@ -475,7 +475,7 @@ class LatestHandler(Handler):
         if not _arkidre.search(path) and _badidre.search(path):
             return self.send_error(400, "Bad identifier syntax")
         if _arklocalre.search(path):
-            path = "ark:/"+ARK_NAAN+"/"+path
+            path = "ark:/"+ark_naan+"/"+path
 
         try:
             pod = self._svc.get_pod(path)

--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
@@ -1131,14 +1131,18 @@ class TestPreservationBagger(test.TestCase):
         self.bagr.finalize_version()
         data = utils.read_nerd(annotf)
         self.assertEqual(data['version'], "1.0.1")
-        self.assertIn('versionHistory', data)
+        self.assertIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
 
         mdrec = bag.nerdm_record(True)
         self.assertEqual(mdrec['version'], "1.0.1")
-        self.assertIn('versionHistory', mdrec)
-        hist = mdrec['versionHistory']
+        self.assertIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+        hist = mdrec['releaseHistory']['hasRelease']
         self.assertEqual(hist[-1]['version'], "1.0.1")
         self.assertEqual(hist[-1]['description'], "metadata update")
+        self.assertTrue(hist[-1]['location'].endswith(".v1_0_1"),
+                        "location does not end with version: "+hist[-1]['location'])
             
 
         

--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas.py
@@ -695,9 +695,9 @@ class TestMIDASMetadataBaggerReview(test.TestCase):
         self.assertTrue(os.path.exists(self.bagdir))
         fmd = self.bagr.bagbldr.bag.nerd_metadata_for("trial1.json")
         self.assertIn('checksum', fmd) # because there's a .sha256 file
-        self.assertIn('_status', fmd)
+        self.assertIn('__status', fmd)
         fmd = self.bagr.bagbldr.bag.nerd_metadata_for("trial2.json")
-        self.assertIn('_status', fmd)
+        self.assertIn('__status', fmd)
         self.assertNotIn('checksum', fmd)
 
         # self.bagr.fileExaminer.run()
@@ -705,7 +705,7 @@ class TestMIDASMetadataBaggerReview(test.TestCase):
         self.bagr.fileExaminer.thread.join()
         fmd = self.bagr.bagbldr.bag.nerd_metadata_for("trial2.json")
         self.assertIn('checksum', fmd)
-        self.assertNotIn('_status', fmd)
+        self.assertNotIn('__status', fmd)
 
     def test_fileExaminer_autolaunch(self):
         # show that the async thread does its work with autolaunch

--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas3.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas3.py
@@ -897,8 +897,17 @@ class TestMIDASMetadataBaggerReview(test.TestCase):
                                                         self.revdir, config=config)
         nerd = self.bagr.finalize_version()
         self.assertEqual(nerd['version'], "1.1.0")
+        self.assertIn('releaseHistory', nerd)
+        self.assertEqual(nerd['releaseHistory']['@id'], nerd['@id']+".rel")
+        self.assertIn('hasRelease', nerd['releaseHistory'])
+        self.assertEqual(len(nerd['releaseHistory']['hasRelease']), 1)
+
         nerd = self.bagr.bagbldr.bag.nerd_metadata_for('', True)
         self.assertEqual(nerd['version'], "1.1.0")
+        self.assertIn('releaseHistory', nerd)
+        self.assertEqual(nerd['releaseHistory']['@id'], nerd['@id']+".rel")
+        self.assertIn('hasRelease', nerd['releaseHistory'])
+        self.assertEqual(len(nerd['releaseHistory']['hasRelease']), 1)
         
         
 class TestMIDASMetadataBaggerUpload(test.TestCase):

--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas3.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas3.py
@@ -908,6 +908,9 @@ class TestMIDASMetadataBaggerReview(test.TestCase):
         self.assertEqual(nerd['releaseHistory']['@id'], nerd['@id']+".rel")
         self.assertIn('hasRelease', nerd['releaseHistory'])
         self.assertEqual(len(nerd['releaseHistory']['hasRelease']), 1)
+        self.assertTrue(nerd['releaseHistory']['hasRelease'][0]['location'].endswith(".v1_1_0"),
+                        "location does not end with version: "+
+                        nerd['releaseHistory']['hasRelease'][0]['location'])
         
         
 class TestMIDASMetadataBaggerUpload(test.TestCase):

--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas3.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas3.py
@@ -1300,12 +1300,12 @@ class TestPreservationBagger(test.TestCase):
         data = utils.read_json(self.bagr.bagbldr.bag.pod_file())
         data["_goober"] = "I am a"
         utils.write_json(data, self.bagr.bagbldr.bag.pod_file())
-        self.bagr.bagbldr.update_metadata_for("", {"_goober": "I am a"})
-        self.bagr.bagbldr.update_annotations_for("trial1.json", {"_goober": "I am a"})
+        self.bagr.bagbldr.update_metadata_for("", {"__goober": "I am a"})
+        self.bagr.bagbldr.update_annotations_for("trial1.json", {"__goober": "I am a"})
 
         # test mods were successful
         data = self.bagr.bagbldr.bag.nerd_metadata_for('trial1.json', True)
-        self.assertIn('_goober', data.keys())
+        self.assertIn('__goober', data.keys())
         dirtyfiles = []
         dirtymd = []
         for (r, d, files) in os.walk(self.bagr.bagdir):
@@ -1325,11 +1325,11 @@ class TestPreservationBagger(test.TestCase):
                                                      "trial1.json", "_goober.txt")),
                                         "metadata admin file not removed")
         data = utils.read_json(self.bagr.bagbldr.bag.pod_file())
-        self.assertNotIn('_goober', data.keys())
+        self.assertNotIn('__goober', data.keys())
         data = self.bagr.bagbldr.bag.nerd_metadata_for('', True)
-        self.assertNotIn('_goober', data.keys())
+        self.assertNotIn('__goober', data.keys())
         data = self.bagr.bagbldr.bag.nerd_metadata_for('trial1.json', True)
-        self.assertNotIn('_goober', data.keys())
+        self.assertNotIn('__goober', data.keys())
 
         # confirm that we are fully clean
         dirtyfiles = []
@@ -1338,7 +1338,7 @@ class TestPreservationBagger(test.TestCase):
             dirtyfiles.extend([os.path.join(r,f) for f in files if f.startswith("_")])
             for mdfile in [f for f in files if f in ['pod.json', 'nerdm.json', 'annot.json']]:
                 data = utils.read_json(os.path.join(r, mdfile))
-                if len([p for p in data.keys() if p.startswith('_')]) > 0:
+                if len([p for p in data.keys() if p.startswith('__')]) > 0:
                     dirtymd.append(os.path.join(r, mdfile))
         self.assertEqual(len(dirtyfiles), 0)
         self.assertEqual(len(dirtymd), 0)

--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas3_update.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas3_update.py
@@ -268,6 +268,7 @@ class TestUpdateMetadataBagger(test.TestCase):
                 dist['downloadURL'] = re.sub(self.prevmidasid, self.midasid, dist['downloadURL'])
             elif 'accessURL' in dist and 'doi.org' in dist['accessURL']:
                 dist['accessURL'] = re.sub(r'/[^/]+$', '/mds8-8888', dist['accessURL'])
+                pod['doi'] = dist['accessURL']
         self.bagr.apply_pod(pod)
 
         bag = NISTBag(self.updbagdir)

--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas3_update.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas3_update.py
@@ -212,7 +212,9 @@ class TestUpdateMetadataBagger(test.TestCase):
         bag = NISTBag(self.updbagdir)
         nerdm = bag.nerdm_record(True)
         self.assertEqual(nerdm['ediid'], self.midasid)
-        self.assertEqual(nerdm['replaces'], self.prevmidasid)
+        self.assertEqual(len(nerdm.get('replaces',[])), 1)
+        self.assertEqual(nerdm['replaces'][0]['ediid'], self.prevmidasid)
+        self.assertTrue(nerdm['replaces'][0]['@id'].startswith("doi:"))
         self.assertEqual(nerdm['@id'], 'ark:/88434/edi00hw91c')
 
     def test_ensure_base_bag_onupdate2(self):
@@ -247,7 +249,10 @@ class TestUpdateMetadataBagger(test.TestCase):
         bag = NISTBag(self.updbagdir)
         nerdm = bag.nerdm_record(True)
         self.assertEqual(nerdm['ediid'], self.midasid)
-        self.assertEqual(nerdm['replaces'], self.prevmidasid)
+        self.assertEqual(len(nerdm.get('replaces',[])), 1)
+        self.assertIn('ediid', nerdm['replaces'][0])
+        self.assertEqual(nerdm['replaces'][0]['ediid'], self.prevmidasid)
+        self.assertTrue(nerdm['replaces'][0]['@id'].startswith("doi:"))
         self.assertEqual(nerdm['@id'], 'ark:/88434/edi00hw91c')
 
     def test_apply_pod_onupdate(self):
@@ -268,7 +273,9 @@ class TestUpdateMetadataBagger(test.TestCase):
         bag = NISTBag(self.updbagdir)
         nerdm = bag.nerdm_record(True)
         self.assertEqual(nerdm['ediid'], self.midasid)
-        self.assertEqual(nerdm['replaces'], self.prevmidasid)
+        self.assertEqual(len(nerdm.get('replaces',[])), 1)
+        self.assertEqual(nerdm['replaces'][0]['ediid'], self.prevmidasid)
+        self.assertTrue(nerdm['replaces'][0]['@id'].startswith("doi:"))
         self.assertEqual(nerdm['@id'], 'ark:/88434/edi00hw91c')
         self.assertEqual(nerdm['doi'], 'doi:10.80443/mds8-8888')
 

--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas3_update.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas3_update.py
@@ -1,0 +1,283 @@
+import os, sys, pdb, shutil, logging, json, time, re
+from cStringIO import StringIO
+from io import BytesIO
+import warnings as warn
+import unittest as test
+from collections import OrderedDict
+from copy import deepcopy
+
+from nistoar.testing import *
+from nistoar.pdr import utils, ARK_NAAN
+import nistoar.pdr.preserv.bagit.builder as bldr
+from nistoar.pdr.preserv.bagit.bag import NISTBag
+import nistoar.pdr.preserv.bagger.midas3 as midas
+import nistoar.pdr.exceptions as exceptions
+from nistoar.pdr.preserv import AIPValidationError
+
+# datadir = nistoar/pdr/preserv/data
+testdir = os.path.dirname(os.path.abspath(__file__))
+datadir = os.path.join(os.path.dirname(testdir), 'data')
+pdrmoddir = os.path.dirname(os.path.dirname(testdir))
+basedir = os.path.dirname(os.path.dirname(os.path.dirname(
+                                                 os.path.dirname(pdrmoddir))))
+distarchdir = os.path.join(pdrmoddir, "distrib", "data")
+descarchdir = os.path.join(pdrmoddir, "describe", "data")
+
+loghdlr = None
+rootlog = None
+def setUpModule():
+    global loghdlr
+    global rootlog
+    ensure_tmpdir()
+#    logging.basicConfig(filename=os.path.join(tmpdir(),"test_builder.log"),
+#                        level=logging.INFO)
+    rootlog = logging.getLogger()
+    loghdlr = logging.FileHandler(os.path.join(tmpdir(),"test_builder.log"))
+    loghdlr.setLevel(logging.INFO)
+    loghdlr.setFormatter(logging.Formatter(bldr.DEF_BAGLOG_FORMAT))
+    rootlog.addHandler(loghdlr)
+    startServices()
+
+def tearDownModule():
+    global loghdlr
+    if loghdlr:
+        if rootlog:
+            rootlog.removeHandler(loghdlr)
+            loghdlr.flush()
+            loghdlr.close()
+        loghdlr = None
+    stopServices()
+    rmtmpdir()
+
+distarchive = os.path.join(tmpdir(), "distarchive")
+mdarchive = os.path.join(tmpdir(), "mdarchive")
+
+def startServices():
+    tdir = tmpdir()
+    archdir = distarchive
+    shutil.copytree(distarchdir, archdir)
+    shutil.copyfile(os.path.join(archdir,"1491.1_0.mbag0_4-0.zip"),
+                    os.path.join(archdir,"3A1EE2F169DD3B8CE0531A570681DB5D1491.1_0.mbag0_4-0.zip"))
+
+    srvport = 9091
+    pidfile = os.path.join(tdir,"simdistrib"+str(srvport)+".pid")
+    wpy = "python/tests/nistoar/pdr/distrib/sim_distrib_srv.py"
+    assert os.path.exists(wpy)
+    cmd = "uwsgi --daemonize {0} --plugin python --http-socket :{1} " \
+          "--wsgi-file {2} --set-ph archive_dir={3} --pidfile {4}"
+    cmd = cmd.format(os.path.join(tdir,"simdistrib.log"), srvport,
+                     os.path.join(basedir, wpy), archdir, pidfile)
+    os.system(cmd)
+
+    archdir = mdarchive
+    shutil.copytree(descarchdir, archdir)
+    nerd = utils.read_nerd(os.path.join(archdir, "pdr02d4t.json"))
+    nerd['ediid'] = "3A1EE2F169DD3B8CE0531A570681DB5D1491"
+    utils.write_json(nerd, os.path.join(archdir, "3A1EE2F169DD3B8CE0531A570681DB5D1491.json"))
+
+    srvport = 9092
+    pidfile = os.path.join(tdir,"simrmm"+str(srvport)+".pid")
+    wpy = "python/tests/nistoar/pdr/describe/sim_describe_svc.py"
+    assert os.path.exists(wpy)
+    cmd = "uwsgi --daemonize {0} --plugin python --http-socket :{1} " \
+          "--wsgi-file {2} --set-ph archive_dir={3} --pidfile {4}"
+    cmd = cmd.format(os.path.join(tdir,"simrmm.log"), srvport,
+                     os.path.join(basedir, wpy), archdir, pidfile)
+    os.system(cmd)
+    time.sleep(0.5)
+
+def stopServices():
+    tdir = tmpdir()
+    srvport = 9091
+    pidfile = os.path.join(tdir,"simdistrib"+str(srvport)+".pid")
+    
+    cmd = "uwsgi --stop {0}".format(os.path.join(tdir,
+                                               "simdistrib"+str(srvport)+".pid"))
+    os.system(cmd)
+
+    # sometimes stopping with uwsgi doesn't work
+    try:
+        with open(pidfile) as fd:
+            pid = int(fd.read().strip())
+        os.kill(pid, signal.SIGTERM)
+    except:
+        pass
+
+    srvport = 9092
+    pidfile = os.path.join(tdir,"simrmm"+str(srvport)+".pid")
+    
+    cmd = "uwsgi --stop {0}".format(os.path.join(tdir,
+                                               "simrmm"+str(srvport)+".pid"))
+    os.system(cmd)
+
+    time.sleep(1)
+
+    # sometimes stopping with uwsgi doesn't work
+    try:
+        with open(pidfile) as fd:
+            pid = int(fd.read().strip())
+        os.kill(pid, signal.SIGTERM)
+    except:
+        pass
+
+
+class TestUpdateMetadataBagger(test.TestCase):
+    
+    testsip = os.path.join(datadir, "midassip")
+    prevmidasid = '3A1EE2F169DD3B8CE0531A570681DB5D1491'
+    midasid = "ark:/"+ARK_NAAN+"/mds8-8888"
+
+    def setUp(self):
+        self.tf = Tempfiles()
+        self.workdir = self.tf.mkdir("bagger")
+        self.mddir = os.path.join(self.workdir, "mddir")
+        os.mkdir(self.mddir)
+        self.pubcache = self.tf.mkdir("headcache")
+
+        testsip = os.path.join(self.testsip, "review")
+        self.revdir = os.path.join(self.workdir, "review")
+        self.sipdir = os.path.join(self.revdir, "8888")
+        shutil.copytree(testsip, self.revdir)
+        now = time.time()
+        for base, dirs, files in os.walk(self.revdir):
+            for f in files+dirs:
+                os.utime(os.path.join(base,f), (now, now))
+        shutil.copytree(os.path.join(self.revdir, "1491"), self.sipdir)
+        
+        self.config = {
+            'relative_to_indir': True,
+            'bag_builder': {
+                'copy_on_link_failure': False,
+                'init_bag_info': {
+                    'Source-Organization':
+                        "National Institute of Standards and Technology",
+                    'Contact-Email': ["datasupport@nist.gov"],
+                    'Organization-Address': [
+                        "100 Bureau Dr., Gaithersburg, MD 20899"],
+                    'NIST-BagIt-Version': "0.4",
+                    'Multibag-Version': "0.4"
+                }
+            },
+            'repo_access': {
+                'headbag_cache':   self.pubcache,
+                'distrib_service': {
+                    'service_endpoint': "http://localhost:9091/"
+                },
+                'metadata_service': {
+                    'service_endpoint': "http://localhost:9092/"
+                }
+            },
+            'store_dir': distarchdir
+        }
+
+        self.bagr = None
+        self.updbagdir = os.path.join(self.mddir, "mds8-8888")
+        self.replbagdir = os.path.join(self.mddir, self.prevmidasid)
+
+    def tearDown(self):
+        if self.bagr:
+            self.bagr.bagbldr._unset_logfile()
+            self.bagr = None
+        self.tf.clean()
+
+    def test_ctor(self):
+        self.bagr = midas.MIDASMetadataBagger.fromMIDAS(self.midasid, self.mddir, self.revdir,
+                                                        config=self.config, replaces=None)
+        self.assertIsNone(self.bagr.previd)
+        prepr = self.bagr.get_prepper()
+        self.assertEqual(prepr.aipid, "mds8-8888")
+        self.assertEqual(prepr._prevaipid, prepr.aipid)
+
+        self.bagr = midas.MIDASMetadataBagger.fromMIDAS(self.midasid, self.mddir, self.revdir,
+                                                        config=self.config, replaces=self.prevmidasid)
+        self.assertIsNotNone(self.bagr.previd)
+        self.assertNotEqual(self.bagr.previd, self.bagr.midasid)
+        prepr = self.bagr.get_prepper()
+        self.assertEqual(prepr.aipid, "mds8-8888")
+        self.assertEqual(prepr._prevaipid, self.prevmidasid)
+
+    def test_ensure_base_bag_onupdate(self):
+        self.assertTrue(not os.path.exists(self.updbagdir))
+        self.assertTrue(not os.path.exists(self.replbagdir))
+        self.bagr = midas.MIDASMetadataBagger.fromMIDAS(self.midasid, self.mddir, self.revdir,
+                                                        config=self.config, replaces=self.prevmidasid)
+        self.bagr.ensure_base_bag()
+        
+        self.assertTrue(not os.path.exists(self.replbagdir))
+        self.assertTrue(os.path.exists(self.updbagdir))
+        self.assertTrue(os.path.exists(os.path.join(self.updbagdir,"metadata","__bagger-midas3.json")))
+        bmd = utils.read_json(os.path.join(self.updbagdir,"metadata","__bagger-midas3.json"))
+        self.assertEqual(bmd.get("replacedEDI"), self.prevmidasid)
+
+        bag = NISTBag(self.updbagdir)
+        nerdm = bag.nerdm_record(True)
+        self.assertEqual(nerdm['ediid'], self.midasid)
+        self.assertEqual(nerdm['replaces'], self.prevmidasid)
+        self.assertEqual(nerdm['@id'], 'ark:/88434/edi00hw91c')
+
+    def test_ensure_base_bag_onupdate2(self):
+        self.assertTrue(not os.path.exists(self.updbagdir))
+        self.assertTrue(not os.path.exists(self.replbagdir))
+
+        # prep under old SIP dir
+        
+        self.bagr = midas.MIDASMetadataBagger.fromMIDAS(self.prevmidasid, self.mddir, self.revdir,
+                                                        config=self.config)
+        self.bagr.ensure_base_bag()
+        self.assertTrue(os.path.exists(self.replbagdir))
+        self.assertTrue(not os.path.exists(self.updbagdir))
+        self.assertTrue(os.path.exists(os.path.join(self.replbagdir,"metadata","__bagger-midas3.json")))
+        bmd = utils.read_json(os.path.join(self.replbagdir,"metadata","__bagger-midas3.json"))
+        self.assertFalse(bmd.get("replacedEDI"))
+
+        # this file will be used to prove that the previous bag was moved to create the new bag
+        open(os.path.join(self.replbagdir, "test.json"), 'a').close()
+        
+        self.bagr = midas.MIDASMetadataBagger.fromMIDAS(self.midasid, self.mddir, self.revdir,
+                                                        config=self.config, replaces=self.prevmidasid)
+        self.bagr.ensure_base_bag()
+        
+        self.assertTrue(not os.path.exists(self.replbagdir))
+        self.assertTrue(os.path.exists(self.updbagdir))
+        self.assertTrue(os.path.exists(os.path.join(self.updbagdir, "test.json")))
+        self.assertTrue(os.path.exists(os.path.join(self.updbagdir,"metadata","__bagger-midas3.json")))
+        bmd = utils.read_json(os.path.join(self.updbagdir,"metadata","__bagger-midas3.json"))
+        self.assertEqual(bmd.get("replacedEDI"), self.prevmidasid)
+
+        bag = NISTBag(self.updbagdir)
+        nerdm = bag.nerdm_record(True)
+        self.assertEqual(nerdm['ediid'], self.midasid)
+        self.assertEqual(nerdm['replaces'], self.prevmidasid)
+        self.assertEqual(nerdm['@id'], 'ark:/88434/edi00hw91c')
+
+    def test_apply_pod_onupdate(self):
+        self.assertTrue(not os.path.exists(self.replbagdir))
+        self.bagr = midas.MIDASMetadataBagger.fromMIDAS(self.midasid, self.mddir, self.revdir,
+                                                        config=self.config, replaces=self.prevmidasid)
+
+        pod = utils.read_json(os.path.join(self.testsip, "review", "1491", "_pod.json"))
+        # POD record will have new MIDAS ID, new DOI, and new download URLs 
+        pod['identifier'] = self.midasid
+        for dist in pod['distribution']:
+            if 'downloadURL' in dist and '/od/ds/' in dist['downloadURL']:
+                dist['downloadURL'] = re.sub(self.prevmidasid, self.midasid, dist['downloadURL'])
+            elif 'accessURL' in dist and 'doi.org' in dist['accessURL']:
+                dist['accessURL'] = re.sub(r'/[^/]+$', '/mds8-8888', dist['accessURL'])
+        self.bagr.apply_pod(pod)
+
+        bag = NISTBag(self.updbagdir)
+        nerdm = bag.nerdm_record(True)
+        self.assertEqual(nerdm['ediid'], self.midasid)
+        self.assertEqual(nerdm['replaces'], self.prevmidasid)
+        self.assertEqual(nerdm['@id'], 'ark:/88434/edi00hw91c')
+        self.assertEqual(nerdm['doi'], 'doi:10.80443/mds8-8888')
+
+        for cmp in nerdm['components']:
+            if 'downloadURL' in cmp and '/od/ds/' in cmp['downloadURL']:
+                self.assertIn('mds8-8888', cmp['downloadURL'])
+        self.assertEqual(len(nerdm['components']), len(pod['distribution'])+1)
+        
+        
+
+if __name__ == '__main__':
+    test.main()

--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas_update.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas_update.py
@@ -49,6 +49,8 @@ def tearDownModule():
     if loghdlr:
         if rootlog:
             rootlog.removeHandler(loghdlr)
+            loghdlr.flush()
+            loghdlr.close()
         loghdlr = None
     stopServices()
     rmtmpdir()

--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas_update.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas_update.py
@@ -354,10 +354,13 @@ class TestPreservationUpdateBagger(test.TestCase):
 
             mdata = bag.nerdm_record()
             self.assertEqual(mdata['version'], "1.1.0")
-            self.assertIn('versionHistory', mdata)
-            hist = mdata['versionHistory']
+            self.assertIn('releaseHistory', mdata)
+            self.assertNotIn('versionHistory', mdata)
+            hist = mdata['releaseHistory']['hasRelease']
             self.assertEqual(hist[-1]['version'], "1.1.0")
             self.assertEqual(hist[-1]['description'], "data update")
+            self.assertTrue(hist[-1]['location'].endswith(".v1_1_0"),
+                            "location does not end with version: "+hist[-1]['location'] )
             self.assertEqual(hist[0]['version'], "1.0.0")
             self.assertEqual(len(hist), 2)
             

--- a/python/tests/nistoar/pdr/preserv/bagger/test_prepupd.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_prepupd.py
@@ -362,6 +362,7 @@ class TestUpdatePrepper(test.TestCase):
         mdata = bag.nerdm_record(True)
         self.assertEquals(mdata['version'], "1.0+ (in edit)")
         self.assertIn('releaseHistory', mdata)
+        self.assertEquals(mdata['releaseHistory']['@id'], mdata['@id']+".rel")
         self.assertIn('hasRelease', mdata['releaseHistory'])
         self.assertEquals(len(mdata['releaseHistory']['hasRelease']), 1)
         self.assertEquals(mdata['releaseHistory']['hasRelease'][0]['version'], "1.0")

--- a/python/tests/nistoar/pdr/preserv/bagger/test_prepupd.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_prepupd.py
@@ -366,7 +366,7 @@ class TestUpdatePrepper(test.TestCase):
         self.assertIn('hasRelease', mdata['releaseHistory'])
         self.assertEquals(len(mdata['releaseHistory']['hasRelease']), 1)
         self.assertEquals(mdata['releaseHistory']['hasRelease'][0]['version'], "1.0")
-        self.assertEquals(mdata['releaseHistory']['hasRelease'][0]['@id'], mdata["@id"])
+        self.assertEquals(mdata['releaseHistory']['hasRelease'][0]['@id'], mdata["@id"]+".v1_0")
         self.assertIn('issued', mdata['releaseHistory']['hasRelease'][0])
 
         depinfof = os.path.join(bag.dir, "multibag", "deprecated-info.txt")

--- a/python/tests/nistoar/pdr/preserv/bagger/test_prepupd.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_prepupd.py
@@ -245,9 +245,45 @@ class TestUpdatePrepper(test.TestCase):
         self.assertEqual(self.prepr.cache_headbag(), cached)
         self.assertTrue(os.path.exists(cached))
 
+    def test_cache_headbag_replace(self):
+        cached = os.path.join(self.headcache, "ABCDEFG.2.mbag0_4-4.zip")
+        self.assertTrue(not os.path.exists(cached))
+
+        self.prepr = self.prepsvc.prepper_for("goober")
+        self.prepr.mdcli = self.mdcli
+        self.prepr.cacher.distsvc = self.distcli
+
+        self.assertIsNone(self.prepr.cache_headbag())
+        self.assertTrue(not os.path.exists(cached))
+
+        self.prepr = self.prepsvc.prepper_for("goober", replaces="ABCDEFG")
+        self.prepr.mdcli = self.mdcli
+        self.prepr.cacher.distsvc = self.distcli
+
+        self.assertEqual(self.prepr.cache_headbag(), cached)
+        self.assertTrue(os.path.exists(cached))
+
     def test_cache_nerdm_rec(self):
         cached = os.path.join(self.headcache,"_nerd","ABCDEFG.json")
         self.assertTrue(not os.path.exists(cached))
+
+        self.assertEqual(self.prepr.cache_nerdm_rec(), cached)
+        self.assertTrue(os.path.exists(cached))
+
+    def test_cache_nerdm_rec_replace(self):
+        cached = os.path.join(self.headcache,"_nerd","ABCDEFG.json")
+        self.assertTrue(not os.path.exists(cached))
+
+        self.prepr = self.prepsvc.prepper_for("goober")
+        self.prepr.mdcli = self.mdcli
+        self.prepr.cacher.distsvc = self.distcli
+
+        self.assertIsNone(self.prepr.cache_nerdm_rec())
+        self.assertTrue(not os.path.exists(cached))
+
+        self.prepr = self.prepsvc.prepper_for("goober", replaces="ABCDEFG")
+        self.prepr.mdcli = self.mdcli
+        self.prepr.cacher.distsvc = self.distcli
 
         self.assertEqual(self.prepr.cache_nerdm_rec(), cached)
         self.assertTrue(os.path.exists(cached))
@@ -267,14 +303,16 @@ class TestUpdatePrepper(test.TestCase):
         self.assertTrue(os.path.exists(cached))
         self.assertEqual(self.prepr._latest_version_from_nerdcache(), "1.0")
         self.assertEqual(self.prepr.latest_version("nerdm-cache"), "1.0")
-        self.prepr.aipid = "goober"
+        self.prepr._aipid = "goober"
+        self.prepr._prevaipid = "gurn"
         self.assertEqual(self.prepr._latest_version_from_nerdcache(), "0")
         
     def test_latest_version_from_repo(self):
         self.assertEqual(self.prepr._latest_version_from_repo(), "1.0")
         self.assertEqual(self.prepr.latest_version("repo"), "1.0")
         self.assertEqual(self.prepr.latest_version(), "1.0")
-        self.prepr.aipid = "goober"
+        self.prepr._aipid = "goober"
+        self.prepr._prevaipid = "gurn"
         self.assertEqual(self.prepr._latest_version_from_repo(), "0")
 
     def test_latest_version_from_dir(self):
@@ -284,7 +322,8 @@ class TestUpdatePrepper(test.TestCase):
         
         self.assertEqual(self.prepr._latest_version_from_dir(self.headcache), "2")
         self.assertEqual(self.prepr.latest_version("bag-cache"), "2")
-        self.prepr.aipid = "goober"
+        self.prepr._aipid = "goober"
+        self.prepr._prevaipid = "gurn"
         self.assertEqual(self.prepr._latest_version_from_dir(self.headcache), "0")
         
 
@@ -322,11 +361,12 @@ class TestUpdatePrepper(test.TestCase):
         bag = NISTBag(root)
         mdata = bag.nerdm_record(True)
         self.assertEquals(mdata['version'], "1.0+ (in edit)")
-        self.assertIn('versionHistory', mdata)
-        self.assertEquals(len(mdata['versionHistory']), 1)
-        self.assertEquals(mdata['versionHistory'][0]['version'], "1.0")
-        self.assertEquals(mdata['versionHistory'][0]['@id'], mdata["@id"])
-        self.assertIn('issued', mdata['versionHistory'][0])
+        self.assertIn('releaseHistory', mdata)
+        self.assertIn('hasRelease', mdata['releaseHistory'])
+        self.assertEquals(len(mdata['releaseHistory']['hasRelease']), 1)
+        self.assertEquals(mdata['releaseHistory']['hasRelease'][0]['version'], "1.0")
+        self.assertEquals(mdata['releaseHistory']['hasRelease'][0]['@id'], mdata["@id"])
+        self.assertIn('issued', mdata['releaseHistory']['hasRelease'][0])
 
         depinfof = os.path.join(bag.dir, "multibag", "deprecated-info.txt")
         self.assertTrue(os.path.isfile(depinfof))
@@ -429,9 +469,9 @@ class TestUpdatePrepper(test.TestCase):
         with open(sf0,'w') as fd:
             pass
 
-        self.assertEqual(self.prepr.find_bag_in_store("12.7"), sf12_7)
-        self.assertEqual(self.prepr.find_bag_in_store("12.8"), sf12_8)
-        self.assertEqual(self.prepr.find_bag_in_store("0"), sf0)
+        self.assertEqual(self.prepr.find_bag_in_store(self.prepr.aipid, "12.7"), sf12_7)
+        self.assertEqual(self.prepr.find_bag_in_store(self.prepr.aipid, "12.8"), sf12_8)
+        self.assertEqual(self.prepr.find_bag_in_store(self.prepr.aipid, "0"), sf0)
 
     def test_create_new_update_fromstore(self):
         shutil.copy(os.path.join(storedir, "pdr2210.3_1_3.mbag0_3-5.zip"),

--- a/python/tests/nistoar/pdr/preserv/bagger/test_utils.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_utils.py
@@ -90,7 +90,7 @@ class TestBagName(test.TestCase):
         self.assertEqual(str(bn), bagname)
         self.assertEqual(bn.fields, ["mds3812", "1_3", "0_4", "14", "tgz"])
         self.assertEqual(bn.aipid, "mds3812")
-        self.assertEqual(bn.version, "1_3")
+        self.assertEqual(bn.version, "1.3")
         self.assertEqual(bn.multibag_profile, "0_4")
         self.assertEqual(bn.sequence, "14")
         self.assertEqual(bn.serialization, "tgz")

--- a/python/tests/nistoar/pdr/preserv/bagger/test_utils.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_utils.py
@@ -552,6 +552,7 @@ class TestBagUtils(test.TestCase):
         }
 
         data = {
+            "@id": "ark:/88888/goober.v12_3_177",
             "$schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.3",
             "foo": {
                 "$extensionSchemas": [ "http://example.com/anext/v88#goob",
@@ -580,6 +581,7 @@ class TestBagUtils(test.TestCase):
         bagut.update_nerdm_schema(data, "1.0", byext)
         self.assertEqual(data['$schema'], 
                          "https://data.nist.gov/od/dm/nerdm-schema/v2.2")
+        self.assertEqual(data['@id'], "ark:/88888/goober")
         self.assertEqual(data['foo']['$extensionSchemas'], 
                          [ "http://example.com/anext/v0.1#goob",
                            "http://goober.com/foop/v99#big" ])
@@ -592,6 +594,7 @@ class TestBagUtils(test.TestCase):
                          "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.8#/definitions/DCiteReference")
         
         data = {
+            "@id": "ark:/88888/goober",
             "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.3",
             "foo": {
                 "_extensionSchemas": [ "http://example.com/anext/v88#goob",
@@ -609,6 +612,7 @@ class TestBagUtils(test.TestCase):
         }
         bagut.update_nerdm_schema(data)
         self.assertEqual(data['_schema'], CORE_SCHEMA_URI)
+        self.assertEqual(data['@id'], "ark:/88888/goober")
         self.assertEqual(data['foo']['_extensionSchemas'], 
                          [ "http://example.com/anext/v88#goob",
                            "http://goober.com/foop/v99#big" ])

--- a/python/tests/nistoar/pdr/preserv/bagger/test_utils.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_utils.py
@@ -435,6 +435,8 @@ class TestBagUtils(test.TestCase):
         self.assertEqual(bagut.select_version(names, "1"),
                          ["mds2-3812.mbag0_4-4.tgz"])
 
+class TestNerdmUtils(test.TestCase):
+
     def test_schuripat(self):
         self.assertTrue(
    bagut._nrdpat.match("https://data.nist.gov/od/dm/nerdm-schema/pub/v1.0#Res") )
@@ -619,6 +621,97 @@ class TestBagUtils(test.TestCase):
         self.assertEqual(data['bar']['tex']['_extensionSchemas'], PUB_SCHEMA_URI+"#Contact")
         self.assertEqual(data['bar']['_extensionSchemas'], [])
         
+    def test_update_nerdm_schema_version_history(self):
+        defver = "1.0"
+        data = {
+            "@id": "ark:/88888/goober",
+            "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.3",
+            "foo": {
+                "_extensionSchemas": [ "http://example.com/anext/v88#goob",
+                          "http://goober.com/foop/v99#big" ],
+                "blah": "snooze"
+            },
+            "bar": {
+                "hank": "aaron",
+                "tex": {
+                    "_extensionSchemas": "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.3#Contact",
+                    "blah": "blah"
+                },
+                "_extensionSchemas": []
+            },
+            "versionHistory": [
+                {
+                    "version": "1.0",
+                    "issued": "2020-10-20",
+                    "location": "https://pdr.nist.gov/od/id/ark:/88888/goober",
+                    "hank": "aaron"
+                }
+            ]
+        }
+
+        bagut.update_nerdm_schema(data)
+        self.assertEqual(data['_schema'], CORE_SCHEMA_URI)
+        self.assertEqual(data['@id'], "ark:/88888/goober")
+        self.assertEqual(data['foo']['_extensionSchemas'], 
+                         [ "http://example.com/anext/v88#goob",
+                           "http://goober.com/foop/v99#big" ])
+        self.assertEqual(data['bar']['tex']['_extensionSchemas'], PUB_SCHEMA_URI+"#Contact")
+        self.assertEqual(data['bar']['_extensionSchemas'], [])
+
+        self.assertIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+        self.assertEqual(data['releaseHistory']['@id'], "ark:/88888/goober.rel")
+        self.assertEqual(data['releaseHistory']['@type'], ["nrdr:ReleaseHistory"])
+        self.assertEqual(len(data['releaseHistory']['hasRelease']), 1)
+        self.assertEqual(data['releaseHistory']['hasRelease'][0]['hank'], 'aaron')
+        self.assertEqual(data['releaseHistory']['hasRelease'][0]['version'], '1.0')
+        self.assertEqual(data['releaseHistory']['hasRelease'][0]['location'],
+                         "https://pdr.nist.gov/od/id/ark:/88888/goober.v1_0")
+
+        data['versionHistory'] = [{
+            "version": "2.0",
+            "issued": "2020-10-20",
+            "goob": "gurn"
+        }]
+        data['releaseHistory']['hasRelease'][0]['location'] = \
+                         "https://pdr.nist.gov/od/id/ark:/88888/goober.v2_0"
+        bagut.update_nerdm_schema(data)
+        self.assertEqual(data['_schema'], CORE_SCHEMA_URI)
+        self.assertEqual(data['@id'], "ark:/88888/goober")
+        self.assertEqual(data['foo']['_extensionSchemas'], 
+                         [ "http://example.com/anext/v88#goob",
+                           "http://goober.com/foop/v99#big" ])
+        self.assertEqual(data['bar']['tex']['_extensionSchemas'], PUB_SCHEMA_URI+"#Contact")
+        self.assertEqual(data['bar']['_extensionSchemas'], [])
+
+        self.assertIn('releaseHistory', data)
+        self.assertNotIn('versionHistory', data)
+        self.assertEqual(data['releaseHistory']['@id'], "ark:/88888/goober.rel")
+        self.assertEqual(data['releaseHistory']['@type'], ["nrdr:ReleaseHistory"])
+        self.assertEqual(len(data['releaseHistory']['hasRelease']), 1)
+        self.assertEqual(data['releaseHistory']['hasRelease'][0]['hank'], 'aaron')
+        self.assertEqual(data['releaseHistory']['hasRelease'][0]['version'], '1.0')
+        self.assertEqual(data['releaseHistory']['hasRelease'][0]['location'],
+                         "https://pdr.nist.gov/od/id/ark:/88888/goober.v2_0")
+
+    def test_create_release_history_for(self):
+        hist = bagut.create_release_history_for("goob")
+        self.assertEqual(hist['@id'], "goob.rel")
+        self.assertEqual(hist['@type'], ["nrdr:ReleaseHistory"])
+        self.assertEqual(hist['hasRelease'], [])
+
+        self.assertEqual(bagut.create_release_history_for("goob.gurn")['@id'], "goob.gurn.rel")
+        self.assertEqual(bagut.create_release_history_for("goob.rel")['@id'], "goob.rel")
+        self.assertEqual(bagut.create_release_history_for("goob.v1")['@id'], "goob.rel")
+        self.assertEqual(bagut.create_release_history_for("goob.v1_2")['@id'], "goob.rel")
+        self.assertEqual(bagut.create_release_history_for("goob.v1.2")['@id'], "goob.rel")
+        self.assertEqual(bagut.create_release_history_for("goob.v1_2_3")['@id'], "goob.rel")
+        self.assertEqual(bagut.create_release_history_for("goob.v2_1_3_0")['@id'], "goob.rel")
+        
+        hist = bagut.create_release_history_for("gary.v1_0_0")
+        self.assertEqual(hist['@id'], "gary.rel")
+        self.assertEqual(hist['@type'], ["nrdr:ReleaseHistory"])
+        self.assertEqual(hist['hasRelease'], [])
 
                     
                          

--- a/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
@@ -1728,7 +1728,7 @@ class TestBuilder2(test.TestCase):
         self.assertEqual(len(oxum), 1)
         oxum = [int(n) for n in oxum[0].split(': ')[1].split('.')]
         self.assertEqual(oxum[1], 14)
-        self.assertEqual(oxum[0], 12180)  # this will change if logging changes
+        self.assertEqual(oxum[0], 12207)  # this will change if logging changes
 
         bagsz = [l for l in lines if "Bag-Size: " in l]
         self.assertEqual(len(bagsz), 1)

--- a/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
@@ -1694,6 +1694,10 @@ class TestBuilder2(test.TestCase):
         self.bag.add_data_file(path, datafile)
         with open(podfile) as fd:
             pod = json.load(fd)
+
+        # this is to test proper handling of single newlines embedded into the description
+        pod['description'] = pod['description'][:52]+"\n"+pod['description'][53:]
+        
         self.bag.add_ds_pod(pod, convert=True)
 
         self.bag.ensure_baginfo()
@@ -1714,6 +1718,7 @@ class TestBuilder2(test.TestCase):
                       lines)
         self.assertEqual(len([l for l in lines
                                 if "External-Identifier: " in l]), 2)
+        self.assertNotIn("in a standing-wave laser interference field\n", lines)
         wrapping = [l for l in lines if ':' not in l]
         self.assertEqual(len(wrapping), 1)
         self.assertEqual(len([l for l in wrapping if l.startswith(' ')]), 1)
@@ -1728,7 +1733,7 @@ class TestBuilder2(test.TestCase):
         self.assertEqual(len(oxum), 1)
         oxum = [int(n) for n in oxum[0].split(': ')[1].split('.')]
         self.assertEqual(oxum[1], 14)
-        self.assertEqual(oxum[0], 12249)  # this will change if logging changes
+        self.assertEqual(oxum[0], 12251)  # this will change if logging changes
 
         bagsz = [l for l in lines if "Bag-Size: " in l]
         self.assertEqual(len(bagsz), 1)

--- a/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
@@ -1728,7 +1728,7 @@ class TestBuilder2(test.TestCase):
         self.assertEqual(len(oxum), 1)
         oxum = [int(n) for n in oxum[0].split(': ')[1].split('.')]
         self.assertEqual(oxum[1], 14)
-        self.assertEqual(oxum[0], 12207)  # this will change if logging changes
+        self.assertEqual(oxum[0], 12203)  # this will change if logging changes
 
         bagsz = [l for l in lines if "Bag-Size: " in l]
         self.assertEqual(len(bagsz), 1)

--- a/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
+++ b/python/tests/nistoar/pdr/preserv/bagit/test_builder.py
@@ -1728,7 +1728,7 @@ class TestBuilder2(test.TestCase):
         self.assertEqual(len(oxum), 1)
         oxum = [int(n) for n in oxum[0].split(': ')[1].split('.')]
         self.assertEqual(oxum[1], 14)
-        self.assertEqual(oxum[0], 12203)  # this will change if logging changes
+        self.assertEqual(oxum[0], 12249)  # this will change if logging changes
 
         bagsz = [l for l in lines if "Bag-Size: " in l]
         self.assertEqual(len(bagsz), 1)

--- a/python/tests/nistoar/pdr/preserv/data/midassip/review/1491/_pod.json
+++ b/python/tests/nistoar/pdr/preserv/data/midassip/review/1491/_pod.json
@@ -51,6 +51,7 @@
             "title": "DOI access for OptSortSph: Sorting Spherical Dielectric Particles in a Standing-Wave Interference Field"
         }
     ],
+    "doi": "https://doi.org/10.80443/pdrut-T4SW26",
     "identifier": "3A1EE2F169DD3B8CE0531A570681DB5D1491",
     "keyword": [
         "optical sorting",

--- a/python/tests/nistoar/pdr/preserv/data/midassip/upload/1491/_pod.json
+++ b/python/tests/nistoar/pdr/preserv/data/midassip/upload/1491/_pod.json
@@ -47,6 +47,7 @@
             "title": "DOI access for OptSortSph: Sorting Spherical Dielectric Particles in a Standing-Wave Interference Field"
         }
     ],
+    "doi": "https://doi.org/10.80443/pdrut-T4SW26",
     "identifier": "3A1EE2F169DD3B8CE0531A570681DB5D1491",
     "keyword": [
         "optical sorting",

--- a/python/tests/nistoar/pdr/preserv/data/simplesip/_nerdm.json
+++ b/python/tests/nistoar/pdr/preserv/data/simplesip/_nerdm.json
@@ -1,8 +1,8 @@
 {
     "@context": "https://data.nist.gov/od/dm/nerdm-pub-context.jsonld",
-    "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.4#",
+    "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.5#",
     "_extensionSchemas": [
-        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/PublishedDataResource"
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.5#/definitions/PublishedDataResource"
     ],
     "@type": [
         "nrdp:PublishedDataResource"
@@ -58,7 +58,7 @@
             "refType": "IsReferencedBy",
             "location": "https://doi.org/10.1364/OE.24.014100",
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/v0.4#/definitions/DCiteDocumentReference"
+                "https://data.nist.gov/od/dm/nerdm-schema/bib/v0.5#/definitions/DCiteDocumentReference"
             ]
         }
     ],
@@ -76,7 +76,7 @@
                 "dcat:Distribution"
             ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.5#/definitions/DataFile"
             ]
         },
         {
@@ -89,7 +89,7 @@
                 "dcat:Distribution"
             ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.5#/definitions/DataFile"
             ]
         },
         {
@@ -113,7 +113,7 @@
                 "dcat:Distribution"
             ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.5#/definitions/DataFile"
             ]
         },
         {
@@ -126,7 +126,7 @@
                 "dcat:Distribution"
             ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.5#/definitions/DataFile"
             ]
         },
         {
@@ -139,7 +139,7 @@
                 "dcat:Distribution"
             ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.5#/definitions/DataFile"
             ]
         },
         {
@@ -152,7 +152,7 @@
                 "dcat:Distribution"
             ],
             "_extensionSchemas": [
-                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.4#/definitions/DataFile"
+                "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.5#/definitions/DataFile"
             ]
         }
     ],

--- a/python/tests/nistoar/pdr/preserv/data/simplesip/_pod.json
+++ b/python/tests/nistoar/pdr/preserv/data/simplesip/_pod.json
@@ -36,6 +36,7 @@
             "title": "DOI access for OptSortSph: Sorting Spherical Dielectric Particles in a Standing-Wave Interference Field"
         }
     ],
+    "doi": "https://doi.org/10.18434/T4SW26",
     "identifier": "3A1EE2F169DD3B8CE0531A570681DB5D1491",
     "keyword": [
         "optical sorting",

--- a/python/tests/nistoar/pdr/preserv/service/test_siphandler_midas3.py
+++ b/python/tests/nistoar/pdr/preserv/service/test_siphandler_midas3.py
@@ -154,6 +154,8 @@ class TestMIDAS3SIPHandler(test.TestCase):
         # check for checksum files in review dir
         cf = os.path.join(self.bagparent, self.midasid+"_0.sha256")
         self.assertTrue(os.path.exists(cf), "Does not exist: "+cf)
+        cf = os.path.join(self.bagparent, "_preserved")
+        self.assertTrue(os.path.exists(cf), "Does not exist: "+cf)
 
         # head bag still in staging area?
         staged = os.listdir(self.sip.stagedir)

--- a/python/tests/nistoar/pdr/preserv/service/test_siphandler_midas3.py
+++ b/python/tests/nistoar/pdr/preserv/service/test_siphandler_midas3.py
@@ -6,6 +6,7 @@ from nistoar.pdr.preserv import PreservationException
 from nistoar.pdr.preserv.service import siphandler as sip
 from nistoar.pdr.preserv.service import status
 from nistoar.pdr.preserv.bagger import midas3 as midas
+from nistoar.pdr.preserv.bagit import BagBuilder
 
 # datadir = nistoar/preserv/data
 datadir = os.path.join( os.path.dirname(os.path.dirname(__file__)), "data" )
@@ -261,6 +262,111 @@ class TestMIDAS3SIPHandler(test.TestCase):
         self.assertGreater(os.stat(destfile).st_size, 1)
             
         
+
+    def test_bagit_wdeactiv8(self):
+        self.assertEqual(self.sip.state, status.FORGOTTEN)
+        self.assertEqual(len(os.listdir(self.sip.stagedir)), 0)
+
+        bldr = BagBuilder(os.path.dirname(self.sipdir), os.path.basename(self.sipdir))
+        bldr.update_metadata_for("", {"status": "removed"})
+        bldr.disconnect_logfile()
+
+        self.sip.bagit()
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.sha256")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.removed")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.sha256.removed")))
+        
+
+    def test_bagit_wdeactiv8_2(self):
+        self.assertEqual(self.sip.state, status.FORGOTTEN)
+        self.assertEqual(len(os.listdir(self.sip.stagedir)), 0)
+
+        self.sip.bagit()
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.sha256")))
+        self.assertTrue(not os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.removed")))
+        self.assertTrue(not os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.sha256.removed")))
+
+        # copy input bag to writable location
+        if not os.path.exists(self.sipdir):
+            shutil.copytree(self.testsip, self.sipdir)
+
+        bldr = BagBuilder(os.path.dirname(self.sipdir), os.path.basename(self.sipdir))
+        bldr.update_metadata_for("", {"version": "1.0.1", "status": "removed"})
+        bldr.disconnect_logfile()
+        self.sip = sip.MIDAS3SIPHandler(self.midasid, self.config)
+
+        self.sip.bagit()
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.sha256")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.removed")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.sha256.removed")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_1.mbag0_4-0.zip")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_1.mbag0_4-0.zip.sha256")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_1.mbag0_4-0.zip.removed")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_1.mbag0_4-0.zip.sha256.removed")))
+
+        
+    def test_bagit_wdeactiv8_3(self):
+        self.assertEqual(self.sip.state, status.FORGOTTEN)
+        self.assertEqual(len(os.listdir(self.sip.stagedir)), 0)
+
+        self.sip.bagit()
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.sha256")))
+        self.assertTrue(not os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.removed")))
+        self.assertTrue(not os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.sha256.removed")))
+
+        # copy input bag to writable location
+        if not os.path.exists(self.sipdir):
+            shutil.copytree(self.testsip, self.sipdir)
+
+        bldr = BagBuilder(os.path.dirname(self.sipdir), os.path.basename(self.sipdir))
+        bldr.update_metadata_for("", {"version": "1.1.0", "status": "removed"})
+        bldr.disconnect_logfile()
+        self.sip = sip.MIDAS3SIPHandler(self.midasid, self.config)
+
+        self.sip.bagit()
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.sha256")))
+        self.assertTrue(not os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.removed")))
+        self.assertTrue(not os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.sha256.removed")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_1_0.mbag0_4-0.zip")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_1_0.mbag0_4-0.zip.sha256")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_1_0.mbag0_4-0.zip.removed")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_1_0.mbag0_4-0.zip.sha256.removed")))
+
+        
+
     def test_is_preserved(self):
         self.assertEqual(self.sip.state, status.FORGOTTEN)
         self.assertFalse(self.sip._is_preserved())

--- a/python/tests/nistoar/pdr/preserv/service/test_siphandler_midas3.py
+++ b/python/tests/nistoar/pdr/preserv/service/test_siphandler_midas3.py
@@ -280,6 +280,8 @@ class TestMIDAS3SIPHandler(test.TestCase):
                                           self.midasid+".1_0_0.mbag0_4-0.zip.removed")))
         self.assertTrue(os.path.exists(os.path.join(self.storedir, 
                                           self.midasid+".1_0_0.mbag0_4-0.zip.sha256.removed")))
+        self.assertTrue(not os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.sha256.sha256.removed")))
         
 
     def test_bagit_wdeactiv8_2(self):

--- a/python/tests/nistoar/pdr/preserv/service/test_siphandler_midas3_rm2.py
+++ b/python/tests/nistoar/pdr/preserv/service/test_siphandler_midas3_rm2.py
@@ -1,0 +1,212 @@
+import os, pdb, sys, logging, yaml, stat
+import unittest as test
+
+from nistoar.testing import *
+from nistoar.pdr.preserv import PreservationException
+from nistoar.pdr.preserv.service import siphandler as sip
+from nistoar.pdr.preserv.service import status
+from nistoar.pdr.preserv.bagger import midas3 as midas
+from nistoar.pdr.preserv.bagit import BagBuilder
+
+# datadir = nistoar/preserv/data
+datadir = os.path.join( os.path.dirname(os.path.dirname(__file__)), "data" )
+pdrmoddir = os.path.dirname(os.path.dirname(datadir))
+basedir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(pdrmoddir))))
+
+loghdlr = None
+rootlog = None
+def setUpModule():
+    global loghdlr
+    global rootlog
+    ensure_tmpdir()
+    rootlog = logging.getLogger()
+    loghdlr = logging.FileHandler(os.path.join(tmpdir(),"test_siphandler.log"))
+    loghdlr.setLevel(logging.DEBUG)
+    rootlog.addHandler(loghdlr)
+    startService()
+
+def tearDownModule():
+    global loghdlr
+    if loghdlr:
+        if rootlog:
+            rootlog.removeHandler(loghdlr)
+        loghdlr = None
+    stopService()
+    rmtmpdir()
+
+distarchive = os.path.join(tmpdir(), "distarchive")
+
+def startService():
+    tdir = tmpdir()
+    archdir = distarchive
+    os.mkdir(archdir)
+
+    srvport = 9091
+    pidfile = os.path.join(tdir,"simdistrib"+str(srvport)+".pid")
+    wpy = "python/tests/nistoar/pdr/distrib/sim_distrib_srv.py"
+    assert os.path.exists(wpy)
+    cmd = "uwsgi --daemonize {0} --plugin python --http-socket :{1} " \
+          "--wsgi-file {2} --set-ph archive_dir={3} --pidfile {4}"
+    cmd = cmd.format(os.path.join(tdir,"simdistrib.log"), srvport,
+                     os.path.join(basedir, wpy), archdir, pidfile)
+    os.system(cmd)
+
+def stopService():
+    tdir = tmpdir()
+    srvport = 9091
+    pidfile = os.path.join(tdir,"simdistrib"+str(srvport)+".pid")
+    
+    cmd = "uwsgi --stop {0}".format(os.path.join(tdir,
+                                               "simdistrib"+str(srvport)+".pid"))
+    os.system(cmd)
+
+    # sometimes stopping with uwsgi doesn't work
+    try:
+        with open(pidfile) as fd:
+            pid = int(fd.read().strip())
+        os.kill(pid, signal.SIGTERM)
+    except:
+        pass
+
+
+class TestMIDAS3SIPHandler(test.TestCase):
+
+    testsip = os.path.join(datadir, "metadatabag")
+    revdir = os.path.join(datadir, "midassip", "review")
+    # testdata = os.path.join(datadir, "samplembag", "data")
+    midasid = '3A1EE2F169DD3B8CE0531A570681DB5D1491'
+    arkid = "ark:/88434/mds2-1491"
+
+    def setUp(self):
+        self.tf = Tempfiles()
+        if not os.path.exists(distarchive):
+            os.mkdir(distarchive)
+
+        self.workdir = self.tf.mkdir("preserv")
+        self.mdbags =  os.path.join(self.workdir, "mdbags")
+        self.dataroot = os.path.join(self.workdir, "data")
+        os.mkdir(self.dataroot)
+        self.datadir = os.path.join(self.dataroot, "1491")
+        self.stagedir = os.path.join(self.workdir, "staging")
+        self.storedir = os.path.join(self.workdir, "store")
+        os.mkdir(self.storedir)
+        self.statusdir = os.path.join(self.workdir, "status")
+        os.mkdir(self.statusdir)
+        self.bagparent = os.path.join(self.datadir, "_preserv")
+        self.sipdir = os.path.join(self.mdbags, self.midasid)
+
+        with open(os.path.join(datadir, "bagger_conf.yml")) as fd:
+            baggercfg = yaml.load(fd)
+            
+        # set the config we'll use
+        self.config = {
+            'working_dir': self.workdir,
+            'review_dir': self.dataroot,
+            "staging_dir": self.stagedir,
+            'store_dir': self.storedir,
+            "status_manager": { "cachedir": self.statusdir },
+            'bagger': baggercfg,
+            "ingester": {
+                "data_dir":  os.path.join(self.workdir, "ingest"),
+                "submit": "none"
+            },
+            "repo_access": {
+                "distrib_service": {
+                    "service_endpoint": "http://localhost:9091"
+                }
+            },
+            "multibag": {
+                "max_headbag_size": 2000000,
+#                "max_headbag_size": 100,
+                "max_bag_size": 200000000
+            }
+        }
+
+        # copy the data files first
+        shutil.copytree(os.path.join(self.revdir, "1491"), self.datadir)
+        # os.mkdir(self.bagparent)
+
+        # copy input bag to writable location
+        shutil.copytree(self.testsip, self.sipdir)
+
+        mdbgr = midas.MIDASMetadataBagger(self.midasid, self.mdbags, self.datadir)
+        mdbgr.ensure_data_files(examine="sync")
+        mdbgr.done()
+
+        self.sip = sip.MIDAS3SIPHandler(self.midasid, self.config)
+
+    def tearDown(self):
+        self.sip = None
+        self.tf.clean()
+
+    def test_ctor(self):
+        self.assertTrue(self.sip.bagger)
+        self.assertTrue(os.path.exists(self.workdir))
+        self.assertTrue(os.path.exists(self.stagedir))
+        self.assertTrue(os.path.exists(self.mdbags))
+
+        self.assertTrue(isinstance(self.sip.status, dict))
+        self.assertEqual(self.sip.state, status.FORGOTTEN)
+
+        self.assertIsNone(self.sip.bagger.asupdate)
+
+    def test_bagit_wdeactiv8_2(self):
+        self.assertEqual(self.sip.state, status.FORGOTTEN)
+        self.assertEqual(len(os.listdir(self.sip.stagedir)), 0)
+
+        self.sip.bagit()
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.sha256")))
+        self.assertTrue(not os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.removed")))
+        self.assertTrue(not os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.sha256.removed")))
+
+        # move bag files to distrib server
+        os.rename(os.path.join(self.storedir, self.midasid+".1_0_0.mbag0_4-0.zip"),
+                  os.path.join(distarchive, self.midasid+".1_0_0.mbag0_4-0.zip"))
+        os.rename(os.path.join(self.storedir, self.midasid+".1_0_0.mbag0_4-0.zip.sha256"),
+                  os.path.join(distarchive, self.midasid+".1_0_0.mbag0_4-0.zip.sha256"))
+        self.assertTrue(not os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip")))
+        self.assertTrue(not os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.sha256")))
+
+        # copy input bag to writable location
+        if not os.path.exists(self.sipdir):
+            shutil.copytree(self.testsip, self.sipdir)
+
+        bldr = BagBuilder(os.path.dirname(self.sipdir), os.path.basename(self.sipdir))
+        bldr.update_metadata_for("", {"version": "1.0.1", "status": "removed"})
+        bldr.disconnect_logfile()
+        self.sip = sip.MIDAS3SIPHandler(self.midasid, self.config)
+
+        self.sip.bagit()
+        self.assertTrue(not os.path.exists(os.path.join(self.storedir, 
+                                                    self.midasid+".1_0_0.mbag0_4-0.zip")))
+        self.assertTrue(not os.path.exists(os.path.join(self.storedir, 
+                                                        self.midasid+".1_0_0.mbag0_4-0.zip.sha256")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.removed")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_0.mbag0_4-0.zip.sha256.removed")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_1.mbag0_4-0.zip")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_1.mbag0_4-0.zip.sha256")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_1.mbag0_4-0.zip.removed")))
+        self.assertTrue(os.path.exists(os.path.join(self.storedir, 
+                                          self.midasid+".1_0_1.mbag0_4-0.zip.sha256.removed")))
+
+        
+
+
+
+
+
+
+if __name__ == '__main__':
+    test.main()

--- a/python/tests/nistoar/pdr/publish/cmd/test_prepupd.py
+++ b/python/tests/nistoar/pdr/publish/cmd/test_prepupd.py
@@ -119,11 +119,23 @@ class TestPrepupdCmd(test.TestCase):
         self.assertEqual(args.cmd, "prepupd")
         self.assertEqual(args.aipid, ["pdr2222"])
 
-        argline = "-q -w "+self.workdir+" prepupd pdr2210 -C headbags -r https://data.nist.gov/"
+        argline = "-q -w "+self.workdir+" prepupd pdr2210 -C headbags -u https://data.nist.gov/"
         args = self.cmd.parser.parse_args(argline.split())
         self.assertEqual(args.workdir, self.workdir)
         self.assertEqual(args.cachedir, 'headbags')
         self.assertEqual(args.repourl, "https://data.nist.gov/")
+        self.assertIsNone(args.replaces)
+        self.assertTrue(args.quiet)
+        self.assertFalse(args.verbose)
+        self.assertEqual(args.cmd, "prepupd")
+        self.assertEqual(args.aipid, ["pdr2210"])
+
+        argline = "-q -w "+self.workdir+" prepupd pdr2210 -C headbags -r pdr2001"
+        args = self.cmd.parser.parse_args(argline.split())
+        self.assertEqual(args.workdir, self.workdir)
+        self.assertEqual(args.cachedir, 'headbags')
+        self.assertEqual(args.replaces, "pdr2001")
+        self.assertIsNone(args.repourl)
         self.assertTrue(args.quiet)
         self.assertFalse(args.verbose)
         self.assertEqual(args.cmd, "prepupd")
@@ -136,7 +148,7 @@ class TestPrepupdCmd(test.TestCase):
         self.assertNotIn('distrib_service', cfg)
         self.assertNotIn('metadata_service', cfg)
 
-        argline = "-q -w "+self.workdir+" prepupd pdr2210 -C headbags -r https://data.nist.gov/"
+        argline = "-q -w "+self.workdir+" prepupd pdr2210 -C headbags -u https://data.nist.gov/"
         args = self.cmd.parser.parse_args(argline.split())
         cfg = prepupd.get_access_config(args, {'working_dir': args.workdir})
         self.assertEqual(cfg['headbag_cache'], os.path.join(self.workdir,"headbags"))

--- a/python/tests/nistoar/pdr/publish/midas3/test_service.py
+++ b/python/tests/nistoar/pdr/publish/midas3/test_service.py
@@ -187,7 +187,7 @@ class TestMIDAS3PublishingService(test.TestCase):
         data = utils.read_json(os.path.join(self.nrddir, self.midasid+".json"))
         self.assertEqual(data.get('ediid'), self.midasid)
         self.assertTrue(data.get('_marker'), "Failed to retain annotations")
-                        
+
     def test_delete(self):
         podf = os.path.join(self.revdir, "1491", "_pod.json")
         pod = utils.read_json(podf)
@@ -348,6 +348,7 @@ class TestMIDAS3PublishingService(test.TestCase):
         self.assertEqual(nerd['title'], "Goober!")
         
         
+                        
 
 
 

--- a/python/tests/nistoar/pdr/publish/midas3/test_service_update.py
+++ b/python/tests/nistoar/pdr/publish/midas3/test_service_update.py
@@ -215,6 +215,7 @@ class TestMIDAS3PublishingServiceOnUpdate(test.TestCase):
         self.assertTrue(not os.path.exists(self.updbagdir))
         data = utils.read_json(os.path.join(self.nrddir, self.prevmidasid+".json"))
         self.assertEqual(data.get('ediid'), self.prevmidasid)
+        self.assertEqual(data.get('version'), "1.0.0")
 
         oldwrkr = self.svc._get_bagging_worker(self.prevmidasid)
         newwrkr = self.svc._get_bagging_worker(self.updmidasid)
@@ -222,9 +223,10 @@ class TestMIDAS3PublishingServiceOnUpdate(test.TestCase):
 
         self.assertTrue(os.path.exists(self.replbagdir))
         self.assertTrue(os.path.exists(self.updbagdir))
-        data = utils.read_json(os.path.join(self.updbagdir, "metadata", "nerdm.json"))
+        data = newwrkr.bagger.sip.nerd
         self.assertEqual(data.get('ediid'), self.updmidasid)
-        
+        self.assertEqual(data.get('version'), "1.0.0+ (in edit)")
+
         
     def test_update_ds_with_pod_onupdate(self):
         podf = os.path.join(self.revdir, "1491", "_pod.json")
@@ -240,6 +242,11 @@ class TestMIDAS3PublishingServiceOnUpdate(test.TestCase):
         self.assertTrue(not os.path.exists(self.updbagdir))
         data = utils.read_json(os.path.join(self.nrddir, self.prevmidasid+".json"))
         self.assertEqual(data.get('ediid'), self.prevmidasid)
+        data = utils.read_json(os.path.join(self.mddir, self.prevmidasid, "metadata", "nerdm.json"))
+        self.assertEqual(data.get('ediid'), self.prevmidasid)
+        self.assertEqual(data.get('version'), "1.0.0")
+        # data = {'version': "1.0.1+ (in edit)"}
+        # utils.write_json(data, os.path.join(self.mddir, self.prevmidasid, "metadata", "annot.json"))
         
         # submit under new EDI-ID; POD record will have new MIDAS ID, new DOI, and new download URLs
         pod['replaces'] = pod['identifier']
@@ -255,6 +262,8 @@ class TestMIDAS3PublishingServiceOnUpdate(test.TestCase):
         self.assertTrue(os.path.exists(self.updbagdir))
         data = utils.read_json(os.path.join(self.nrddir, "mds8-8888.json"))
         self.assertEqual(data.get('ediid'), self.updmidasid)
+        # self.assertEqual(data.get('version'), "1.0.1+ (in edit)")
+        self.assertEqual(data.get('version'), "1.0.0+ (in edit)")
         
         self.assertTrue(os.path.exists(os.path.join(self.updbagdir,"metadata","__bagger-midas3.json")))
         bmd = utils.read_json(os.path.join(self.updbagdir,"metadata","__bagger-midas3.json"))

--- a/python/tests/nistoar/pdr/publish/midas3/test_service_update.py
+++ b/python/tests/nistoar/pdr/publish/midas3/test_service_update.py
@@ -1,0 +1,268 @@
+import os, sys, pdb, shutil, logging, json, time, re
+from cStringIO import StringIO
+from io import BytesIO
+import warnings as warn
+import unittest as test
+from collections import OrderedDict
+from copy import deepcopy
+
+from nistoar.testing import *
+from nistoar.pdr import utils, ARK_NAAN
+import nistoar.pdr.preserv.bagit.builder as bldr
+from nistoar.pdr.preserv.bagit.bag import NISTBag
+from nistoar.pdr.publish.midas3 import service as mdsvc
+import nistoar.pdr.exceptions as exceptions
+from nistoar.pdr.preserv import AIPValidationError
+
+# datadir = nistoar/pdr/preserv/data
+testdir = os.path.dirname(os.path.abspath(__file__))
+pdrmoddir = os.path.dirname(os.path.dirname(testdir))
+datadir = os.path.join(pdrmoddir, 'preserv', 'data')
+pdrmoddir = os.path.dirname(os.path.dirname(testdir))
+basedir = os.path.dirname(os.path.dirname(os.path.dirname(
+                                                 os.path.dirname(pdrmoddir))))
+distarchdir = os.path.join(pdrmoddir, "distrib", "data")
+descarchdir = os.path.join(pdrmoddir, "describe", "data")
+
+loghdlr = None
+rootlog = None
+def setUpModule():
+    global loghdlr
+    global rootlog
+    ensure_tmpdir()
+#    logging.basicConfig(filename=os.path.join(tmpdir(),"test_builder.log"),
+#                        level=logging.INFO)
+    rootlog = logging.getLogger()
+    loghdlr = logging.FileHandler(os.path.join(tmpdir(),"test_builder.log"))
+    loghdlr.setLevel(logging.INFO)
+    loghdlr.setFormatter(logging.Formatter(bldr.DEF_BAGLOG_FORMAT))
+    rootlog.addHandler(loghdlr)
+    startServices()
+
+def tearDownModule():
+    global loghdlr
+    if loghdlr:
+        if rootlog:
+            rootlog.removeHandler(loghdlr)
+            loghdlr.flush()
+            loghdlr.close()
+        loghdlr = None
+    stopServices()
+    rmtmpdir()
+
+distarchive = os.path.join(tmpdir(), "distarchive")
+mdarchive = os.path.join(tmpdir(), "mdarchive")
+
+def startServices():
+    tdir = tmpdir()
+    archdir = distarchive
+    shutil.copytree(distarchdir, archdir)
+    shutil.copyfile(os.path.join(archdir,"1491.1_0.mbag0_4-0.zip"),
+                    os.path.join(archdir,"3A1EE2F169DD3B8CE0531A570681DB5D1491.1_0.mbag0_4-0.zip"))
+
+    srvport = 9091
+    pidfile = os.path.join(tdir,"simdistrib"+str(srvport)+".pid")
+    wpy = "python/tests/nistoar/pdr/distrib/sim_distrib_srv.py"
+    assert os.path.exists(wpy)
+    cmd = "uwsgi --daemonize {0} --plugin python --http-socket :{1} " \
+          "--wsgi-file {2} --set-ph archive_dir={3} --pidfile {4}"
+    cmd = cmd.format(os.path.join(tdir,"simdistrib.log"), srvport,
+                     os.path.join(basedir, wpy), archdir, pidfile)
+    os.system(cmd)
+
+    archdir = mdarchive
+    shutil.copytree(descarchdir, archdir)
+    nerd = utils.read_nerd(os.path.join(archdir, "pdr02d4t.json"))
+    nerd['ediid'] = "3A1EE2F169DD3B8CE0531A570681DB5D1491"
+    utils.write_json(nerd, os.path.join(archdir, "3A1EE2F169DD3B8CE0531A570681DB5D1491.json"))
+
+    srvport = 9092
+    pidfile = os.path.join(tdir,"simrmm"+str(srvport)+".pid")
+    wpy = "python/tests/nistoar/pdr/describe/sim_describe_svc.py"
+    assert os.path.exists(wpy)
+    cmd = "uwsgi --daemonize {0} --plugin python --http-socket :{1} " \
+          "--wsgi-file {2} --set-ph archive_dir={3} --pidfile {4}"
+    cmd = cmd.format(os.path.join(tdir,"simrmm.log"), srvport,
+                     os.path.join(basedir, wpy), archdir, pidfile)
+    os.system(cmd)
+    time.sleep(0.5)
+
+def stopServices():
+    tdir = tmpdir()
+    srvport = 9091
+    pidfile = os.path.join(tdir,"simdistrib"+str(srvport)+".pid")
+    
+    cmd = "uwsgi --stop {0}".format(os.path.join(tdir,
+                                               "simdistrib"+str(srvport)+".pid"))
+    os.system(cmd)
+
+    # sometimes stopping with uwsgi doesn't work
+    try:
+        with open(pidfile) as fd:
+            pid = int(fd.read().strip())
+        os.kill(pid, signal.SIGTERM)
+    except:
+        pass
+
+    srvport = 9092
+    pidfile = os.path.join(tdir,"simrmm"+str(srvport)+".pid")
+    
+    cmd = "uwsgi --stop {0}".format(os.path.join(tdir,
+                                               "simrmm"+str(srvport)+".pid"))
+    os.system(cmd)
+
+    time.sleep(1)
+
+    # sometimes stopping with uwsgi doesn't work
+    try:
+        with open(pidfile) as fd:
+            pid = int(fd.read().strip())
+        os.kill(pid, signal.SIGTERM)
+    except:
+        pass
+
+
+
+
+
+class TestMIDAS3PublishingServiceOnUpdate(test.TestCase):
+
+    testsip = os.path.join(datadir, "midassip")
+    prevmidasid = '3A1EE2F169DD3B8CE0531A570681DB5D1491'
+    updmidasid = "ark:/"+ARK_NAAN+"/mds8-8888"
+
+    defcfg = {
+        'customization_service': {
+            'auth_key': 'SECRET',
+            'service_endpoint': "http:notused.net/",
+            'merge_convention': 'midas1'
+        },
+        'update': {
+            'updatable_properties': [ "title", "authors", "_editStatus" ]
+        },
+        'metadata_bags_dir': "mddir"
+    }
+
+    def setUp(self):
+        self.tf = Tempfiles()
+        self.workdir = self.tf.mkdir("pubserv")
+        self.mddir = os.path.join(self.workdir, "mddir")
+        os.mkdir(self.mddir)
+        self.pubcache = self.tf.mkdir("headcache")
+
+        testsip = os.path.join(self.testsip, "review")
+        self.revdir = os.path.join(self.workdir, "review")
+        self.upldir = os.path.join(self.workdir, "upload")
+        self.sipdir = os.path.join(self.revdir, "8888")
+        shutil.copytree(testsip, self.revdir)
+        now = time.time()
+        for base, dirs, files in os.walk(self.revdir):
+            for f in files+dirs:
+                os.utime(os.path.join(base,f), (now, now))
+        shutil.copytree(os.path.join(self.revdir, "1491"), self.sipdir)
+        os.mkdir(self.upldir)
+        
+        self.nrddir = os.path.join(self.workdir, "nrdserv")
+        self.bagconfig = {
+            'relative_to_indir': True,
+            'bag_builder': {
+                'copy_on_link_failure': False,
+                'init_bag_info': {
+                    'Source-Organization':
+                        "National Institute of Standards and Technology",
+                    'Contact-Email': ["datasupport@nist.gov"],
+                    'Organization-Address': [
+                        "100 Bureau Dr., Gaithersburg, MD 20899"],
+                    'NIST-BagIt-Version': "0.4",
+                    'Multibag-Version': "0.4"
+                }
+            },
+            'repo_access': {
+                'headbag_cache':   self.pubcache,
+                'distrib_service': {
+                    'service_endpoint': "http://localhost:9091/"
+                },
+                'metadata_service': {
+                    'service_endpoint': "http://localhost:9092/"
+                }
+            },
+            'store_dir': distarchdir
+        }
+        self.config = { "bagger": self.bagconfig }
+        self.config.update(deepcopy(self.defcfg))
+
+        self.svc = mdsvc.MIDAS3PublishingService(self.defcfg, self.workdir,
+                                                 self.revdir, self.upldir)
+        self.updbagdir = os.path.join(self.mddir, "mds8-8888")
+        self.replbagdir = os.path.join(self.mddir, self.prevmidasid)
+
+    def tearDown(self):
+        if self.svc:
+            self.svc._drop_all_workers(300)
+        self.tf.clean()
+
+    def test_copy_oldbag_when_done(self):
+        podf = os.path.join(self.revdir, "1491", "_pod.json")
+        pod = utils.read_json(podf)
+
+        self.assertTrue(not os.path.exists(self.updbagdir))
+        self.assertTrue(not os.path.exists(self.replbagdir))
+
+        # submit pod under old EDI-ID
+        bagr = self.svc.update_ds_with_pod(pod, False)
+        
+        self.assertTrue(os.path.exists(self.replbagdir))
+        self.assertTrue(not os.path.exists(self.updbagdir))
+        data = utils.read_json(os.path.join(self.nrddir, self.prevmidasid+".json"))
+        self.assertEqual(data.get('ediid'), self.prevmidasid)
+
+        oldwrkr = self.svc._get_bagging_worker(self.prevmidasid)
+        newwrkr = self.svc._get_bagging_worker(self.updmidasid)
+        self.svc._copy_oldbag_when_done(oldwrkr, newwrkr)
+
+        self.assertTrue(os.path.exists(self.replbagdir))
+        self.assertTrue(os.path.exists(self.updbagdir))
+        data = utils.read_json(os.path.join(self.updbagdir, "metadata", "nerdm.json"))
+        self.assertEqual(data.get('ediid'), self.updmidasid)
+        
+        
+    def test_update_ds_with_pod_onupdate(self):
+        podf = os.path.join(self.revdir, "1491", "_pod.json")
+        pod = utils.read_json(podf)
+
+        self.assertTrue(not os.path.exists(self.updbagdir))
+        self.assertTrue(not os.path.exists(self.replbagdir))
+
+        # submit pod under old EDI-ID
+        bagr = self.svc.update_ds_with_pod(pod, False)
+        
+        self.assertTrue(os.path.exists(self.replbagdir))
+        self.assertTrue(not os.path.exists(self.updbagdir))
+        data = utils.read_json(os.path.join(self.nrddir, self.prevmidasid+".json"))
+        self.assertEqual(data.get('ediid'), self.prevmidasid)
+        
+        # submit under new EDI-ID; POD record will have new MIDAS ID, new DOI, and new download URLs
+        pod['replaces'] = pod['identifier']
+        pod['identifier'] = self.updmidasid
+        for dist in pod['distribution']:
+            if 'downloadURL' in dist and '/od/ds/' in dist['downloadURL']:
+                dist['downloadURL'] = re.sub(self.prevmidasid, self.updmidasid, dist['downloadURL'])
+            elif 'accessURL' in dist and 'doi.org' in dist['accessURL']:
+                dist['accessURL'] = re.sub(r'/[^/]+$', '/mds8-8888', dist['accessURL'])
+                        
+        bagr = self.svc.update_ds_with_pod(pod, False)
+        self.assertTrue(os.path.exists(self.replbagdir))
+        self.assertTrue(os.path.exists(self.updbagdir))
+        data = utils.read_json(os.path.join(self.nrddir, "mds8-8888.json"))
+        self.assertEqual(data.get('ediid'), self.updmidasid)
+        
+        self.assertTrue(os.path.exists(os.path.join(self.updbagdir,"metadata","__bagger-midas3.json")))
+        bmd = utils.read_json(os.path.join(self.updbagdir,"metadata","__bagger-midas3.json"))
+        self.assertEqual(bmd.get("replacedEDI"), self.prevmidasid)
+        
+
+
+
+if __name__ == '__main__':
+    test.main()
+

--- a/python/tests/nistoar/pdr/test_utils.py
+++ b/python/tests/nistoar/pdr/test_utils.py
@@ -116,7 +116,7 @@ class TestMeausreDirSize(test.TestCase):
     def test_measure2(self):
         vals = utils.measure_dir_size(testdatadir2)
         self.assertEqual(vals[1], 5)
-        self.assertEqual(vals[0], 9276)
+        self.assertEqual(vals[0], 9322)
 
 class TestRmtree(test.TestCase):
 

--- a/python/tests/nistoar/pdr/test_utils.py
+++ b/python/tests/nistoar/pdr/test_utils.py
@@ -116,7 +116,7 @@ class TestMeausreDirSize(test.TestCase):
     def test_measure2(self):
         vals = utils.measure_dir_size(testdatadir2)
         self.assertEqual(vals[1], 5)
-        self.assertEqual(vals[0], 9272)
+        self.assertEqual(vals[0], 9276)
 
 class TestRmtree(test.TestCase):
 


### PR DESCRIPTION
NIST policy regarding updates to data publications changed recently, and this PR adapts to the new policy.  In particular, when an author replaces a previously published file, the policy mandates that it receive a new EDI-ID and a new DOI.  This PR now supports this use case while retaining the original PDR identifier and tracking the version according to the PDR versioning convention.  To help track the evolution of a publication, several new kinds of dates are now embedded into the NERDm metadata.  Further, the policy allows under rare circumstances for old versions of publications to be "deactivated"--that is, it files being no longer downloadable.  This PR also adds support for doing this automatically, triggered by MIDAS via a `"status": "deactivated"` property in the submitted POD file.  

This PR relies strongly on a corresponding update in MIDAS; thus, testing on datapubtest with the updated MIDAS is necessary.