### PR TITLE
Display dataset metrics instead of file metrics; Hide metrics display…

### DIFF
--- a/angular/src/app/landing/landingpage.component.html
+++ b/angular/src/app/landing/landingpage.component.html
@@ -60,6 +60,7 @@
                 <tools-menu #menu2  [record]="md" 
                 [recordLevelMetrics]="recordLevelMetrics"
                 [hasCurrentMetrics]="hasCurrentMetrics"
+                [showMetrics]="showMetrics"
                 [metricsUrl]="metricsUrl"
                 [isPopup]="false"
                 (toggle_citation)="toggleCitation('large')"

--- a/angular/src/app/landing/landingpage.component.ts
+++ b/angular/src/app/landing/landingpage.component.ts
@@ -73,6 +73,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
     dataCartStatus: DataCartStatus;
     fileLevelMetrics: any;
     hasCurrentMetrics: boolean = false;
+    showMetrics: boolean = false;
 
     /**
      * create the component.
@@ -175,9 +176,10 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
             else{
                 // Get metrics when edit is not enabled. Otherwise display "Metrics not available"
                 if(this.inBrowser){
-                    if(this.editEnabled)
+                    if(this.editEnabled){
                         this.hasCurrentMetrics = false;
-                    else
+                        this.showMetrics = true;
+                    }else
                         this.getMetrics();
                 }
 
@@ -254,6 +256,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
             // when it finishes downloading
             if(event.type == HttpEventType.Response){
                 let response = await event.body.text();
+
                 this.fileLevelMetrics = JSON.parse(response);
 
                 if(this.fileLevelMetrics.FilesMetrics != undefined && this.fileLevelMetrics.FilesMetrics.length > 0){
@@ -268,10 +271,13 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
                 }else{
                     this.hasCurrentMetrics = false;
                 }
+
+                this.showMetrics = true;
             }
         },
         (err) => {
             console.error("Failed to retrieve file metrics: ", err);
+            this.showMetrics = true;
         });                    
 
         this.metricsService.getRecordLevelMetrics(ediid).subscribe(async (event) => {
@@ -281,6 +287,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
         },
         (err) => {
             console.error("Failed to retrieve dataset metrics: ", err);
+            this.showMetrics = true;
         });  
     }
 

--- a/angular/src/app/landing/tools/toolmenu.component.ts
+++ b/angular/src/app/landing/tools/toolmenu.component.ts
@@ -38,6 +38,9 @@ export class ToolMenuComponent implements OnChanges {
     // flag if there is file level metrics data
     @Input() hasCurrentMetrics : boolean|null = false;
 
+    // flag if metrics is ready to display
+    @Input() showMetrics : boolean|null = false;
+
     // Record level metrics data
     @Input() metricsUrl : string|null = "";
 
@@ -202,53 +205,55 @@ export class ToolMenuComponent implements OnChanges {
 
         // Dataset Metrics
         // First check if there is any file in the dataset. If not, do not display metrics.
-        if(this.hasCurrentMetrics){
-            let hasFile = false;
-    
-            if(this.record.components && this.record.components.length > 0){
-                this.record.components.forEach(element => {
-                    if(element.filepath){
-                        hasFile = true;
-                        return;
-                    }
-                });
-            }
-
-            if(hasFile){
-                //Now check if there is any metrics data
-                let totalFileDownload = this.recordLevelMetrics.DataSetMetrics[0] != undefined? this.recordLevelMetrics.DataSetMetrics[0].success_get : 0;
-    
-                totalFileDownload = totalFileDownload == undefined? 0 : totalFileDownload;
+        if(this.showMetrics){
+            if(this.hasCurrentMetrics){
+                let hasFile = false;
         
-                let totalUsers = this.recordLevelMetrics.DataSetMetrics[0] != undefined? this.recordLevelMetrics.DataSetMetrics[0].number_users : 0;
-        
-                totalUsers = totalUsers == undefined? 0 : totalUsers;
-        
-                let totalDownloadSize = this.recordLevelMetrics.DataSetMetrics[0] != undefined?
-                    this.commonFunctionService.formatBytes(this.recordLevelMetrics.DataSetMetrics[0].total_size, 2) : 0;
-        
-                if(this.recordLevelMetrics.DataSetMetrics.length > 0 && totalFileDownload > 0){
-                    subitems = [
-                        this.createMenuItem(totalFileDownload>1?totalFileDownload.toString() + ' files downloaded':totalFileDownload.toString() + ' file downloaded', null,null, this.metricsUrl, "_self"),
-                        this.createMenuItem(totalUsers > 1?totalUsers.toString() + ' unique users':totalUsers.toString() + ' unique user', null,null, this.metricsUrl, "_self"),
-                        this.createMenuItem(totalDownloadSize.toString() + ' downloaded', null,null, this.metricsUrl, "_self")
-                        // this.createMenuItem('More ...', null,null, this.metricsUrl, "_self")
-                    ];
-    
-                    hasMetrics = true;
+                if(this.record.components && this.record.components.length > 0){
+                    this.record.components.forEach(element => {
+                        if(element.filepath){
+                            hasFile = true;
+                            return;
+                        }
+                    });
                 }
-            }
-        }else{
-            hasMetrics = false;
-        }
-        
-        if(!hasMetrics){
-            subitems = [
-                this.createMenuItem('Metrics not available', null,null, null)
-            ]; 
-        }
 
-        mitems.push({ label: "Dataset Metrics", items: subitems });
+                if(hasFile){
+                    //Now check if there is any metrics data
+                    let totalDatasetDownload = this.recordLevelMetrics.DataSetMetrics[0] != undefined? this.recordLevelMetrics.DataSetMetrics[0].record_download : 0;
+        
+                    // totalFileDownload = totalFileDownload == undefined? 0 : totalFileDownload;
+            
+                    let totalUsers = this.recordLevelMetrics.DataSetMetrics[0] != undefined? this.recordLevelMetrics.DataSetMetrics[0].number_users : 0;
+            
+                    totalUsers = totalUsers == undefined? 0 : totalUsers;
+            
+                    let totalDownloadSize = this.recordLevelMetrics.DataSetMetrics[0] != undefined?
+                        this.commonFunctionService.formatBytes(this.recordLevelMetrics.DataSetMetrics[0].total_size, 2) : 0;
+            
+                    if(this.recordLevelMetrics.DataSetMetrics.length > 0 && totalDatasetDownload > 0){
+                        subitems = [
+                            this.createMenuItem(totalDatasetDownload.toString() + ' dataset downloads', null,null, this.metricsUrl, "_self"),
+                            this.createMenuItem(totalUsers > 1?totalUsers.toString() + ' unique users':totalUsers.toString() + ' unique user', null,null, this.metricsUrl, "_self"),
+                            this.createMenuItem(totalDownloadSize.toString() + ' downloaded', null,null, this.metricsUrl, "_self")
+                            // this.createMenuItem('More ...', null,null, this.metricsUrl, "_self")
+                        ];
+        
+                        hasMetrics = true;
+                    }
+                }
+            }else{
+                hasMetrics = false;
+            }
+            
+            if(!hasMetrics){
+                subitems = [
+                    this.createMenuItem('Metrics not available', null,null, null)
+                ]; 
+            }
+
+            mitems.push({ label: "Dataset Metrics", items: subitems });
+        }
 
         this.items = mitems;
     }


### PR DESCRIPTION
This check in has two fixes:
1. In the top right green menu of the landing page, display dataset downloads instead of file download.
2. Hide dataset metrics block until metrics data is available (or error) so dataset metrics will not display "Metrics not available" then some metrics data.

Tested locally with fake backend. Testing in local docker...