### PR TITLE
Add support for github actions as replacement for travis-ci

### DIFF
--- a/.github/workflows/angular-source.yml
+++ b/.github/workflows/angular-source.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup node.js 10.9
+        uses: actions/setup-node@v2
         with:
           node-version: 10.9
 

--- a/.github/workflows/angular-source.yml
+++ b/.github/workflows/angular-source.yml
@@ -1,0 +1,37 @@
+name: source-update
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore: ['main', 'integration']
+    paths:
+      - 'angular/src/**'
+      - 'angular/pom.xml'
+jobs:
+  buildtest:
+    runs-on: ubuntu-20.04
+#    strategy:
+#      matrix:
+#        java: [ '8' ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup node.js 10.9
+        with:
+          node-version: 10.9
+
+      - name: Setup dependency caching
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('angular/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node
+
+      - name: Install dependencies
+        run: cd angular && npm install
+
+      - name: Run unit tests
+        run: cd angular && npm test
+
+
+  

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,6 +22,15 @@ jobs:
           bash scripts/dhsetup.sh
           cd docker && bash ./dockbuild.sh
 
-      - name: Run Unit Tests via Docker
-        run: cd docker && ./testall
+      - name: Build & Run Python Tests via Docker
+        run: cd docker && ./testall python
+
+      - name: Build & Run Java Tests via Docker
+        run: cd docker && ./makedist java
+
+      - name: Build Angular Code
+        run: cd docker && ./makedist angular
+
+      - name: Run Angular Tests
+        run: cd docker && ./testall angular
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,25 @@
+name: integration
+on:
+  workflow_dispatch:
+  push:
+    branches: [integration]
+jobs:
+  testall:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build Containers
+        env:
+          OAR_DOCKERHUB_CRED: ${{ secrets.OAR_DOCKERHUB_CRED }}
+        run: |
+          bash scripts/dhsetup.sh
+          cd docker && bash ./dockbuild.sh
+
+      - name: Run Unit Tests via Docker
+        run: cd docker && ./testall
+

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Set up Docker
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/java-source.yml
+++ b/.github/workflows/java-source.yml
@@ -1,0 +1,36 @@
+name: source-update
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore: ['main', 'integration']
+    paths:
+      - 'java/src/**'
+      - 'java/pom.xml'
+jobs:
+  buildtest:
+    runs-on: ubuntu-20.04
+#    strategy:
+#      matrix:
+#        java: [ '8' ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('java/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Test with Maven
+        run: cd java && mvn --batch-mode test
+
+
+  

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,15 @@ jobs:
           bash scripts/dhsetup.sh
           cd docker && bash ./dockbuild.sh
 
-      - name: Run Unit Tests via Docker
-        run: cd docker && ./testall
+      - name: Build & Run Python Tests via Docker
+        run: cd docker && ./testall python
+
+      - name: Build & Run Java Tests via Docker
+        run: cd docker && ./makedist java
+
+      - name: Build Angular Code
+        run: cd docker && ./makedist angular
+
+      - name: Run Angular Tests
+        run: cd docker && ./testall angular
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Set up Docker
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: main
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+jobs:
+  testall:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build Containers
+        env:
+          OAR_DOCKERHUB_CRED: ${{ secrets.OAR_DOCKERHUB_CRED }}
+        run: |
+          bash scripts/dhsetup.sh
+          cd docker && bash ./dockbuild.sh
+
+      - name: Run Unit Tests via Docker
+        run: cd docker && ./testall
+

--- a/.github/workflows/python-source.yml
+++ b/.github/workflows/python-source.yml
@@ -1,6 +1,6 @@
 name: python-source
 on:
-  workflow-dispatch:
+  workflow_dispatch:
   push:
     branches-ignore: ['main', 'integration']
     paths:

--- a/.github/workflows/python-source.yml
+++ b/.github/workflows/python-source.yml
@@ -1,0 +1,29 @@
+name: python-source
+on:
+  workflow-dispatch:
+  push:
+    branches-ignore: ['main', 'integration']
+    paths:
+      - 'python/**'
+      - 'scripts/*.py'
+      - 'scripts/**/*.py'
+jobs:
+  testall.python:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build Containers
+        env:
+          OAR_DOCKERHUB_CRED: ${{ secrets.OAR_DOCKERHUB_CRED }}
+        run: |
+          bash scripts/dhsetup.sh
+          cd docker && bash ./dockbuild.sh pdrtests
+
+      - name: Run Unit Tests via Docker
+        run: cd docker && ./testall python
+

--- a/.github/workflows/python-source.yml
+++ b/.github/workflows/python-source.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Set up Docker
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/testall.yml
+++ b/.github/workflows/testall.yml
@@ -26,6 +26,14 @@ jobs:
           bash scripts/dhsetup.sh
           cd docker && bash ./dockbuild.sh
 
-      - name: Run Unit Tests via Docker
-        run: cd docker && ./testall
+      - name: Build & Run Python Tests via Docker
+        run: cd docker && ./testall python
 
+      - name: Build & Run Java Tests via Docker
+        run: cd docker && ./makedist java
+
+      - name: Build Angular Code
+        run: cd docker && ./makedist angular
+
+      - name: Run Angular Tests
+        run: cd docker && ./testall angular

--- a/.github/workflows/testall.yml
+++ b/.github/workflows/testall.yml
@@ -1,0 +1,29 @@
+name: testall
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches-ignore: ['main', 'integration']
+    paths:
+      - 'docker/**'
+      - '.github/workflows/**'
+jobs:
+  testall:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build Containers
+        env:
+          OAR_DOCKERHUB_CRED: ${{ secrets.OAR_DOCKERHUB_CRED }}
+        run: |
+          bash scripts/dhsetup.sh
+          cd docker && bash ./dockbuild.sh
+
+      - name: Run Unit Tests via Docker
+        run: cd docker && ./testall
+

--- a/.github/workflows/testall.yml
+++ b/.github/workflows/testall.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Set up Docker
         uses: docker/setup-buildx-action@v1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Publishing Data Repository (oar-pdr)
 
+[![main branch status](https://github.com/usnistgov/oar-pdr/actions/workflows/main.yml/badge.svg)](https://github.com/usnistgov/oar-pdr/actions/workflows/main.yml) | 
+[![integration branch status](https://github.com/usnistgov/oar-pdr/actions/workflows/integration.yml/badge.svg)](https://github.com/usnistgov/oar-pdr/actions/workflows/integration.yml)
+
 This repository provides the implementation of the NIST Publishing
 Data Repository (PDR) platform, the technology that provides the NIST
 Data Publishing Repository (DPR).


### PR DESCRIPTION
Travis-CI has been used as our continuous integration service that automatically runs unit tests with every push and pull request to the repository.  With Travis-CI's reduction of free limits, we are migrating our CI scripts to GitHub Actions.  This PR introduces those scripts (held in `.github/workflows`).  GitHub Actions provides greater flexibility for configuring triggered workflows, so several scripts are introduced following the patter established in [oar-rmm](https://github.com/usnistgov/oar-rmm) (see [PR#36](https://github.com/usnistgov/oar-rmm/pull/36)).  

To test, ensure that the GitHub action check-marks appear in this PR page. Click on the mark to access the log for the action.