### PR TITLE
Hide sha files

### DIFF
--- a/angular/src/app/landing/data-files/data-files.component.spec.ts
+++ b/angular/src/app/landing/data-files/data-files.component.spec.ts
@@ -104,6 +104,7 @@ describe('DataFilesComponent', () => {
   it('_updateNodesFromCart()', async(() => {
     let dc: DataCart = DataCart.openCart("goob");
     dc.addFile(component.ediid, component.record.components[1]);
+    dc.addFile(component.ediid, component.record.components[2]);
     expect(component._updateNodesFromCart(component.files, dc)).toBeTruthy();
   }));
 
@@ -113,7 +114,7 @@ describe('DataFilesComponent', () => {
     component.toggleAllFilesInGlobalCart();
     tick(1);
     dc.restore();
-    expect(dc.size()).toBe(1);
+    expect(dc.size()).toBe(2);
     component.toggleAllFilesInGlobalCart()
     tick(1);
     dc.restore();

--- a/angular/src/app/landing/data-files/data-files.component.spec.ts
+++ b/angular/src/app/landing/data-files/data-files.component.spec.ts
@@ -57,9 +57,6 @@ describe('DataFilesComponent', () => {
     fixture = TestBed.createComponent(DataFilesComponent);
     component = fixture.componentInstance;
     component.record = record;
-    // component.distdownload = "/od/ds/zip?id=ark:/88434/mds0149s9z";
-    // component.filescount = 8;
-    // component.recordEditmode = false;
     component.inBrowser = true;
     component.ngOnChanges({});
     fixture.detectChanges();
@@ -73,7 +70,7 @@ describe('DataFilesComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
     expect(component.files.length > 0).toBeTruthy();
-    expect(component.fileCount).toBe(3);
+    expect(component.fileCount).toBe(2);
     expect(component.downloadStatus).not.toBe("downloaded");
     expect(component.allInCart).toBeFalsy();
   });
@@ -107,7 +104,7 @@ describe('DataFilesComponent', () => {
   it('_updateNodesFromCart()', async(() => {
     let dc: DataCart = DataCart.openCart("goob");
     dc.addFile(component.ediid, component.record.components[1]);
-    expect(component._updateNodesFromCart(component.files, dc)).toBeFalsy();
+    expect(component._updateNodesFromCart(component.files, dc)).toBeTruthy();
   }));
 
   it('toggleAllFilesInGlobalCart()', fakeAsync(() => {
@@ -116,7 +113,7 @@ describe('DataFilesComponent', () => {
     component.toggleAllFilesInGlobalCart();
     tick(1);
     dc.restore();
-    expect(dc.size()).toBe(2);
+    expect(dc.size()).toBe(1);
     component.toggleAllFilesInGlobalCart()
     tick(1);
     dc.restore();

--- a/angular/src/app/landing/data-files/data-files.component.ts
+++ b/angular/src/app/landing/data-files/data-files.component.ts
@@ -251,14 +251,14 @@ export class DataFilesComponent implements OnInit, OnChanges {
 
         // Filter out sha files
         for (let comp of this.record['components']) {
-            if (comp.filepath && comp['@type'].filter(tp => tp.includes(':Hidden')).length == 0) {
-                if(!(comp['downloadURL'] && comp['downloadURL'].endsWith('sha256'))){
-                    node = insertComp(comp, root);
+            if (comp.filepath && comp['@type'].filter(tp => tp.includes(':Hidden')).length == 0 &&
+                comp['@type'].filter(tp => tp.includes(':ChecksumFile')).length == 0)
+            {
+                node = insertComp(comp, root);
 
-                    if (node.data.comp['@type'].filter(tp => tp.endsWith("File")).length > 0) {
-                        count++;
-                        if (node.data.downloadStatus == DownloadStatus.DOWNLOADED) downloadedCount++;
-                    }
+                if (node.data.comp['@type'].filter(tp => tp.endsWith("File")).length > 0) {
+                    count++;
+                    if (node.data.downloadStatus == DownloadStatus.DOWNLOADED) downloadedCount++;
                 }
             }
         }

--- a/angular/src/app/shared/download-service/download-service.service.ts
+++ b/angular/src/app/shared/download-service/download-service.service.ts
@@ -8,7 +8,6 @@ import { ZipData } from './zipData';
 import { DownloadData } from './downloadData';
 import { CartService } from '../../datacart/cart.service';
 import { DataCartItem } from '../../datacart/cart';
-import { TestDataService } from '../../shared/testdata-service/testDataService';
 import { FileSaverService } from 'ngx-filesaver';
 import { DataCart } from '../../datacart/cart';
 import { DownloadStatus } from '../../datacart/cartconstants';
@@ -37,8 +36,7 @@ export class DownloadService {
         private cfg: AppConfig,
         private http: HttpClient,
         private cartService: CartService,
-        private _FileSaverService: FileSaverService,
-        private testDataService: TestDataService
+        private _FileSaverService: FileSaverService
     ) {
         this.distApi = this.cfg.get("distService", "/od/ds/");
         this.setDownloadingNumber(-1);


### PR DESCRIPTION
http://mml.nist.gov:8080/browse/ODD-997

This change is to hide .sha files from the file list on the PDR landing page.

To test, run local docker and make sure no .sha file shows up in the file list.

Sample odid to test:
http://localhost:4200/od/id/66492819760D3FF6E05324570681BA721894
http://localhost:4200/od/id/3CF6F926D7309656E0531A5706810E0D1498 