### PR TITLE
LPS: Fix bug determining proper resource type label

### DIFF
--- a/angular/src/app/landing/sections/resourceidentity.component.spec.ts
+++ b/angular/src/app/landing/sections/resourceidentity.component.spec.ts
@@ -42,6 +42,7 @@ describe('ResourceIdentityComponent', () => {
         makeComp();
         component.inBrowser = true;
         component.editEnabled = false;
+        component.ngOnChanges()
         fixture.detectChanges();
     }));
 
@@ -58,4 +59,23 @@ describe('ResourceIdentityComponent', () => {
 
         // expect(component.versionCmp.newer).toBeNull();
     });
+
+    it('should correctly determine resource type', () => {
+        expect(component).toBeDefined();
+        let cmpel = fixture.nativeElement;
+        
+        let el = cmpel.querySelector(".recordType");
+        expect(el).toBeTruthy();
+        expect(el.textContent).toContain("Public Data Resource");
+
+        let resmd = JSON.parse(JSON.stringify(rec))
+        expect(component.determineResourceLabel(resmd)).toEqual("Public Data Resource")
+        resmd['@type'][0] = "nrdp:DataPublication"
+        expect(component.determineResourceLabel(resmd)).toEqual("Data Publication")
+        resmd['@type'][0] = "nrd:SRD"
+        expect(component.determineResourceLabel(resmd)).toEqual("Standard Reference Data")
+        resmd['@type'][0] = "nrd:SRM"
+        expect(component.determineResourceLabel(resmd)).toEqual("Standard Reference Material")
+    });
+        
 })

--- a/angular/src/app/landing/sections/resourceidentity.component.ts
+++ b/angular/src/app/landing/sections/resourceidentity.component.ts
@@ -73,10 +73,12 @@ export class ResourceIdentityComponent implements OnChanges {
      * the title.
      */
     public determineResourceLabel(resmd: NerdmRes): string {
-        if (this.record instanceof Array && this.record.length > 0) {
-            switch (this.record['@type'][0]) {
+        if (resmd['@type'] instanceof Array && resmd['@type'].length > 0) {
+            switch (resmd['@type'][0]) {
                 case 'nrd:SRD':
                     return "Standard Reference Data";
+                case 'nrd:SRM':
+                    return "Standard Reference Material";
                 case 'nrdp:DataPublication':
                     return "Data Publication";
                 case 'nrdp:PublicDataResource':


### PR DESCRIPTION
This PR fixes a bug that prevents the landing page from properly indicating the resource type above the dataset title.  Currently, all records are showing the type as "Data Resource", this value is displayed by default when the primary type is not recognized.  A resource's primary type is the first element of the `@type` property in the NERDm record.  The proper label is determined within the `ResourceIdentityComponent` via its `determineResourceLabel()` function.  This function was not accessing the `@type` property properly.  This PR fixes this bug and adds support for recognizing SRM datasets.  

This is fix is currently deployed to oardev.  
