### PR TITLE
LPS: add displays of ORCIDs

### DIFF
--- a/angular/src/app/landing/author/author.component.html
+++ b/angular/src/app/landing/author/author.component.html
@@ -7,9 +7,15 @@
         </div>
         <ng-template #hasAuthors>
             <div class="editable_field" style="max-width:calc(100% - 4em);" [ngStyle]="mdupdsvc.getFieldStyle(fieldName)">
-                <div *ngIf="record['authors']">
+                <div class="authorsbrief" *ngIf="record['authors']">
                     <span *ngFor="let author of record.authors; let i = index" (click)="openModal()">
-                        {{ author.fn }}<span *ngIf="i < record.authors.length-1 ">,</span>
+                        {{ author.fn }}         
+                        <span *ngIf="author.orcid">
+                          <a href="https://orcid.org/{{ author.orcid }}" target="blank">
+                             <img src="assets/images/orcid-logo.png" style="width: 20px;">
+                          </a>
+                        </span>                            
+                        <span *ngIf="i < record.authors.length-1 ">,</span>
                     </span>
                     <i style="margin-left: 0.5rem;" class="faa"
                         [ngClass]="{'faa-plus-square-o': !clickAuthors, 'faa-minus-square-o': clickAuthors}"
@@ -17,10 +23,18 @@
                         (click)="isCollapsedContent = !isCollapsedContent; clickAuthors = expandClick();"></i>
                 </div>
                 <div [collapse]="!isCollapsedContent" class="card card-block card-header customcard" style="width: fit-content; padding:.5em;">
-                    <div class="" *ngIf="record.authors" (click)="openModal()">
+                    <div class="authorsdetail" *ngIf="record.authors" (click)="openModal()">
                         <span><b>Authors:</b></span>
                         <div *ngFor="let author of record.authors; let i = index">
-                            <div>{{ author.fn}}</div>
+                        <div>
+                          <span>{{ author.fn}}</span>
+                          <span *ngIf="author.orcid">&nbsp;&nbsp;&nbsp;&nbsp;
+                            <a href="https://orcid.org/{{ author.orcid }}" target="blank">
+                               <img src="assets/images/orcid-logo.png" style="width: 20px;">:
+                               {{ author.orcid }}
+                            </a>
+                          </span>                            
+                         </div>
                             <div *ngFor="let aff of author.affiliation" style="padding-left: 1em">
                                 <i>
                                 <div>{{aff.title}}</div>

--- a/angular/src/app/landing/author/author.component.spec.ts
+++ b/angular/src/app/landing/author/author.component.spec.ts
@@ -13,6 +13,7 @@ import { ToastrModule } from 'ngx-toastr';
 import { MetadataUpdateService } from '../editcontrol/metadataupdate.service';
 import { UserMessageService } from '../../frame/usermessage.service';
 import { AuthService, WebAuthService, MockAuthService } from '../editcontrol/auth.service';
+import { testdata } from '../../../environments/environment';
 
 describe('AuthorComponent', () => {
     let component: AuthorComponent;
@@ -21,6 +22,7 @@ describe('AuthorComponent', () => {
     let plid: Object = "browser";
     let ts: TransferState = new TransferState();
     let authsvc: AuthService = new MockAuthService(undefined);
+    let rec = testdata['test2'];
 
     beforeEach(async(() => {
         cfg = (new AngularEnvironmentConfigService(plid, ts)).getConfig() as AppConfig;
@@ -42,14 +44,26 @@ describe('AuthorComponent', () => {
     }));
 
     beforeEach(() => {
-        let record: any = require('../../../assets/sampleRecord.json');
+        // let record: any = require('../../../assets/sampleRecord.json');
         fixture = TestBed.createComponent(AuthorComponent);
         component = fixture.componentInstance;
-        component.record = record;
+        component.record = rec;
         fixture.detectChanges();
     });
 
     it('should create', () => {
         expect(component).toBeTruthy();
+        expect(component.fieldName).toEqual("authors");
+    });
+
+    it('should have ORCID icon image displayed', () => {
+        expect(component).toBeTruthy();
+        expect(component.record['authors']).toBeTruthy();
+        expect(component.record['authors'].length).toEqual(2);
+        let cmpel = fixture.nativeElement;
+
+        let els = cmpel.querySelectorAll(".authorsbrief img"); 
+        expect(els).toBeTruthy();
+        expect(els.length).toEqual(1);
     });
 });

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -231,7 +231,8 @@ export const testdata: {} = {
             {
                 "familyName": "Doe",
                 "givenName": "John",
-                "fn": "John Doe"
+                "fn": "John Doe",
+                "orcid": "0000-0000-0000-0000"
             },
             {
                 "familyName": "Plant",


### PR DESCRIPTION
We prompt users to provide ORCIDs for authors during landing page editing; however, we currently are not displaying them.  This PR puts ORCID icons next to author names that link to their ORCID pages, as is common practice.  When the author list is expanded, the ORCID number is fully displayed.  

This is currently deployed on oardev.  A good example to look at is [Hudgens et al.](https://oardev.nist.gov/od/id/76F046F18CCA46FBE05324570681CB301977) 