### PR TITLE
LPS: Fix blank link to "described in" article at top

### DIFF
--- a/angular/src/app/landing/sections/resourceidentity.component.html
+++ b/angular/src/app/landing/sections/resourceidentity.component.html
@@ -16,7 +16,7 @@
         <span *ngIf="!doiUrl"><i> 
             <a href="{{ cfg.get('landingPageService','/od/id/') }}{{record['@id']}}">{{record["@id"]}}</a></i>
         </span>
-        <span *ngIf="primaryRefs.length > 0"><br>
+        <span class="describedin" *ngIf="primaryRefs.length > 0"><br>
             <span>Described in article: </span>
             <div *ngFor="let ref of primaryRefs; let i =index">
                 <span style="padding-left:20px">

--- a/angular/src/app/landing/sections/resourceidentity.component.spec.ts
+++ b/angular/src/app/landing/sections/resourceidentity.component.spec.ts
@@ -60,6 +60,35 @@ describe('ResourceIdentityComponent', () => {
         // expect(component.versionCmp.newer).toBeNull();
     });
 
+    it('should correctly render special references', () => {
+        expect(component).toBeDefined();
+        expect(component.primaryRefs.length).toEqual(1);
+        let cmpel = fixture.nativeElement;
+
+        let el = cmpel.querySelector(".describedin")
+        expect(el).toBeTruthy();
+        el = el.querySelector("a");
+        expect(el.textContent).toContain("Solids: In-situ");
+
+        let tstrec = JSON.parse(JSON.stringify(rec));
+        delete tstrec['references'][0]['label'];
+        component.record = tstrec;
+        component.useMetadata();
+        expect(component.primaryRefs[0]['label']).toEqual(component.primaryRefs[0]['title']);
+
+        delete tstrec['references'][0]['title'];
+        delete tstrec['references'][0]['label'];
+        component.record = tstrec;
+        component.useMetadata();
+        expect(component.primaryRefs[0]['label']).toEqual(component.primaryRefs[0]['citation']);
+
+        delete tstrec['references'][0]['citation'];
+        delete tstrec['references'][0]['label'];
+        component.record = tstrec;
+        component.useMetadata();
+        expect(component.primaryRefs[0]['label']).toEqual(component.primaryRefs[0]['location']);
+    });
+
     it('should correctly determine resource type', () => {
         expect(component).toBeDefined();
         let cmpel = fixture.nativeElement;
@@ -78,4 +107,5 @@ describe('ResourceIdentityComponent', () => {
         expect(component.determineResourceLabel(resmd)).toEqual("Standard Reference Material")
     });
         
-})
+});
+

--- a/angular/src/app/landing/sections/resourceidentity.component.ts
+++ b/angular/src/app/landing/sections/resourceidentity.component.ts
@@ -54,6 +54,10 @@ export class ResourceIdentityComponent implements OnChanges {
         if (this.record['doi'] !== undefined && this.record['doi'] !== "")
             this.doiUrl = "https://doi.org/" + this.record['doi'].substring(4);
         this.primaryRefs = (new NERDResource(this.record)).getPrimaryReferences();
+        for (let ref of this.primaryRefs) {
+            if (! ref['label'])
+                ref['label'] = ref['title'] || ref['citation'] || ref['location']
+        }
     }    
 
     /**


### PR DESCRIPTION
This PR fixes a bug in rendering at the top of the landing page a reference to a key article that describes the data.  When a references is marked with the either `refType` of `DocumentedBy` or `IsSupplementTo`, the reference will appear as a link at the top of landing page underneath the identifier.  With this bug, the link text is often blank.  This is because, the code looks for a `label` property for the reference to use as the text, and this value is not getting set by default in the publishing workflow.  This PR fixes this by setting a backup label for the reference: the values of (in order of preference) `title`, `citation`, or `location`.  

This has been deployed to oardev.  Compare https://data.nist.gov/od/id/mds2-2409 with https://oardev.nist.gov/od/id/mds2-2409.  