### PR TITLE
Fixed the error while loading metrics

### DIFF
--- a/angular/src/app/landing/landingpage.component.ts
+++ b/angular/src/app/landing/landingpage.component.ts
@@ -277,7 +277,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
 
                 this.fileLevelMetrics = JSON.parse(response);
 
-                if(this.fileLevelMetrics.FilesMetrics != undefined && this.fileLevelMetrics.FilesMetrics.length > 0){
+                if(this.fileLevelMetrics.FilesMetrics != undefined && this.fileLevelMetrics.FilesMetrics.length > 0 && this.md.components){
                     // check if there is any current metrics data
                     for(let i = 1; i < this.md.components.length; i++){
                         let filepath = this.md.components[i].filepath;


### PR DESCRIPTION
This is a quick fix to the error while loading metrics data.

Caused by the case that MERDm data does not have "components" field.