### PR TITLE
Disable useMetadataService for client side

### DIFF
--- a/angular/src/environments/environment.prod.ts
+++ b/angular/src/environments/environment.prod.ts
@@ -12,7 +12,7 @@ import { LPSConfig } from '../app/config/config';
 
 export const context = {
     production: true,
-    useMetadataService: true,
+    useMetadataService: false,
     useCustomizationService: true
 };
 


### PR DESCRIPTION
http://mml.nist.gov:8080/browse/ODD-1010

The error was caused by calling remote Web metadata service from client side.
This can be fixed by turning useMetadataService off in environment.prod.ts.

To test, run it in local docker.