### PR TITLE
Fix/odd1016 safari bug

### DIFF
--- a/angular/src/app/landing/sections/resourceidentity.component.spec.ts
+++ b/angular/src/app/landing/sections/resourceidentity.component.spec.ts
@@ -53,9 +53,9 @@ describe('ResourceIdentityComponent', () => {
         let el = cmpel.querySelector("h2"); 
         expect(el.textContent).toContain(rec.title);
 
-        expect(component.record['version']).toBe("1.0.1");
+        expect(component.record['version']).toBe("1.0.2");
         let descs = cmpel.querySelectorAll("p");
-        expect(descs.length).toBe(0);
+        expect(descs.length).toBe(1);
 
         // expect(component.versionCmp.newer).toBeNull();
     });

--- a/angular/src/app/landing/sections/resourceidentity.component.spec.ts
+++ b/angular/src/app/landing/sections/resourceidentity.component.spec.ts
@@ -53,7 +53,7 @@ describe('ResourceIdentityComponent', () => {
         let el = cmpel.querySelector("h2"); 
         expect(el.textContent).toContain(rec.title);
 
-        expect(component.record['version']).toBe("1.0.2");
+        expect(component.record['version']).toBe("1.0.1");
         let descs = cmpel.querySelectorAll("p");
         expect(descs.length).toBe(1);
 

--- a/angular/src/app/landing/version/version.component.spec.ts
+++ b/angular/src/app/landing/version/version.component.spec.ts
@@ -39,7 +39,7 @@ describe('VersionComponent', () => {
         let cmpel = fixture.nativeElement;
         let spans = cmpel.querySelectorAll("span"); 
         expect(spans[0].textContent).toContain("Version:");
-        expect(spans[0].textContent).toContain("1.0.2");
+        expect(spans[0].textContent).toContain("1.0.1");
         expect(spans[2].textContent).toContain("Released:");
         expect(spans[2].textContent).toContain("2019-04-05");
         expect(spans[3].textContent).toContain("Last modified:");
@@ -104,14 +104,14 @@ describe('VersionComponent', () => {
         component.record['version'] = "1.0.0";
         component.assessNewer();
         expect(component.newer).not.toBeNull();
-        expect(component.newer['version']).toBe("1.0.1");
+        expect(component.newer['version']).toBe("1.0.2");
 
         fixture.detectChanges();
         cmpel = fixture.nativeElement;
         ps = cmpel.querySelectorAll("p"); 
         expect(ps.length).toBe(1);
         expect(ps[0].textContent).toContain("more recent release");
-        expect(ps[0].textContent).toContain("1.0.1");
+        expect(ps[0].textContent).toContain("1.0.2");
     });
 
     it('test expandHistory()', () => {

--- a/angular/src/app/landing/version/version.component.spec.ts
+++ b/angular/src/app/landing/version/version.component.spec.ts
@@ -39,11 +39,11 @@ describe('VersionComponent', () => {
         let cmpel = fixture.nativeElement;
         let spans = cmpel.querySelectorAll("span"); 
         expect(spans[0].textContent).toContain("Version:");
-        expect(spans[0].textContent).toContain("1.0.1");
+        expect(spans[0].textContent).toContain("1.0.2");
         expect(spans[2].textContent).toContain("Released:");
         expect(spans[2].textContent).toContain("2019-04-05");
         expect(spans[3].textContent).toContain("Last modified:");
-        expect(spans[3].textContent).toContain("2019-03-28");
+        expect(spans[3].textContent).toContain("2019-03-27");
     });
 
     it('test renderRelAsLink()', () => {
@@ -163,21 +163,21 @@ describe("version compare functions", () => {
     });
 
     it("normalize_date", () => {
-        expect(normalize_date("2017")).toBe("2017-01-01 00:00:00");
-        expect(normalize_date("2017-01")).toBe("2017-01-01 00:00:00");
-        expect(normalize_date("2017-01-01")).toBe("2017-01-01 00:00:00");
-        expect(normalize_date("2017-01-01 00:00")).toBe("2017-01-01 00:00:00");
+        expect(normalize_date("2017")).toBe("2017-01-01T00:00:00");
+        expect(normalize_date("2017-01")).toBe("2017-01-01T00:00:00");
+        expect(normalize_date("2017-01-01")).toBe("2017-01-01T00:00:00");
+        expect(normalize_date("2017-01-01 00:00")).toBe("2017-01-01T00:00:00");
         expect(normalize_date("2017-01-01T00:00")).toBe("2017-01-01T00:00:00");
-        expect(normalize_date("2017-01-01 00:00:00")).toBe("2017-01-01 00:00:00");
-        expect(normalize_date("2017-01-01 00:00:00.093")).toBe("2017-01-01 00:00:00.093");
+        expect(normalize_date("2017-01-01 00:00:00")).toBe("2017-01-01T00:00:00");
+        expect(normalize_date("2017-01-01 00:00:00.093")).toBe("2017-01-01T00:00:00.093");
 
-        expect(normalize_date("2017Z-0530")).toBe("2017-01-01 00:00:00");
-        expect(normalize_date("2017-01Z-0530")).toBe("2017-01-01 00:00:00");
-        expect(normalize_date("2017-01-01Z-0530")).toBe("2017-01-01 00:00:00");
-        expect(normalize_date("2017-01-01 00:00Z-0530")).toBe("2017-01-01 00:00:00");
+        expect(normalize_date("2017Z-0530")).toBe("2017-01-01T00:00:00");
+        expect(normalize_date("2017-01Z-0530")).toBe("2017-01-01T00:00:00");
+        expect(normalize_date("2017-01-01Z-0530")).toBe("2017-01-01T00:00:00");
+        expect(normalize_date("2017-01-01 00:00Z-0530")).toBe("2017-01-01T00:00:00");
         expect(normalize_date("2017-01-01T00:00Z-0530")).toBe("2017-01-01T00:00:00");
-        expect(normalize_date("2017-01-01 00:00:00Z-0530")).toBe("2017-01-01 00:00:00");
-        expect(normalize_date("2017-01-01 00:00:00.093Z-0530")).toBe("2017-01-01 00:00:00.093");
+        expect(normalize_date("2017-01-01 00:00:00Z-0530")).toBe("2017-01-01T00:00:00");
+        expect(normalize_date("2017-01-01 00:00:00.093Z-0530")).toBe("2017-01-01T00:00:00.093");
     });
 
     it("compare_dates", () => {

--- a/angular/src/app/landing/version/version.component.ts
+++ b/angular/src/app/landing/version/version.component.ts
@@ -234,12 +234,15 @@ export function normalize_date(datestr : string) {
     // ignore zone designations
     if (datestr.includes("Z"))
         datestr = datestr.substring(0, datestr.indexOf("Z"));
-    
+        
+    // Safari requires a "T" between date and time
+    datestr = datestr.replace(" ", "T");
+
     let m = datestr.match(/^\s*\d{4}(-\d\d(-\d\d([ T]\d\d:\d\d(:\d\d(\.\d+)?)?)?)?)?\s*$/);
     if (! m) return datestr;
     if (! m[1]) datestr += "-01";
     if (! m[2]) datestr += "-01";
-    if (! m[3]) datestr += " 00:00";
+    if (! m[3]) datestr += "T00:00";
     if (! m[4]) datestr += ":00";
     return datestr
 }

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -68,7 +68,7 @@ export const testdata: {} = {
         "issued": "2019-04-05T16:04:26.0",
         "ediid": "26DEA39AD677678AE0531A570681F32C1449",
         "landingPage": "https://www.nist.gov/itl/iad/image-group/special-database-32-multiple-encounter-dataset-meds",
-        "version": "1.0.2",
+        "version": "1.0.1",
         "versionHistory": [
             {
                 "version": "1.0.0",
@@ -78,7 +78,7 @@ export const testdata: {} = {
                 "description": "initial release"
             },
             {
-                "version": "1.0.1",
+                "version": "1.0.2",
                 "issued": "2019-03-28 12:24:31",
                 "@id": "ark:/88434/mds0000fbkmds1103vzr",
                 "location": "https://data.nist.gov/od/id/ark:/88434/mds0000fbk",

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -64,11 +64,11 @@ export const testdata: {} = {
             "hasEmail": "mailto:patricia.flanagan@nist.gov",
             "fn": "Patricia Flanagan"
         },
-        "modified": "2019-03-28 12:24:31",
+        "modified": "2019-03-27 12:24:31",
         "issued": "2019-04-05T16:04:26.0",
         "ediid": "26DEA39AD677678AE0531A570681F32C1449",
         "landingPage": "https://www.nist.gov/itl/iad/image-group/special-database-32-multiple-encounter-dataset-meds",
-        "version": "1.0.1",
+        "version": "1.0.2",
         "versionHistory": [
             {
                 "version": "1.0.0",
@@ -204,7 +204,6 @@ export const testdata: {} = {
             "_updateDate": "2019-12-03T15:50:53.208+0000"
         }
         ]
-
     },
 
     


### PR DESCRIPTION
http://mml.nist.gov:8080/browse/ODD-1016

The problem was caused by Date.parse() function. Safari does not like "2017-01-01 00:00:00". Have to put a "T" between date and time: "2017-01-01T00:00:00".

The test1 sample in environment.ts has been modified for the testing of this case. 
To test, run app locally and browse http://localhost:4200/od/id/test1 using Chrome and Safari. Both should display the following line in version section:
    There is a more recent release of this resource available:    1.0.2

<img width="1148" alt="Screen Shot 2021-11-16 at 2 14 51 PM" src="https://user-images.githubusercontent.com/44069356/142051042-11bba800-4712-49bb-ad56-f4fe320ac519.png">

