### PR TITLE
Update download status when user cancels all

### DIFF
--- a/angular/src/app/datacart/bundleplan/bundleplan.component.ts
+++ b/angular/src/app/datacart/bundleplan/bundleplan.component.ts
@@ -402,6 +402,7 @@ export class BundleplanComponent implements OnInit {
      * Process data returned from bundle_plan (stored in zipData)
      */
     processBundle() {
+        let processingZip: ZipData;
         this.gaService.gaTrackEvent('download', undefined, 'all files', "Data cart");
 
         this.messageColor = this.getColor();
@@ -544,29 +545,34 @@ export class BundleplanComponent implements OnInit {
     }
 
     /**
-     * Cancell all download
+     * Cancell all download and cleanup all zipdata
      */
     cancelDownloadAll() {
         for (let zip of this.zipData) {
-            if (zip.downloadInstance != null) {
-                zip.downloadInstance.unsubscribe();
+            if(zip.downloadStatus == DownloadStatus.DOWNLOADING) {
+                this.cancelDownloadZip(zip);
+            }else{
+                if (zip.downloadInstance != null) {
+                    zip.downloadInstance.unsubscribe();
+                }
+                zip.downloadInstance = null;
+                zip.downloadProgress = 0;
+                zip.downloadStatus = null;
             }
-            zip.downloadInstance = null;
-            zip.downloadProgress = 0;
-            zip.downloadStatus = null;
-        }
+       }
 
         for (let sub of this.subscriptions) {
             sub.unsubscribe();
         }
 
-        // this.clearDownloadingStatus();
         this.showCurrentTask = false;
         this.overallStatus = DownloadStatus.CANCELED;
         this.outputOverallStatus.emit(this.overallStatus);
         setTimeout(() => {
             this.updateDownloadPercentage(0)
         }, 1000);
+
+        this.zipData = [];
     }
 
     /**

--- a/angular/src/app/shared/download-service/download-service.service.ts
+++ b/angular/src/app/shared/download-service/download-service.service.ts
@@ -358,13 +358,16 @@ export class DownloadService {
      */
     downloadNextZip(zipData: ZipData[], dataCart: DataCart) {
         let sub = this.zipFilesDownloadingDataCartSub;
+        let nextZip: ZipData = null;
 
         if (sub.getValue() < this.getMaxConcurDownload()) {
-            let nextZip = this.getNextZipInQueue(zipData);
+            nextZip = this.getNextZipInQueue(zipData);
             if (nextZip != null) {
                 this.download(nextZip, zipData, dataCart);
             }
         }
+
+        return nextZip;
     }
 
     /**


### PR DESCRIPTION
http://mml.nist.gov:8080/browse/ODD-1019

Please refer to the Jira ticket for problem details.

To test, either run the app locally or in docker. If run it locally, set the following in environment.ts
    useMetadataService: true,
    useCustomizationService: true

    editEnabled: false, 

Once bundle downloading starts, and you see download status show up in the file list, click on "x" (cancel) button in "Overall progress" row. Make sure those "downloading" status change to "Canceled". Bundle list should disappear.