### PR TITLE
Support restricted public access in publishing workflow

### DIFF
--- a/docker/pdrtest/Dockerfile
+++ b/docker/pdrtest/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y python-yaml nginx curl wget less sudo \
                                          p7zip-full ca-certificates git
 RUN pip install --upgrade pip 'setuptools==44.0.0'
 RUN pip install funcsigs 'bagit>=1.6.3,<2.0' 'fs>=2.0.21' mako
+COPY verify-asc.sh /usr/local/bin
 
 # install multibag from source
 RUN curl -L -o multibag-py.zip \
@@ -24,18 +25,15 @@ RUN curl -L -o multibag-py.zip \
     cd multibag-py-master &&     \
     python setup.py install
 
-ENV GOSU_VERSION 1.10
+ENV GOSU_VERSION 1.14
 RUN set -ex; \
     arch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
     wget -O /usr/local/bin/gosu \
    "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$arch"; \
     wget -O /usr/local/bin/gosu.asc \
 "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$arch.asc";\
-    export GNUPGHOME="$(mktemp -d)"; \
-    echo "disable-ipv6" >> "$GNUPGHOME/dirmngr.conf"; \
-    gpg --batch --keyserver hkps://keys.openpgp.org \
-         --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
-    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+    verify-asc.sh /usr/local/bin/gosu /usr/local/bin/gosu.asc    \
+                  B42F6819007F00F88E364FD4036A9C25BF357DD4;      \
     sleep 1; rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc || true; \
     chmod +x /usr/local/bin/gosu; \
     gosu nobody true

--- a/docker/pdrtest/verify-asc.sh
+++ b/docker/pdrtest/verify-asc.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+#
+# verify-asc.sh target target.asc keyid
+#
+keyservers="hkps://keys.openpgp.org hkps://keyserver.ubuntu.com hkp://keyserver.ubuntu.com hkps://keys.gnupg.net"
+# set -x
+
+export GNUPGHOME="$(mktemp -d)"
+echo "disable-ipv6" >> "$GNUPGHOME/dirmngr.conf"
+
+for keysrvr in $keyservers; do
+    echo '++' gpg --batch --keyserver $keysrvr --recv-keys $3
+    gpg --batch --keyserver $keysrvr --recv-keys $3 && break
+done
+[ $? == 0 ] || {
+    echo Failed to retrieve key for id=$3
+    [ -e "$GNUPGHOME" ] && rm -r "$GNUPGHOME"
+    exit 1
+}
+
+echo '++' gpg --batch --verify $2 $1
+gpg --batch --verify $2 $1 || {
+    echo "$2": does not verify against $1
+    [ -e "$GNUPGHOME" ] && rm -r "$GNUPGHOME"
+    exit 2
+}
+
+[ -e "$GNUPGHOME" ] && rm -r "$GNUPGHOME"

--- a/python/nistoar/pdr/preserv/bagger/midas3.py
+++ b/python/nistoar/pdr/preserv/bagger/midas3.py
@@ -25,6 +25,7 @@ from ..bagit.builder import BagBuilder, NERDMD_FILENAME, FILEMD_FILENAME
 from ..bagit import NISTBag
 from ..bagit.tools import synchronize_enhanced_refs
 from ....id import PDRMinter
+from ....nerdm import utils as nerdutils
 from ... import def_merge_etcdir, utils, ARK_NAAN, PDR_PUBLIC_SERVER
 from .. import (SIPDirectoryError, SIPDirectoryNotFound, AIPValidationError,
                 ConfigurationException, StateException, PODError,
@@ -586,8 +587,13 @@ class MIDASMetadataBagger(SIPBagger):
         # of this dataset
         self.prepsvc = None
         if 'repo_access' in self.cfg:
-            # support for updates requires access to the distribution and
-            # rmm services
+            # support for updates requires access to the distribution and rmm services
+
+            if 'store_dir' not in self.cfg['repo_access'] and 'store_dir' in self.cfg:
+                self.cfg['repo_access']['store_dir'] = self.cfg['store_dir']
+            if 'restricted_store_dir' not in self.cfg['repo_access'] and 'restricted_store_dir' in self.cfg:
+                self.cfg['repo_access']['restricted_store_dir'] = self.cfg['restricted_store_dir']
+
             self.prepsvc = UpdatePrepService(self.cfg['repo_access'],
                                              os.path.join("metadata", self.BGRMD_FILENAME))
         else:
@@ -902,6 +908,28 @@ class MIDASMetadataBagger(SIPBagger):
             nerd['doi'] = doi
             self.bagbldr.update_metadata_for('', {'doi': doi},
                                              message="added default DOI: "+doi)
+
+        # check for use of the restricted public gateway
+        if self.cfg.get('restricted_access',{}).get('gateway_url') and \
+           nerd['accessLevel'] == "restricted public":
+            racfg = self.cfg['restricted_access']
+            burl = racfg['gateway_url']
+            disclaimer = racfg.get('disclaimer')
+
+            nerdres = self.bagbldr.bag.nerd_metadata_for('', False)
+            rpg = [c for c in nerdres.get('components', [])
+                     if 'accessURL' in c and c['accessURL'].startswith(burl)]
+            for c in rpg:
+                if not nerdutils.is_type(c, "RestrictedAccessPage"):
+                    c['@type'] = ["nrdp:RestrictedAccessPage"] + c['@type']
+
+            if len(rpg) > 0:
+                nerdres = {'components': nerdres['components']}
+                if disclaimer:
+                    nerdres['disclaimer'] = disclaimer
+                self.bagbldr.update_metadata_for('', nerdres,
+                                                 message="enhancing metadata for restricted access")
+                    
 
         # we're done; update the cached NERDm metadata and the data file map
         if not self.sip.nerd or updated['updated'] or updated['added'] or updated['deleted']:
@@ -1853,9 +1881,16 @@ class PreservationBagger(SIPBagger):
         if finalcfg.get('validate', True):
             # this will raise an exception if any issues are found
             self._validate(finalcfg.get('validator', {}))
+
+        isrestricted = nerd.get('accessLevel', 'public') != 'public' and \
+                       any([ nerdutils.is_type(c, 'RestrictedAccessPage') 
+                             for c in nerd.get('components', []) if 'accessURL' in c ])
         if finalcfg.get('check_data_files', True):
-            # this will raise an exception if any issues are found
-            self._check_data_files(finalcfg.get('data_checker', {}))
+            if isrestricted:
+                log.warning("Must skip data availability check for restricted data")
+            else:
+                # this will raise an exception if any issues are found
+                self._check_data_files(finalcfg.get('data_checker', {}))
 
         return self.bagbldr.bagdir
 
@@ -1927,7 +1962,8 @@ class PreservationBagger(SIPBagger):
         """
         config = {
             "repo_access": self.cfg.get('repo_access', {}),
-            "store_dir":  self.cfg.get('store_dir')
+            "store_dir":  self.cfg.get('store_dir'),
+            "restricted_store_dir":  self.cfg.get('restricted_store_dir')
         }
         config.update( deepcopy(data_checker_config) )
 

--- a/python/nistoar/pdr/preserv/bagger/midas3.py
+++ b/python/nistoar/pdr/preserv/bagger/midas3.py
@@ -929,6 +929,7 @@ class MIDASMetadataBagger(SIPBagger):
                     nerdres['disclaimer'] = disclaimer
                 self.bagbldr.update_metadata_for('', nerdres,
                                                  message="enhancing metadata for restricted access")
+                nerd = self.bagbldr.bag.nerdm_record(True)
                     
 
         # we're done; update the cached NERDm metadata and the data file map
@@ -1582,7 +1583,11 @@ class PreservationBagger(SIPBagger):
                                 AIP (see constructor documentation).
         """
         if not config:
-            config = mdbagger.cfg.get('preservation_service', {})
+            pcfg = mdbagger.cfg.get('preservation_service', {})
+            if 'sip_type' in pcfg:
+                config = pcfg['sip_type'].get('midas3', {}).get('preserv',{}).get('bagger', {})
+            else:
+                config = pcfg.get('bagger', {})
         datadir = mdbagger.sip.revdatadir
         return cls(mdbagger.bagdir, bagparent, datadir, config, asupdate=None)
 

--- a/python/nistoar/pdr/preserv/bagger/prepupd.py
+++ b/python/nistoar/pdr/preserv/bagger/prepupd.py
@@ -599,7 +599,9 @@ class UpdatePrepper(object):
             if src == "repo":
                 out = self._latest_version_from_repo()
             elif src == "bag-store":
-                if self.storedir:
+                if self.restricted_storedir:
+                    out = self._latest_version_from_dir(self.restricted_storedir)
+                if out == "0" and self.storedir:
                     out = self._latest_version_from_dir(self.storedir)
             elif src == "bag-cache":
                 out = self._latest_version_from_dir(self.cacher.cachedir)

--- a/python/nistoar/pdr/preserv/bagit/multibag.py
+++ b/python/nistoar/pdr/preserv/bagit/multibag.py
@@ -7,6 +7,7 @@ import os, logging, re, json, shutil
 from functools import cmp_to_key
 
 import multibag
+from multibag.restore import restore_bag
 
 from .. import ConfigurationException, StateException, AIPValidationError
 from ... import utils

--- a/python/nistoar/pdr/preserv/service/service.py
+++ b/python/nistoar/pdr/preserv/service/service.py
@@ -74,14 +74,12 @@ class PreservationService(object):
                                  "directory: " + workdir, sys=self)
         self.workdir = workdir
 
-        storedir = self.cfg.get('store_dir')
-        if not storedir:
+        if not self.cfg.get('store_dir'):
             raise ConfigurationException("Missing required config parameter: "+
                                          "store_dir", sys=self)
-        if not os.path.isdir(storedir):
+        if not os.path.isdir(self.cfg.get('store_dir')):
             raise StateException("Store directory does not exist as a " +
-                                 "directory: " + storedir, sys=self)
-        self.storedir = storedir
+                                 "directory: " + self.cfg.get('store_dir'), sys=self)
 
         if not self.cfg.get('sip_type'):
             raise ConfigurationException("Missing required config parameter: "+
@@ -421,7 +419,9 @@ class PreservationService(object):
         if 'working_dir' not in pcfg:
             pcfg['working_dir'] = self.workdir
         if 'store_dir' not in pcfg:
-            pcfg['store_dir'] = self.storedir
+            pcfg['store_dir'] = self.cfg.get('store_dir')
+        if 'restricted_store_dir' not in pcfg and 'restricted_store_dir' in self.cfg:
+            pcfg['restricted_store_dir'] = self.cfg.get('restricted_store_dir')
         if 'id_registry_dir' not in pcfg:
             pcfg['id_registry_dir'] = self.idregdir
         if 'metadata_bags_dir' not in pcfg:
@@ -583,7 +583,7 @@ class MultiprocPreservationService(PreservationService):
         # for child process:
         try:
             log.info("Preserving %s SIP id=%s", handler.name, handler._sipid)
-            handler.bagit('zip', self.storedir)
+            handler.bagit('zip')
         except Exception, e:
             if isinstance(e, PreservationStateError):
                 log.exception("Incorrect state for client's request: "+str(e))

--- a/python/nistoar/pdr/preserv/service/siphandler.py
+++ b/python/nistoar/pdr/preserv/service/siphandler.py
@@ -594,9 +594,10 @@ class MIDASSIPHandler(SIPHandler):
         nerdm = bag.nerdm_record()
         if self._ingester:
             ingmd = nerdm
-            if not nerdm.get('accessLevel', 'public') and 'components' in nerdm:
+            if nerdm.get('accessLevel', 'public') != 'public' and 'components' in nerdm:
+                log.debug("Filtering out files from record sent to public PDR")
                 ingmd = deepcopy(ingmd)
-                ingmd['components'] = [c for c in imgmd['components'] if 'filepath' not in c]
+                ingmd['components'] = [c for c in ingmd['components'] if 'filepath' not in c]
             try:
                 self._ingester.stage(ingmd, self.bagger.name)
             except Exception as ex:
@@ -1044,9 +1045,10 @@ class MIDAS3SIPHandler(SIPHandler):
         nerdm = bag.nerdm_record()
         if self._ingester:
             ingmd = nerdm
-            if not nerdm.get('accessLevel', 'public') and 'components' in nerdm:
+            if nerdm.get('accessLevel', 'public') != 'public' and 'components' in nerdm:
+                log.debug("Filtering out files from record sent to public PDR")
                 ingmd = deepcopy(ingmd)
-                ingmd['components'] = [c for c in imgmd['components'] if 'filepath' not in c]
+                ingmd['components'] = [c for c in ingmd['components'] if 'filepath' not in c]
             try:
                 self._ingester.stage(ingmd, self.bagger.name)
             except Exception as ex:

--- a/python/nistoar/pdr/publish/midas3/service.py
+++ b/python/nistoar/pdr/publish/midas3/service.py
@@ -899,7 +899,7 @@ class MIDAS3PublishingService(PublishSystem):
             self._validate_pod(pod, DEF_POD_DATASET_SCHEMA)
         if not pod.get('identifier'):
             raise ejs.ValidationError("POD record missing required property: identifier")
-        if pod.get('accessLevel') != 'public':
+        if pod.get('accessLevel') == 'non-public':
             raise ejs.ValidationError("Unacceptable accessLevel property value for preservation: " +
                                       str(pod.get('accessLevel')))
 

--- a/python/tests/nistoar/pdr/preserv/service/test_service_midas3.py
+++ b/python/tests/nistoar/pdr/preserv/service/test_service_midas3.py
@@ -54,6 +54,8 @@ class TestM3MultiprocessPreservationService(test.TestCase):
         self.stagedir = os.path.join(self.workdir, "staging")
         self.storedir = os.path.join(self.workdir, "store")
         os.mkdir(self.storedir)
+        self.restrictdir = os.path.join(self.workdir, "restricted")
+        os.mkdir(self.restrictdir)
         self.statusdir = os.path.join(self.workdir, "status")
         os.mkdir(self.statusdir)
         self.bagparent = os.path.join(self.datadir, "_preserv")
@@ -66,6 +68,7 @@ class TestM3MultiprocessPreservationService(test.TestCase):
         self.config = {
             "working_dir": self.workdir,
             "store_dir": self.storedir,
+            "restricted_store_dir": self.restrictdir,
             "id_registry_dir": self.workdir,
             "announce_subproc": False,
             "sip_type": {

--- a/python/tests/nistoar/pdr/preserv/service/test_siphandler_datacite.py
+++ b/python/tests/nistoar/pdr/preserv/service/test_siphandler_datacite.py
@@ -150,6 +150,8 @@ class TestPreservationDOIMockSrvr(test.TestCase):
         self.stagedir = os.path.join(self.workdir, "staging")
         self.storedir = os.path.join(self.workdir, "store")
         os.mkdir(self.storedir)
+        self.restrictdir = os.path.join(self.workdir, "restricted")
+        os.mkdir(self.restrictdir)
         self.statusdir = os.path.join(self.workdir, "status")
         os.mkdir(self.statusdir)
         self.bagparent = os.path.join(self.datadir, "_preserv")
@@ -164,6 +166,7 @@ class TestPreservationDOIMockSrvr(test.TestCase):
             'review_dir': self.dataroot,
             "staging_dir": self.stagedir,
             'store_dir': self.storedir,
+            'restricted_store_dir': self.restrictdir,
             "status_manager": { "cachedir": self.statusdir },
             'bagger': baggercfg,
             "ingester": {
@@ -316,6 +319,8 @@ class TestPreservationDOIDataCite(test.TestCase):
         os.mkdir(self.storedir)
         self.statusdir = os.path.join(self.workdir, "status")
         os.mkdir(self.statusdir)
+        self.restrictdir = os.path.join(self.workdir, "restricted")
+        os.mkdir(self.restrictdir)
         self.bagparent = os.path.join(self.datadir, "_preserv")
         self.sipdir = os.path.join(self.mdbags, self.midasid)
 

--- a/python/tests/nistoar/pdr/preserv/service/test_siphandler_midas3.py
+++ b/python/tests/nistoar/pdr/preserv/service/test_siphandler_midas3.py
@@ -27,6 +27,7 @@ def tearDownModule():
     if loghdlr:
         if rootlog:
             rootlog.removeHandler(loghdlr)
+            loghdlr.close()
         loghdlr = None
     rmtmpdir()
 

--- a/python/tests/nistoar/pdr/preserv/service/test_siphandler_midas3.py
+++ b/python/tests/nistoar/pdr/preserv/service/test_siphandler_midas3.py
@@ -49,6 +49,8 @@ class TestMIDAS3SIPHandler(test.TestCase):
         self.stagedir = os.path.join(self.workdir, "staging")
         self.storedir = os.path.join(self.workdir, "store")
         os.mkdir(self.storedir)
+        self.restrictdir = os.path.join(self.workdir, "restricted")
+        os.mkdir(self.restrictdir)
         self.statusdir = os.path.join(self.workdir, "status")
         os.mkdir(self.statusdir)
         self.bagparent = os.path.join(self.datadir, "_preserv")
@@ -63,6 +65,7 @@ class TestMIDAS3SIPHandler(test.TestCase):
             'review_dir': self.dataroot,
             "staging_dir": self.stagedir,
             'store_dir': self.storedir,
+            'restricted_store_dir': self.restrictdir,
             "status_manager": { "cachedir": self.statusdir },
             'bagger': baggercfg,
             "ingester": {

--- a/python/tests/nistoar/pdr/preserv/service/test_siphandler_midas3_rm2.py
+++ b/python/tests/nistoar/pdr/preserv/service/test_siphandler_midas3_rm2.py
@@ -90,6 +90,8 @@ class TestMIDAS3SIPHandler(test.TestCase):
         self.stagedir = os.path.join(self.workdir, "staging")
         self.storedir = os.path.join(self.workdir, "store")
         os.mkdir(self.storedir)
+        self.restrictdir = os.path.join(self.workdir, "restricted")
+        os.mkdir(self.restrictdir)
         self.statusdir = os.path.join(self.workdir, "status")
         os.mkdir(self.statusdir)
         self.bagparent = os.path.join(self.datadir, "_preserv")
@@ -104,6 +106,7 @@ class TestMIDAS3SIPHandler(test.TestCase):
             'review_dir': self.dataroot,
             "staging_dir": self.stagedir,
             'store_dir': self.storedir,
+            'restricted_store_dir': self.restrictdir,
             "status_manager": { "cachedir": self.statusdir },
             'bagger': baggercfg,
             "ingester": {

--- a/python/tests/nistoar/pdr/preserv/service/test_siphandler_restricted.py
+++ b/python/tests/nistoar/pdr/preserv/service/test_siphandler_restricted.py
@@ -1,0 +1,359 @@
+# These unit tests specifically test the siphandler module's support for
+# restricted public data.  This includes creating a special bag for downloading
+# via the restricted public gateway.
+#
+import os, pdb, sys, logging, yaml, time, re
+import unittest as test
+from zipfile import ZipFile
+
+from nistoar.testing import *
+from nistoar.pdr.preserv.service import siphandler as sip
+from nistoar.pdr.preserv.service import status
+import nistoar.pdr.preserv.bagit.builder as bldr
+from nistoar.pdr.preserv.bagit.bag import NISTBag
+from nistoar.pdr.preserv import AIPValidationError
+from nistoar.pdr.preserv.bagger import midas3 as midas
+from nistoar.pdr import utils
+
+# datadir = nistoar/pdr/preserv/data
+datadir = os.path.join( os.path.dirname(os.path.dirname(__file__)), "data" )
+
+testdir = os.path.dirname(os.path.abspath(__file__))
+pdrmoddir = os.path.dirname(os.path.dirname(testdir))
+basedir = os.path.dirname(os.path.dirname(os.path.dirname(
+                                                 os.path.dirname(pdrmoddir))))
+descarchdir = os.path.join(pdrmoddir, "describe", "data")
+
+
+loghdlr = None
+rootlog = None
+def setUpModule():
+    global loghdlr
+    global rootlog
+    ensure_tmpdir()
+#    logging.basicConfig(filename=os.path.join(tmpdir(),"test_builder.log"),
+#                        level=logging.INFO)
+    rootlog = logging.getLogger()
+    loghdlr = logging.FileHandler(os.path.join(tmpdir(),"test_builder.log"))
+    loghdlr.setLevel(logging.INFO)
+    loghdlr.setFormatter(logging.Formatter(bldr.DEF_BAGLOG_FORMAT))
+    rootlog.addHandler(loghdlr)
+    startServices()
+
+def tearDownModule():
+    global loghdlr
+    if loghdlr:
+        if rootlog:
+            rootlog.removeHandler(loghdlr)
+        loghdlr = None
+    stopServices()
+    rmtmpdir()
+
+distarchive = os.path.join(tmpdir(), "distarchive")
+mdarchive = os.path.join(tmpdir(), "mdarchive")
+
+def startServices():
+    tdir = tmpdir()
+    archdir = distarchive
+    os.mkdir(archdir)   # keep it empty for now
+
+    srvport = 9091
+    pidfile = os.path.join(tdir,"simdistrib"+str(srvport)+".pid")
+    wpy = "python/tests/nistoar/pdr/distrib/sim_distrib_srv.py"
+    assert os.path.exists(wpy)
+    cmd = "uwsgi --daemonize {0} --plugin python --http-socket :{1} " \
+          "--wsgi-file {2} --set-ph archive_dir={3} --pidfile {4}"
+    cmd = cmd.format(os.path.join(tdir,"simdistrib.log"), srvport,
+                     os.path.join(basedir, wpy), archdir, pidfile)
+    os.system(cmd)
+
+    archdir = mdarchive
+    shutil.copytree(descarchdir, archdir)
+
+    srvport = 9092
+    pidfile = os.path.join(tdir,"simrmm"+str(srvport)+".pid")
+    wpy = "python/tests/nistoar/pdr/describe/sim_describe_svc.py"
+    assert os.path.exists(wpy)
+    cmd = "uwsgi --daemonize {0} --plugin python --http-socket :{1} " \
+          "--wsgi-file {2} --set-ph archive_dir={3} --pidfile {4}"
+    cmd = cmd.format(os.path.join(tdir,"simrmm.log"), srvport,
+                     os.path.join(basedir, wpy), archdir, pidfile)
+    os.system(cmd)
+    time.sleep(0.5)
+
+def stopServices():
+    tdir = tmpdir()
+    srvport = 9091
+    pidfile = os.path.join(tdir,"simdistrib"+str(srvport)+".pid")
+    
+    cmd = "uwsgi --stop {0}".format(os.path.join(tdir,
+                                               "simdistrib"+str(srvport)+".pid"))
+    os.system(cmd)
+
+    # sometimes stopping with uwsgi doesn't work
+    try:
+        with open(pidfile) as fd:
+            pid = int(fd.read().strip())
+        os.kill(pid, signal.SIGTERM)
+    except:
+        pass
+
+    srvport = 9092
+    pidfile = os.path.join(tdir,"simrmm"+str(srvport)+".pid")
+    
+    cmd = "uwsgi --stop {0}".format(os.path.join(tdir,
+                                               "simrmm"+str(srvport)+".pid"))
+    os.system(cmd)
+
+    time.sleep(1)
+
+    # sometimes stopping with uwsgi doesn't work
+    try:
+        with open(pidfile) as fd:
+            pid = int(fd.read().strip())
+        os.kill(pid, signal.SIGTERM)
+    except:
+        pass
+
+def unzip(zipfile):
+    zipdir = os.path.dirname(zipfile)
+    zip = ZipFile(zipfile)
+    zip.extractall(zipdir)
+    
+
+class TestSIPHandlerRestricted(test.TestCase):
+
+    testsip = os.path.join(datadir, "metadatabag")
+    revdir = os.path.join(datadir, "midassip", "review")
+    # testdata = os.path.join(datadir, "samplembag", "data")
+    midasid = '3A1EE2F169DD3B8CE0531A570681DB5D1491'
+    arkid = "ark:/88434/mds2-1491"
+
+    def setUp(self):
+        self.archtf = Tempfiles()
+        self.storedir = distarchive
+        if not os.path.exists(distarchive):
+            self.archtf.mkdir("distarchive")
+        
+        self.tf = Tempfiles()
+        self.workdir = self.tf.mkdir("preserv")
+        self.sipdata = os.path.join(self.revdir, "1491")
+        self.mdbags =  os.path.join(self.workdir, "mdbags")
+        os.mkdir(self.mdbags)
+        self.dataroot = os.path.join(self.workdir, "data")
+        os.mkdir(self.dataroot)
+        self.datadir = os.path.join(self.dataroot, "1491")
+        self.stagedir = os.path.join(self.workdir, "staging")
+        os.mkdir(self.stagedir)
+        os.mkdir(os.path.join(self.stagedir,"_nerd"))
+        self.pubcache = self.stagedir
+        # self.storedir = os.path.join(self.workdir, "store")
+        # os.mkdir(self.storedir)
+        self.restrictdir = os.path.join(self.workdir, "restrict")
+        os.mkdir(self.restrictdir)
+        self.statusdir = os.path.join(self.workdir, "status")
+        os.mkdir(self.statusdir)
+        self.bagparent = os.path.join(self.datadir, "_preserv")
+        self.sipdir = os.path.join(self.mdbags, self.midasid)
+
+        with open(os.path.join(datadir, "bagger_conf.yml")) as fd:
+            baggercfg = yaml.load(fd)
+        baggercfg.update({
+            'store_dir': self.storedir,
+            'restricted_store_dir': self.restrictdir,
+            'restricted_access': {
+                "gateway_url": "https://nist.force.com/pdr?",
+                "disclaimer": "Be careful."
+            }
+        })            
+            
+        # set the config we'll use
+        self.config = {
+            'working_dir': self.workdir,
+            'review_dir': self.dataroot,
+            "staging_dir": self.stagedir,
+            'store_dir': self.storedir,
+            'restricted_store_dir': self.restrictdir,
+            "status_manager": { "cachedir": self.statusdir },
+            'bagger': baggercfg,
+            "ingester": {
+                "data_dir":  os.path.join(self.workdir, "ingest"),
+                "submit": "none"
+            },
+            'repo_access': {
+                'headbag_cache':   self.pubcache,
+                'distrib_service': {
+                    'service_endpoint': "http://localhost:9091/"
+                },
+                'metadata_service': {
+                    'service_endpoint': "http://localhost:9092/"
+                }
+            },
+            "multibag": {
+                "max_headbag_size": 2000000,
+#                "max_headbag_size": 100,
+                "max_bag_size": 200000000
+            }
+        }
+        
+    def tearDown(self):
+        self.sip = None
+        self.tf.clean()
+        self.archtf.clean()
+
+    def setup_sip(self, srcdir, destdir):
+        # replicate the SIP data to a writable directory; change download
+        # urls in metadata to reference simulated service
+        shutil.copytree(srcdir, destdir)
+        podf = os.path.join(destdir, "_pod.json")
+        self.restrict_pod(podf)
+
+        mdbgr = midas.MIDASMetadataBagger(self.midasid, self.mdbags, destdir, config=self.config['bagger'])
+        mdbgr.ensure_data_files(examine="sync")
+        mdbgr.apply_pod(podf)
+        mdbgr.done()
+
+        
+    def restrict_pod(self, podf):
+        # change download urls in given POD file to reference simulated service
+        datadotnist = re.compile(r'^https://data.nist.gov/')
+        pod = utils.read_json(podf)
+        dists = pod.setdefault('distribution',[])
+        for dist in dists:
+            if 'downloadURL' in dist:
+                dist['downloadURL'] = \
+                    datadotnist.sub('http://localhost:9091/',dist['downloadURL'])
+        dists.append({
+            "title": "Restricted Access Gateway",
+            "accessURL": "https://nist.force.com/pdr?id="+pod.get('identifier'),
+            "mediaType": "text/html"
+        })
+        pod['accessLevel'] = "restricted public"
+        pod.setdefault('rights', "gotta register")
+        utils.write_json(pod, podf)
+
+    def test_singlebag(self):
+        # test creation of a small single bag
+        self.setup_sip(self.sipdata, self.datadir)
+        self.sip = sip.MIDAS3SIPHandler(self.midasid, self.config)
+
+        self.assertEqual(self.sip.state, status.FORGOTTEN)
+
+        # prep bag for serialization
+        self.sip.bagger.make_bag()
+
+        # check to make sure the midas3 bagger did its work
+        bag = NISTBag(self.sip.bagger.bagdir)
+        nerdm = bag.nerdm_record()
+        self.assertEqual(nerdm.get('accessLevel'), "restricted public")
+        self.assertEqual(nerdm.get('disclaimer'), "Be careful.")
+        rpg = [c for c in self.sip.bagger.sip.nerd.get('components')
+                 if 'accessURL' in c and c['accessURL'].startswith("https://nist.force.com/pdr?")]
+        self.assertEquals(len(rpg), 1)
+        self.assertEquals(rpg[0]['@type'][0], "nrdp:RestrictedAccessPage")
+        self.assertTrue(self.sip.bagger.sip.nerd.get('rights'))
+        self.assertEquals(self.sip.bagger.sip.nerd.get('version'), '1.0.0')
+        
+        # serialize
+        aipid = re.sub(r'^ark:/\d+/', '', nerdm['ediid'])
+        savefiles = self.sip._serialize_restricted(self.sip.bagger.bagdir, aipid, self.stagedir, "zip")
+
+        self.assertEquals(len(savefiles), 2)
+        self.assertIn(os.path.join(self.stagedir, aipid+'.zip'), savefiles)
+        self.assertIn(os.path.join(self.stagedir, aipid+'.zip.sha256'), savefiles)
+
+        # files were created
+        self.assertTrue(os.path.isfile(savefiles[0]))
+        self.assertTrue(os.path.isfile(savefiles[1]))
+
+        os.system("cd %s; unzip -q %s" % (self.stagedir, aipid+'.zip'))
+        self.assertTrue(os.path.isdir(os.path.join(self.stagedir, aipid)))
+        for f in "trial1.json trial2.json trial3/trial3a.json".split():
+            self.assertTrue(os.path.isfile(os.path.join(self.stagedir, aipid, "data", f)))
+            self.assertTrue(os.path.isfile(os.path.join(self.stagedir, aipid, "metadata", f, "nerdm.json")))
+        self.assertTrue(os.path.isfile(os.path.join(self.stagedir, aipid, "bag-info.txt")))
+        self.assertTrue(not os.path.exists(os.path.join(self.stagedir, aipid, "multibag")))
+
+    def test_update(self):
+        # test creation of a small single bag
+        self.setup_sip(self.sipdata, self.datadir)
+        self.sip = sip.MIDAS3SIPHandler(self.midasid, self.config)
+        pod = utils.read_json(os.path.join(self.datadir, "_pod.json"))
+
+        self.assertEqual(self.sip.state, status.FORGOTTEN)
+
+        # create the initial version
+        self.sip.bagit()
+
+        # check that the output files got sent to the restricted dir
+        stored = [f for f in os.listdir(self.storedir) if f.startswith(self.midasid)]
+        self.assertEquals(len(stored), 0)
+        stored = [f for f in os.listdir(self.restrictdir) if f.startswith(self.midasid)]
+        self.assertIn(self.midasid+".zip", stored)
+        self.assertIn(self.midasid+".zip.sha256", stored)
+        stored = [f for f in stored if f.startswith(self.midasid+".1_0_0.mbag")]
+        self.assertEquals(len(stored), 2)
+        shutil.rmtree(os.path.join(self.mdbags, self.midasid))
+        shutil.rmtree(self.datadir)
+        os.mkdir(self.datadir)
+
+        # create an update
+        pod['title'] += '!'
+        mdbgr = midas.MIDASMetadataBagger(self.midasid, self.mdbags, self.datadir,
+                                          config=self.config['bagger'])
+        mdbgr.ensure_data_files(examine="sync")
+        mdbgr.apply_pod(pod)
+        mdbgr.finalize_version()
+        mdbgr.done()
+
+        nerdm = mdbgr.bagbldr.bag.nerd_metadata_for('', True)
+        self.assertEquals(nerdm['version'], "1.0.1")
+        self.assertEqual(nerdm.get('accessLevel'), "restricted public")
+        self.assertEqual(nerdm.get('disclaimer'), "Be careful.")
+
+        self.sip = sip.MIDAS3SIPHandler(self.midasid, self.config)
+        self.sip.bagger.make_bag()
+        
+        bag = NISTBag(self.sip.bagger.bagdir)
+        nerdm = bag.nerdm_record()
+        self.assertEqual(nerdm.get('accessLevel'), "restricted public")
+        self.assertEqual(nerdm.get('disclaimer'), "Be careful.")
+        self.assertEqual(len(nerdm['components']), 9)
+        self.assertEquals(nerdm['version'], "1.0.1")
+        
+        # serialize
+        aipid = re.sub(r'^ark:/\d+/', '', nerdm['ediid'])
+        savefiles = self.sip._serialize_restricted(self.sip.bagger.bagdir, aipid, self.stagedir, "zip")
+
+        self.assertEquals(len(savefiles), 2)
+        self.assertIn(os.path.join(self.stagedir, aipid+'.zip'), savefiles)
+        self.assertIn(os.path.join(self.stagedir, aipid+'.zip.sha256'), savefiles)
+
+        # files were created
+        self.assertTrue(os.path.isfile(savefiles[0]))
+        self.assertTrue(os.path.isfile(savefiles[1]))
+
+        os.system("cd %s; unzip -q %s" % (self.stagedir, aipid+'.zip'))
+        self.assertTrue(os.path.isdir(os.path.join(self.stagedir, aipid)))
+        for f in "trial1.json trial2.json trial3/trial3a.json".split():
+            self.assertTrue(os.path.isfile(os.path.join(self.stagedir, aipid, "metadata", f, "nerdm.json")),
+                            "restored bag is missing metadata file for "+f)
+            self.assertTrue(os.path.isfile(os.path.join(self.stagedir, aipid, "data", f)),
+                            "restored bag is missing data file, "+f)
+        self.assertTrue(os.path.isfile(os.path.join(self.stagedir, aipid, "bag-info.txt")))
+        self.assertTrue(not os.path.exists(os.path.join(self.stagedir, aipid, "multibag")))
+
+        bag = NISTBag(os.path.join(self.stagedir, aipid))
+        nerdm = bag.nerdm_record()
+        self.assertEqual(nerdm.get('accessLevel'), "restricted public")
+        self.assertEqual(nerdm.get('disclaimer'), "Be careful.")
+        self.assertEqual(len(nerdm['components']), 9)
+        self.assertEquals(nerdm['version'], "1.0.1")
+        
+        
+        
+                         
+
+
+if __name__ == '__main__':
+    test.main()

--- a/python/tests/nistoar/pdr/publish/midas3/test_service_preserve.py
+++ b/python/tests/nistoar/pdr/publish/midas3/test_service_preserve.py
@@ -108,6 +108,8 @@ class TestMIDAS3PublishingServicePreserve(test.TestCase):
         self.stagedir = os.path.join(self.workdir, "staging")
         self.storedir = os.path.join(self.workdir, "store")
         os.mkdir(self.storedir)
+        self.restrictdir = os.path.join(self.workdir, "restricted")
+        os.mkdir(self.restrictdir)
         self.statusdir = os.path.join(self.workdir, "status")
         os.mkdir(self.statusdir)
         self.sipdir = os.path.join(self.mdbags, self.midasid)
@@ -127,6 +129,7 @@ class TestMIDAS3PublishingServicePreserve(test.TestCase):
         defcfg.update({
             "working_dir": self.workdir,
             "store_dir":   self.storedir,
+            "restricted_store_dir":   self.storedir,
             "announce_subproc": False,
             "repo_access": {
                 "headbag_cache": self.stagedir,

--- a/python/tests/nistoar/pdr/publish/midas3/test_wsgi_preserve.py
+++ b/python/tests/nistoar/pdr/publish/midas3/test_wsgi_preserve.py
@@ -134,6 +134,7 @@ class TestPreserveHandler(test.TestCase):
         defcfg.update({
             "working_dir": self.workdir,
             "store_dir":   self.storedir,
+            "restricted_store_dir":   self.storedir,
             "announce_subproc": False,
             "auth_key": "secret",
             "repo_access": {


### PR DESCRIPTION
This PR addresses ODD-992 that updates the publishing system to support special processing of SIPs featuring restricted public access. SIPs from MIDAS are recognized as providing data under restricted public access when the POD includes files and an accessURL that points to the new Salesforce-connected Restricted Access Gateway; upon recognition, several bits of metadata are automatically attached to the record that are ultimately used by the Salesforce gateway.  It also applies two bits of specialized handling upon preservation and ingest:  the preservation bag files are sent to a special storage directory to be stored separately from the public data, and the file components are removed from the NERDm record sent to the ingest service.  
