### PR TITLE
Fixed 'More' button in Metrics Info box.

### DIFF
--- a/angular/src/app/landing/metricsinfo/metricsinfo.component.html
+++ b/angular/src/app/landing/metricsinfo/metricsinfo.component.html
@@ -17,7 +17,7 @@
                 </li>
             </ul>
             <div style="width: 100%;text-align: right;margin-top: -15px;font-size: small;">
-                <a *ngIf="metricsData.hasCurrentMetrics" href="{{metricsUrl}}" target="_blank"><span data-toggle="tooltip" title="More Metrics Data">More...</span></a>
+                <a *ngIf="metricsData.hasCurrentMetrics" href="{{metricsData.url}}" target="_blank"><span data-toggle="tooltip" title="More Metrics Data"><i class="faa faa-bar-chart" style="margin-right: 5px;"></i>More...</span></a>
             </div>
         </div>
         <ng-template #noMetrics>


### PR DESCRIPTION
http://mml.nist.gov:8080/browse/ODD-1023

This check in fixes the "more" button in the metrics info box in the landing page. It supposed to open the metrics page but is currently link to the about page instead.

A chart icon was also added at front of "More" to make it consistent with the link under "About This Dataset".

To test, run it locally with useMetadataService: true and editEnabled: false in environment.ts. Or run it in docker. 