### PR TITLE
Adjust display of isPartOf property

### DIFF
--- a/angular/src/app/landing/aboutdataset/aboutdataset.component.html
+++ b/angular/src/app/landing/aboutdataset/aboutdataset.component.html
@@ -1,9 +1,23 @@
 <!-- About This Dataset section -->
-<!-- is part of -->
-<div id="ispartof" *ngIf="isPartOf != ''">{{isPartOf}}</div>
 
 <!-- Version info -->
 <pdr-version [record]="record"></pdr-version> 
+
+<!-- is part of -->
+<div id="about-ispartof" *ngIf="isPartOf">
+  <div *ngIf="isPartOf.length == 1; else multiIsPartOf">
+    This dataset is part of {{isPartOf[0][0]}}
+    <a href="{{isPartOf[0][1]}}" title="view collection">{{isPartOf[0][2]}}</a> {{isPartOf[0][3]}}. 
+  </div>
+  <ng-template #multiIsPartOf>
+    This dataset is part of the following collections:
+    <ul>
+    <div *ngFor="let coll of isPartOf">
+       <li> {{coll[0]}} <a href="{{coll[1]}}" title="view collection">{{coll[2]}}</a> {{coll[3]}} </li>
+    </div>
+    </ul>
+  </ng-template>
+</div>
 
 <!-- Facilitators -->
 <div *ngIf="theme == scienceTheme" style="width: 100%; margin-bottom: 2em;">

--- a/angular/src/app/landing/aboutdataset/aboutdataset.component.spec.ts
+++ b/angular/src/app/landing/aboutdataset/aboutdataset.component.spec.ts
@@ -12,6 +12,8 @@ import { config, testdata } from '../../../environments/environment';
 import { By } from "@angular/platform-browser";
 import { MetricsData } from "../metrics-data";
 
+import * as _ from 'lodash-es';
+
 describe('AboutdatasetComponent', () => {
     let component: AboutdatasetComponent;
     let fixture: ComponentFixture<AboutdatasetComponent>;
@@ -69,6 +71,64 @@ describe('AboutdatasetComponent', () => {
         el = cmpel.querySelector("#metrics");
         expect(el).toBeTruthy();
         expect(el.textContent).toContain("Access Metrics");
+
+        // test record does not include isPartOf
+        el = cmpel.querySelector("#about-ispartof");
+        expect(el).toBeFalsy();
+    });
+
+    it('single isPartOf rendering', () => {
+        let cmpel = fixture.nativeElement;
+        let member = _.cloneDeep(rec);
+        member['isPartOf'] = [{
+            "@id": "ark:/88888/goober",
+            title: "Uber Research",
+            "@type": [ "nrda:Aggregation", "nrd:PublicDataResource" ]
+        }];
+        component.record = member;
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        let el = cmpel.querySelector("#about-ispartof");
+        expect(el).toBeTruthy();
+        expect(el.querySelector("ul")).toBeFalsy();
+        expect(el.innerHTML.includes(" collection.")).toBeTruthy();
+        let a = el.querySelector("a");
+        expect(a).toBeTruthy();
+        expect(a.href.endsWith("/ark:/88888/goober")).toBeTruthy();
+    });
+
+    it('multiple isPartOf rendering', () => {
+        let cmpel = fixture.nativeElement;
+        let member = _.cloneDeep(rec);
+        member['isPartOf'] = [
+            {
+                "@id": "ark:/88888/goober",
+                title: "Uber Research",
+                "@type": [ "nrda:ScienceTheme", "nrd:PublicDataResource" ]
+            },
+            {
+                "@id": "ark:/88888/gomer",
+                title: "Sleepy Research",
+                "@type": [ "nrda:Aggregation", "nrd:PublicDataResource" ]
+            }
+        ];
+        component.record = member;
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        let el = cmpel.querySelector("#about-ispartof");
+        expect(el).toBeTruthy();
+        expect(el.querySelector("ul")).toBeTruthy();
+        expect(el.innerHTML.includes("This dataset is part of")).toBeTruthy();
+        let li = el.querySelectorAll("ul li");
+        expect(li.length).toEqual(2);
+        expect(li[0].innerHTML.includes(" Science Theme ")).toBeTruthy();
+        let html = li[1].innerHTML
+        expect(li[1].innerHTML.includes("Science Theme")).toBeFalsy();
+        expect(li[1].innerHTML.endsWith("collection ")).toBeFalsy();
+        expect(li[0].querySelector("a").href.endsWith("/ark:/88888/goober")).toBeTruthy();
+        expect(li[1].querySelector("a").href.endsWith("/ark:/88888/gomer")).toBeTruthy();
     });
 
     it('getDownloadURL()', () => {

--- a/angular/src/app/landing/sections/resourceidentity.component.html
+++ b/angular/src/app/landing/sections/resourceidentity.component.html
@@ -6,7 +6,10 @@
         </span>
         <br>
         <app-title [record]="record" [inBrowser]="inBrowser"></app-title>
-        <div id="ispartof" *ngIf="isPartOf != ''">{{isPartOf}}</div>
+        <div id="ispartof" *ngIf="isPartOf">
+          <i style="font-size: smaller;">Part of {{isPartOf[0]}} <a href="{{isPartOf[1]}}"
+             title="view collection">{{isPartOf[2]}}</a> {{isPartOf[3]}}</i>
+        </div>
         <app-author [record]="record" [inBrowser]="inBrowser"></app-author>
     </div>
     

--- a/angular/src/app/landing/sections/resourceidentity.component.spec.ts
+++ b/angular/src/app/landing/sections/resourceidentity.component.spec.ts
@@ -13,7 +13,9 @@ import { AuthService, WebAuthService, MockAuthService } from '../editcontrol/aut
 import { GoogleAnalyticsService } from '../../shared/ga-service/google-analytics.service';
 import { config, testdata } from '../../../environments/environment';
 
-describe('ResourceIdentityComponent', () => {
+import * as _ from 'lodash-es';
+
+fdescribe('ResourceIdentityComponent', () => {
     let component : ResourceIdentityComponent;
     let fixture : ComponentFixture<ResourceIdentityComponent>;
     let cfg : AppConfig = new AppConfig(config);
@@ -42,7 +44,7 @@ describe('ResourceIdentityComponent', () => {
     beforeEach(waitForAsync(() => {
         makeComp();
         component.inBrowser = true;
-        component.ngOnChanges()
+        component.ngOnChanges({})
         fixture.detectChanges();
     }));
 
@@ -58,6 +60,10 @@ describe('ResourceIdentityComponent', () => {
         expect(descs.length).toBe(1);
 
         // expect(component.versionCmp.newer).toBeNull();
+
+        // test record does not include isPartOf
+        el = cmpel.querySelector("#ispartof");
+        expect(el).toBeFalsy();
     });
 
     it('should correctly render special references', () => {
@@ -89,5 +95,54 @@ describe('ResourceIdentityComponent', () => {
         expect(component.primaryRefs[0]['label']).toEqual(component.primaryRefs[0]['location']);
     });
        
+    it('single isPartOf rendering', () => {
+        let cmpel = fixture.nativeElement;
+        let member = _.cloneDeep(rec);
+        member['isPartOf'] = [{
+            "@id": "ark:/88888/goober",
+            title: "Uber Research",
+            "@type": [ "nrda:Aggregation", "nrd:PublicDataResource" ]
+        }];
+        component.record = member;
+        component.ngOnChanges({});
+        fixture.detectChanges();
+
+        let el = cmpel.querySelector("#ispartof");
+        expect(el).toBeTruthy();
+        expect(el.querySelector("ul")).toBeFalsy();
+        expect(el.innerHTML.includes(" Collection")).toBeTruthy();
+        let a = el.querySelector("a");
+        expect(a).toBeTruthy();
+        expect(a.href.endsWith("/ark:/88888/goober")).toBeTruthy();
+    });
+
+    it('multiple isPartOf rendering', () => {
+        let cmpel = fixture.nativeElement;
+        let member = _.cloneDeep(rec);
+        member['isPartOf'] = [
+            {
+                "@id": "ark:/88888/goobler",
+                title: "Uber Research",
+                "@type": [ "nrda:ScienceTheme", "nrd:PublicDataResource" ]
+            },
+            {
+                "@id": "ark:/88888/gomer",
+                title: "Sleepy Research",
+                "@type": [ "nrda:Aggregation", "nrd:PublicDataResource" ]
+            }
+        ];
+        component.record = member;
+        component.ngOnChanges({});
+        fixture.detectChanges();
+
+        let el = cmpel.querySelector("#ispartof");
+        expect(el).toBeTruthy();
+        expect(el.querySelector("ul")).toBeFalsy();
+        expect(el.innerHTML.includes(" Science Theme")).toBeTruthy();
+        let a = el.querySelector("a");
+        expect(a).toBeTruthy();
+        expect(a.href.endsWith("/ark:/88888/goobler")).toBeTruthy();
+    });
+
 });
 

--- a/angular/src/app/landing/sections/resourceidentity.component.spec.ts
+++ b/angular/src/app/landing/sections/resourceidentity.component.spec.ts
@@ -15,7 +15,7 @@ import { config, testdata } from '../../../environments/environment';
 
 import * as _ from 'lodash-es';
 
-fdescribe('ResourceIdentityComponent', () => {
+describe('ResourceIdentityComponent', () => {
     let component : ResourceIdentityComponent;
     let fixture : ComponentFixture<ResourceIdentityComponent>;
     let cfg : AppConfig = new AppConfig(config);

--- a/angular/src/app/landing/sections/resourceidentity.component.ts
+++ b/angular/src/app/landing/sections/resourceidentity.component.ts
@@ -42,10 +42,6 @@ export class ResourceIdentityComponent implements OnChanges {
     ngOnInit(): void {
         this.EDIT_MODES = LandingConstants.editModes;
 
-        if(this.record['isPartOf'] != undefined) {
-            this.isPartOf = "Part of " + this.record['isPartOf'][0].title 
-        }
-
         // Watch current edit mode set by edit controls
         this.editstatsvc.watchEditMode((editMode) => {
             this.editMode = editMode;
@@ -74,7 +70,29 @@ export class ResourceIdentityComponent implements OnChanges {
      */
     useMetadata(): void {
         this.showHomePageLink = this.isExternalHomePage(this.record['landingPage']);
+
         this.recordType = (new NERDResource(this.record)).resourceLabel();
+
+        if (this.record['isPartOf'] && Array.isArray(this.record['isPartOf']) && 
+            this.record['isPartOf'].length > 0 && this.record['isPartOf'][0]['@id'])
+        {
+            // this resource is part of a collection; format a label indicating that
+            let coll = this.record['isPartOf'][0]
+            
+            let article = "";
+            let title = "another collection";
+            let suffix = "";
+            if (coll['title']) {
+                article = "the";
+                title = coll['title']
+                suffix = "Collection";
+                if (NERDResource.objectMatchesTypes(coll, "ScienceTheme"))
+                    suffix = "Science Theme";
+            }
+           
+            this.isPartOf = '<i>Part of ' + artitcle + '<a href="' + cfg.get("locations.landinPageService") +
+                coll['@id'] + '" title="view collection">' + title + "</a> " + suffix + "</i>";
+        }
 
         if (this.record['doi'] !== undefined && this.record['doi'] !== "")
             this.doiUrl = "https://doi.org/" + this.record['doi'].substring(4);

--- a/angular/src/app/landing/sections/resourceidentity.component.ts
+++ b/angular/src/app/landing/sections/resourceidentity.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnChanges, Input, ViewChild } from '@angular/core';
+import { Component, OnChanges, SimpleChanges, Input, ViewChild } from '@angular/core';
 
 import { AppConfig } from '../../config/config';
 import { NerdmRes, NERDResource } from '../../nerdm/nerdm';
@@ -25,7 +25,7 @@ export class ResourceIdentityComponent implements OnChanges {
     primaryRefs: any[] = [];
     editMode: string;
     EDIT_MODES: any;
-    isPartOf: string = "";
+    isPartOf: string[] = null;
 
     // passed in by the parent component:
     @Input() record: NerdmRes = null;
@@ -55,7 +55,7 @@ export class ResourceIdentityComponent implements OnChanges {
         return this.editMode == this.EDIT_MODES.VIEWONLY_MODE;
     }
 
-    ngOnChanges() {
+    ngOnChanges(changes: SimpleChanges) {
         if (this.recordLoaded())
             this.useMetadata();  // initialize internal component data based on metadata
     }
@@ -77,7 +77,7 @@ export class ResourceIdentityComponent implements OnChanges {
             this.record['isPartOf'].length > 0 && this.record['isPartOf'][0]['@id'])
         {
             // this resource is part of a collection; format a label indicating that
-            let coll = this.record['isPartOf'][0]
+            let coll = this.record['isPartOf'][0];
             
             let article = "";
             let title = "another collection";
@@ -90,8 +90,12 @@ export class ResourceIdentityComponent implements OnChanges {
                     suffix = "Science Theme";
             }
            
-            this.isPartOf = '<i>Part of ' + artitcle + '<a href="' + cfg.get("locations.landinPageService") +
-                coll['@id'] + '" title="view collection">' + title + "</a> " + suffix + "</i>";
+            this.isPartOf = [
+                article,
+                this.cfg.get("locations.landingPageService") + coll['@id'],
+                title,
+                suffix
+            ];
         }
 
         if (this.record['doi'] !== undefined && this.record['doi'] !== "")

--- a/angular/src/app/nerdm/nerdm.ts
+++ b/angular/src/app/nerdm/nerdm.ts
@@ -191,6 +191,17 @@ export class NERDResource {
     }
 
     /**
+     * return True if one of the @types assigned to this resource matches the resource
+     * type given
+     * @param type   a resource type label (like "DataPublication" or "ScienceTheme").  The 
+     *               value may include a namespace prefix, which is ignored.
+     * @return boolean   True if the given type matches one of the assigned types
+     */
+    isType(restype: string) : boolean {
+        return NERDResource.objectMatchesTypes(this, restype);
+    }
+
+    /**
      * return an array of the component objects that match any of the given @type labels.
      * The labels should not include namespace qualifiers
      */


### PR DESCRIPTION
This PR adjusts the display of the isPartOf NERDm property:
   *  make collection name a clickable link to the collection page
   *  support Aggregation collections, too
   *  in "About" section, list all enclosing collections if record is a member of more than one.
   *  tweak top reference: italicize and use slightly smaller font.  

Please confirm that unit tests pass and display looks okay.

