### PR TITLE
Support linkless ("in press") references and fix layout problems

### DIFF
--- a/angular/src/app/landing/sections/resourceidentity.component.css
+++ b/angular/src/app/landing/sections/resourceidentity.component.css
@@ -4,6 +4,11 @@
     font-size: 16px;
 }
 
+.primary-ref-entry {
+    line-height: 1.2;
+    margin-bottom: 0.3em;
+}
+
 .home_button {
     float:right;
     margin:.5em 1em .5em 0em;

--- a/angular/src/app/landing/sections/resourceidentity.component.html
+++ b/angular/src/app/landing/sections/resourceidentity.component.html
@@ -16,24 +16,22 @@
         <span *ngIf="!doiUrl"><i> 
             <a href="{{ cfg.get('landingPageService','/od/id/') }}{{record['@id']}}">{{record["@id"]}}</a></i>
         </span>
-        <span class="describedin" *ngIf="primaryRefs.length > 0"><br>
-            <span>Described in
+        <div class="describedin" *ngIf="primaryRefs.length > 0">
+            <div>Described in
                   <span *ngIf="primaryRefs.length < 2">this article:</span>
-                  <span *ngIf="primaryRefs.length > 1">these articles: </span></span>
-            <div *ngFor="let ref of primaryRefs; let i =index"
+                  <span *ngIf="primaryRefs.length > 1">these articles: </span></div>
+            <div *ngFor="let ref of primaryRefs; let i =index" class="primary-ref-entry"
                  style="padding-left:20px">
-              <span *ngIf="ref.location; else nopreflink" class="primary-ref-entry">
-                  <span class="faa faa-external-link">&nbsp;&nbsp;
-                    <i><a href={{ref.location}} target="blank"
-                          (click)="gaService.gaTrackEvent('outbound', $event, 'Resource title: ' + record.title, ref.location)">{{ ref.label }}</a><span *ngIf="i < primaryRefs.length-1">,</span></i></span>
+              <span *ngIf="ref.location; else nopreflink">
+                  <span class="faa faa-external-link">&nbsp;&nbsp;</span>
+                  <i><a href={{ref.location}} target="blank"
+                        (click)="gaService.gaTrackEvent('outbound', $event, 'Resource title: ' + record.title, ref.location)">{{ ref.label }}</a><span *ngIf="i < primaryRefs.length-1">,</span></i>
               </span>
               <ng-template #nopreflink>
-                <i class="primary-ref-entry">
-                  {{ ref.label }}<span *ngIf="i < primaryRefs.length-1">,</span>
-                </i>
+                <i>{{ ref.label }}<span *ngIf="i < primaryRefs.length-1">,</span></i>
               </ng-template>
             </div>
-        </span>
+        </div>
         <pdr-version [record]="record"></pdr-version>
     </div>
 

--- a/angular/src/app/landing/sections/resourceidentity.component.html
+++ b/angular/src/app/landing/sections/resourceidentity.component.html
@@ -23,14 +23,14 @@
             <div *ngFor="let ref of primaryRefs; let i =index"
                  style="padding-left:20px">
               <span *ngIf="ref.location; else nopreflink" class="primary-ref-entry">
-                  <i class="faa faa-external-link">&nbsp;&nbsp;
-                      <a href={{ref.location}} target="blank"
-                         (click)="gaService.gaTrackEvent('outbound', $event, 'Resource title: ' + record.title, ref.location)">{{ ref.label }}</a><span *ngIf="i < primaryRefs.length-1">,</span></i>
+                  <span class="faa faa-external-link">&nbsp;&nbsp;
+                    <i><a href={{ref.location}} target="blank"
+                          (click)="gaService.gaTrackEvent('outbound', $event, 'Resource title: ' + record.title, ref.location)">{{ ref.label }}</a><span *ngIf="i < primaryRefs.length-1">,</span></i></span>
               </span>
               <ng-template #nopreflink>
-                <span class="primary-ref-entry">
+                <i class="primary-ref-entry">
                   {{ ref.label }}<span *ngIf="i < primaryRefs.length-1">,</span>
-                </span>
+                </i>
               </ng-template>
             </div>
         </span>

--- a/angular/src/app/landing/sections/resourceidentity.component.html
+++ b/angular/src/app/landing/sections/resourceidentity.component.html
@@ -17,14 +17,21 @@
             <a href="{{ cfg.get('landingPageService','/od/id/') }}{{record['@id']}}">{{record["@id"]}}</a></i>
         </span>
         <span class="describedin" *ngIf="primaryRefs.length > 0"><br>
-            <span>Described in article: </span>
-            <div *ngFor="let ref of primaryRefs; let i =index">
-                <span style="padding-left:20px">
-                    <i class="faa faa-external-link">
-                        <a href={{ref.location}} target="blank"
-                            (click)="gaService.gaTrackEvent('outbound', $event, 'Resource title: ' + record.title, ref.location)">&nbsp;&nbsp;{{ ref.label }}</a></i>
-                    <span *ngIf="i < primaryRefs.length-1">,</span>
+            <span>Described in
+                  <span *ngIf="primaryRefs.length < 2">this article:</span>
+                  <span *ngIf="primaryRefs.length > 1">these articles: </span></span>
+            <div *ngFor="let ref of primaryRefs; let i =index"
+                 style="padding-left:20px">
+              <span *ngIf="ref.location; else nopreflink" class="primary-ref-entry">
+                  <i class="faa faa-external-link">&nbsp;&nbsp;
+                      <a href={{ref.location}} target="blank"
+                         (click)="gaService.gaTrackEvent('outbound', $event, 'Resource title: ' + record.title, ref.location)">{{ ref.label }}</a><span *ngIf="i < primaryRefs.length-1">,</span></i>
+              </span>
+              <ng-template #nopreflink>
+                <span class="primary-ref-entry">
+                  {{ ref.label }}<span *ngIf="i < primaryRefs.length-1">,</span>
                 </span>
+              </ng-template>
             </div>
         </span>
         <pdr-version [record]="record"></pdr-version>

--- a/angular/src/app/landing/sections/resourceidentity.component.spec.ts
+++ b/angular/src/app/landing/sections/resourceidentity.component.spec.ts
@@ -13,7 +13,7 @@ import { AuthService, WebAuthService, MockAuthService } from '../editcontrol/aut
 import { GoogleAnalyticsService } from '../../shared/ga-service/google-analytics.service';
 import { config, testdata } from '../../../environments/environment';
 
-fdescribe('ResourceIdentityComponent', () => {
+describe('ResourceIdentityComponent', () => {
     let component : ResourceIdentityComponent;
     let fixture : ComponentFixture<ResourceIdentityComponent>;
     let cfg : AppConfig = new AppConfig(config);

--- a/angular/src/app/landing/sections/resourceidentity.component.spec.ts
+++ b/angular/src/app/landing/sections/resourceidentity.component.spec.ts
@@ -65,6 +65,8 @@ describe('ResourceIdentityComponent', () => {
 
         let el = cmpel.querySelector(".describedin")
         expect(el).toBeTruthy();
+        expect(el.querySelectorAll(".primary-ref-entry").length).toEqual(1);
+        expect(el.querySelectorAll("a").length).toEqual(1);
         el = el.querySelector("a");
         expect(el.textContent).toContain("Solids: In-situ");
 
@@ -85,6 +87,50 @@ describe('ResourceIdentityComponent', () => {
         component.record = tstrec;
         component.useMetadata();
         expect(component.primaryRefs[0]['label']).toEqual(component.primaryRefs[0]['location']);
+    });
+
+    it('should not render special reference as link without location', () => {
+        // remove the location from the special reference
+        let tstrec = JSON.parse(JSON.stringify(rec));
+        tstrec['references'][0]['location'] = null;
+        component.record = tstrec;
+        component.useMetadata();
+        fixture.detectChanges();
+        
+        expect(component).toBeDefined();
+        expect(component.primaryRefs.length).toEqual(1);
+        let cmpel = fixture.nativeElement;
+
+        let el = cmpel.querySelector(".describedin")
+        expect(el).toBeTruthy();
+        expect(el.querySelectorAll(".primary-ref-entry").length).toEqual(1);
+        expect(el.querySelectorAll("a").length).toEqual(0);
+    });
+
+    it('should correctly render multiple special references', () => {
+        let tstrec = JSON.parse(JSON.stringify(rec));
+        tstrec['references'][1]['refType'] = "IsSupplementTo";
+        tstrec['references'][1]['location'] = null;
+        component.record = tstrec;
+        component.useMetadata();
+        fixture.detectChanges();
+        
+        expect(component).toBeDefined();
+        expect(component.primaryRefs.length).toEqual(2);
+        let cmpel = fixture.nativeElement;
+
+        let el = cmpel.querySelector(".describedin")
+        expect(el).toBeTruthy();
+        expect(el.querySelectorAll("a").length).toEqual(1);
+//        expect(el.textContent.includes(' ,')).toBeFalsy(); // doesn't work
+
+        let entries = el.querySelectorAll(".primary-ref-entry");
+        expect(entries.length).toEqual(2);
+        expect(entries[0].querySelectorAll("a").length).toEqual(1);
+        expect(entries[1].querySelectorAll("a").length).toEqual(0);
+        expect(entries[0].textContent.includes(',')).toBeTruthy();
+        expect(entries[1].textContent.includes(',')).toBeFalsy();
+        expect(entries[0].textContent.includes(' ,')).toBeFalsy();
     });
 
     it('should correctly determine resource type', () => {

--- a/angular/src/app/landing/sections/resourceidentity.component.spec.ts
+++ b/angular/src/app/landing/sections/resourceidentity.component.spec.ts
@@ -13,7 +13,7 @@ import { AuthService, WebAuthService, MockAuthService } from '../editcontrol/aut
 import { GoogleAnalyticsService } from '../../shared/ga-service/google-analytics.service';
 import { config, testdata } from '../../../environments/environment';
 
-describe('ResourceIdentityComponent', () => {
+fdescribe('ResourceIdentityComponent', () => {
     let component : ResourceIdentityComponent;
     let fixture : ComponentFixture<ResourceIdentityComponent>;
     let cfg : AppConfig = new AppConfig(config);

--- a/angular/src/app/landing/sections/resourcerefs.component.css
+++ b/angular/src/app/landing/sections/resourcerefs.component.css
@@ -1,0 +1,4 @@
+.ref-entry {
+    line-height: 1.2;
+}
+

--- a/angular/src/app/landing/sections/resourcerefs.component.html
+++ b/angular/src/app/landing/sections/resourcerefs.component.html
@@ -2,12 +2,13 @@
     <div class="col-12 col-md-12 col-lg-12 col-sm-12">
         <div *ngIf="hasDisplayableReferences()">
             <div class="section-header"><h3><b>References</b></h3></div>
-            <div style="margin: 0em 0em .5em 1em;" *ngFor="let ref of record['references']">
-              <span *ngIf="ref.location; else noreflink" class="faa faa-external-link ref-entry">&nbsp;
+            <div style="margin: 0em 0em .5em 1em;" *ngFor="let ref of record['references']" class="ref-entry">
+              <span *ngIf="ref.location; else noreflink">
+                <span class="faa faa-external-link">&nbsp;</span>
                 <a href={{ref.location}} target="blank">{{ getReferenceText(ref) }}</a>
               </span>
               <ng-template #noreflink>
-                <span class="ref-entry">{{ getReferenceText(ref) }}</span>
+                <span>{{ getReferenceText(ref) }}</span>
               </ng-template>
             </div>
         </div>

--- a/angular/src/app/landing/sections/resourcerefs.component.html
+++ b/angular/src/app/landing/sections/resourcerefs.component.html
@@ -3,9 +3,12 @@
         <div *ngIf="hasDisplayableReferences()">
             <div class="section-header"><h3><b>References</b></h3></div>
             <div style="margin: 0em 0em .5em 1em;" *ngFor="let ref of record['references']">
-                <i class="faa faa-external-link"> &nbsp;
-                    <a href={{ref.location}} target="blank">{{ getReferenceText(ref) }}</a>
-                </i>
+              <span *ngIf="ref.location; else noreflink" class="faa faa-external-link ref-entry">&nbsp;
+                <a href={{ref.location}} target="blank">{{ getReferenceText(ref) }}</a>
+              </span>
+              <ng-template #noreflink>
+                <span class="ref-entry">{{ getReferenceText(ref) }}</span>
+              </ng-template>
             </div>
         </div>
     </div>

--- a/angular/src/app/landing/sections/resourcerefs.component.spec.ts
+++ b/angular/src/app/landing/sections/resourcerefs.component.spec.ts
@@ -69,6 +69,25 @@ describe('ResourceRefsComponent', () => {
         expect(els.length).toBe(0);
     });
 
+    it('should not render ref as a link without location', () => {
+        // remove the locations from the two reference
+        component.record['references'][0]['location'] = null;
+        delete component.record['references'][1].location;
+        component.ngOnChanges({});
+        fixture.detectChanges();
+
+        expect(component).toBeTruthy();
+        let cmpel = fixture.nativeElement;
+        let reflist = cmpel.querySelector("#references");
+        expect(reflist).toBeTruthy();
+
+        // has 2 references
+        let els = cmpel.querySelectorAll(".ref-entry")
+        expect(els.length).toBe(2);
+        els = cmpel.querySelectorAll("a");
+        expect(els.length).toBe(0);
+    });
+
     it('getReferenceText()', () => {
         expect(component).toBeTruthy();
         let ref = { 'location': 'http://example.com/doc.txt' }

--- a/angular/src/app/landing/sections/resourcerefs.component.ts
+++ b/angular/src/app/landing/sections/resourcerefs.component.ts
@@ -11,7 +11,8 @@ import { NerdmRes, NERDResource } from '../../nerdm/nerdm';
     selector:      'pdr-resource-refs',
     templateUrl:   './resourcerefs.component.html',
     styleUrls:   [
-        '../landing.component.css'
+        '../landing.component.css',
+        './resourcerefs.component.css'
     ]
 })
 export class ResourceRefsComponent implements OnChanges {


### PR DESCRIPTION
The main motivation behind this PR is to properly display references that do not include a link to the thing being reference--e.g. a paper that is still "in press".  Previously, if a NERDm reference did not include a `location` property (which provides the URL to the cited thing), the landing was still rendering it as a link, which by default went to the PDR home URL.  With this PR, it is now rendered as regular text.  Supporting this feature required an update to the NERDm core schema (see [oar-metadata PR#50](https://github.com/usnistgov/oar-metadata/pull/50)).

I took this opportunity to fix a few other reference rendering issues:
  *  When listing multiple references, the commas  were being prepended with a space; sometimes this would cause the comma to appear on a line by itself.
  * references were being forced into a line-height of 1.0, which is a bit too tight; with this PR, this set to a more pleasant 1.2 with a little extra space between reference.

To test these changes, I've set up a [special oar-docker branch, test/inpress-refs](https://github.com/usnistgov/oar-docker/tree/test/inpress-refs).  After running `localdeploy` and `oarctl local build`,  run the following script to load three test records:
```
   data/load_nerdm.sh data/pdr/nerdm/*.json
```
(There is no need to start from scratch.)

Next view the following landing pages and confirm proper rendering as described below:
   * [mds2-2304](https://localhost/od/id/mds2-2304):  This page will display one reference in the references section as a link to the remote article, but none at the top of the page (above the version info).
   * [mds1141dw08w](https://localhost/od/id/6998B81EF78777B2E05324570681D4DC1911): This page will show three references in the References section, but only one of them will appear at the top of the page under a label of "Described in this article".  The text for the top reference will be the article title.  All references will appear as links.  
   * [mds2-2176](https://localhost/od/id/mds2-2176):  The References section will show 6 references; all are links except for the third one.  The unlinked reference will _not_ feature the external link icon.  Three references will appear at the top of the page with the following features:
      * the last reference will not be a link and will not include the external link icon
      * there is no space before the comma at the end of the first and second reference
