### PR TITLE
LPS: always display DynamicResourceSets

### DIFF
--- a/angular/src/app/landing/resultlist/resultlist.component.ts
+++ b/angular/src/app/landing/resultlist/resultlist.component.ts
@@ -75,6 +75,7 @@ export class ResultlistComponent implements OnInit {
 
         let that = this;
         let urls = (new NERDResource(this.md)).dynamicSearchUrls();
+        console.log("ResultlistComponent: Found "+urls.length+" search url(s)");
         for(let i=0; i < urls.length; i++){
             this.searchService.resolveSearchRequest(urls[i])
             .subscribe(
@@ -227,8 +228,8 @@ export class ResultlistComponent implements OnInit {
     /**
      * If search is unsuccessful push the error message
      */
-    onError(error: any[]) {
-
+    onError(error: any) {
+        console.error("Search URL failed to resolve: "+error.error);
     }
 
     /**

--- a/angular/src/app/landing/sections/resourcedata.component.html
+++ b/angular/src/app/landing/sections/resourcedata.component.html
@@ -84,7 +84,7 @@
             (dlStatus)="setDownloadStatus($event)">
         </pdr-data-files>
 
-        <div *ngIf="theme == scienceTheme" style="margin-top: 2em;">
+        <div *ngIf="hasDRS" style="margin-top: 2em;">
             <app-searchresult 
                 [record]="record" 
                 [inBrowser]="inBrowser">

--- a/angular/src/app/landing/sections/resourcedata.component.ts
+++ b/angular/src/app/landing/sections/resourcedata.component.ts
@@ -35,6 +35,7 @@ import { Themes, ThemesPrefs } from '../../shared/globals/globals';
 })
 export class ResourceDataComponent implements OnChanges {
     accessPages: NerdmComp[] = [];
+    hasDRS: boolean = false;
     showDescription: boolean = false;
     showRestrictedDescription: boolean = false;
     currentState = 'initial';
@@ -79,6 +80,8 @@ export class ResourceDataComponent implements OnChanges {
             // If this is a science theme and the collection contains one or more components that contain both AccessPage (or SearchPage) and DynamicSourceSet, we want to remove it from accessPages array since it's already displayed in the search result.
             if(this.theme == this.scienceTheme) 
                 this.accessPages = this.accessPages.filter(cmp => ! cmp['@type'].includes("nrda:DynamicResourceSet"));
+
+            this.hasDRS = this.hasDynamicResourceSets();
         }
     }
 
@@ -97,6 +100,15 @@ export class ResourceDataComponent implements OnChanges {
 
             return cmp;
         });
+    }
+
+    /**
+     * return true if the components include non-hidden DynamicResourceSets.  If there are, the 
+     * results from the DynamicResourceSet searches will be display in a special in-page 
+     * search results display.
+     */
+    hasDynamicResourceSets(): boolean {
+        return (new NERDResource(this.record)).selectDynamicResourceComps().length > 0;
     }
 
     /**

--- a/angular/src/app/landing/sections/resourcedata.component.ts
+++ b/angular/src/app/landing/sections/resourcedata.component.ts
@@ -74,12 +74,29 @@ export class ResourceDataComponent implements OnChanges {
     useMetadata(): void {
         this.accessPages = [];
         if (this.record['components']) {
-            this.accessPages = (new NERDResource(this.record)).selectAccessPages();
+            this.accessPages = this.selectAccessPages();
 
             // If this is a science theme and the collection contains one or more components that contain both AccessPage (or SearchPage) and DynamicSourceSet, we want to remove it from accessPages array since it's already displayed in the search result.
             if(this.theme == this.scienceTheme) 
                 this.accessPages = this.accessPages.filter(cmp => ! cmp['@type'].includes("nrda:DynamicResourceSet"));
         }
+    }
+
+    /**
+     * select the AccessPage components to display, adding special disply options
+     */
+    selectAccessPages() : NerdmComp[] {
+        let use: NerdmComp[] = (new NERDResource(this.record)).selectAccessPages();
+        use = (JSON.parse(JSON.stringify(use))) as NerdmComp[];
+
+        return use.map((cmp) => {
+            if (! cmp['title']) cmp['title'] = cmp['accessURL'];
+
+            cmp['showDesc'] = false;
+            cmp['backcolor'] = 'white';
+
+            return cmp;
+        });
     }
 
     /**

--- a/angular/src/app/nerdm/nerdm.spec.ts
+++ b/angular/src/app/nerdm/nerdm.spec.ts
@@ -223,10 +223,10 @@ describe('NERDResource', function() {
 
 
     it('selectAccessPages()', () => {
-        let nrd1 = new nerdm.NERDResource(testdata['test1']);
+        let nrd1 = new nerdm.NERDResource(testdata['test3']);
 
         let aps = nrd1.selectAccessPages();
-        expect(aps.length).toBe(1);
+        expect(aps.length).toBe(2);
         expect(aps[0]['accessURL']).toBeTruthy();
     });
 });

--- a/angular/src/app/nerdm/nerdm.ts
+++ b/angular/src/app/nerdm/nerdm.ts
@@ -311,13 +311,10 @@ export class NERDResource {
      * Returns Nerdm comps that contains DynamicResourceSet
      */
     public selectDynamicResourceComps() : NerdmComp[] {
-        let use : NerdmComp[];
-        use = this.data['components'].filter(cmp => cmp['@type'].includes("nrda:DynamicResourceSet") &&
-        ! cmp['@type'].includes("nrd:Hidden"));
-
-        use = (JSON.parse(JSON.stringify(use))) as NerdmComp[];
-
-        return use;
+        let drctypes = ["DynamicResourceSet"];
+        let hidden = ["Hidden"];
+        return this.getComponentsByType(drctypes)
+                   .filter((c) => ! NERDResource.objectMatchesTypes(c, hidden));
     }
 
     /**
@@ -336,19 +333,10 @@ export class NERDResource {
      * @type contain "nrdp:AccessPage" or "nrdp:SearchPage" but not "nrd:Hidden"
      */
     selectAccessPages() : NerdmComp[] {
-        let use : NerdmComp[];
-        use = this.data['components'].filter(cmp => cmp['@type'].includes("nrdp:AccessPage") || cmp['@type'].includes("nrdp:SearchPage") && ! cmp['@type'].includes("nrd:Hidden"));
-
-        use = (JSON.parse(JSON.stringify(use))) as NerdmComp[];
-
-        return use.map((cmp) => {
-            if (! cmp['title']) cmp['title'] = cmp['accessURL'];
-
-            cmp['showDesc'] = false;
-            cmp['backcolor'] = 'white';
-
-            return cmp;
-        });
+        let accesstypes = ["AccessPage", "SearchPage"];
+        let hidden = ["Hidden"];
+        return this.getComponentsByType(accesstypes)
+                   .filter((c) => ! NERDResource.objectMatchesTypes(c, hidden));
     }
 }
 

--- a/angular/src/app/nerdm/nerdm.ts
+++ b/angular/src/app/nerdm/nerdm.ts
@@ -321,11 +321,7 @@ export class NERDResource {
      * Return science theme search urls as a string array
      */
     public dynamicSearchUrls(): string[] {
-        if(this.theme() == Themes.SCIENCE_THEME) {
-            return this.selectDynamicResourceComps().map(a=>a.searchURL);
-        }else{
-            return [];
-        }
+        return this.selectDynamicResourceComps().map(a=>a.searchURL);
     }
 
     /**

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -295,6 +295,7 @@ export const testdata: {} = {
             "nrdp:PublicDataResource"
         ],
         "@id": "ark:/88434/mds0000fbk3",
+        "doi": "doi:10.18434/mds0000fbk3",
         "title": "Multiple Encounter Dataset (MEDS-I) - NIST Special Database 32",
         "contactPoint": {
             "hasEmail": "mailto:patricia.flanagan@nist.gov",
@@ -403,6 +404,20 @@ export const testdata: {} = {
                 "@id": "cmps/NIST_SD32_MEDS-I_html.zip",
                 "_extensionSchemas": [
                     "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
+                ]
+            },
+            {
+                "accessURL": "https://doi.org/10.18434/mds0000fbk",
+                "description": "DOI Access to landing page",
+                "title": "DOI Access to \"Multiple Encounter Dataset (MEDS-I)\"",
+                "@type": [
+                    "nrd:Hidden",
+                    "nrdp:AccessPage",
+                    "dcat:Distribution"
+                ],
+                "@id": "#doi:10.18434/mds0000fbk",
+                "_extensionSchemas": [
+                    "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/"
                 ]
             }
         ],


### PR DESCRIPTION
The NERDm schemas allow any type of resource record to include one or more `DynamicResourceSet` components.  Consequently, the dynamic search results should always be displayed--regardless of whether it is a `ScienceTheme` resource or not.  When the resource is a `ScienceTheme` resource, however, the display may be a little different.  Previously, the Landing Page Service code would only display dynamic search results for `ScienceTheme` records.  This PR fixes this.  

This PR also includes some changes to the `NERDResource` class.  Previously (on my advice), we moved a `selectAccessPages()` function from the `ResourceDataComponent` class to the `NERDResource` class; however, on closer inspection, that function included some manipulations specific to the `ResourceDataComponent`.  (More specifically, it annotated each selected component with some extra properties used for display.)  This PR splits this implementation between the two classes.  In addition, I've updated the `NERDResource` select functions to use its internal type matching functions to make it more robust.  
