### PR TITLE
LPS: fix setMenuPosition() exception preventing editing

### DIFF
--- a/angular/src/app/landing/landingpage.component.ts
+++ b/angular/src/app/landing/landingpage.component.ts
@@ -89,8 +89,8 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
     dialogOpen: boolean = false;
     modalReference: any;
     windowScrolled: boolean = false;
-    btnPosition: any;
-    menuPosition: any;
+    btnPosition: number = 20;
+    menuPosition: number = 20;
     menuBottom: string = "1em";
     showMetrics: boolean = false;
     recordType: string = "";
@@ -466,10 +466,12 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
             .subscribe((state: BreakpointState) => {
                 if (state.matches) {
                     this.mobileMode = false;
-                    this.menuPosition = this.menuElement.nativeElement.offsetTop + 20;
+                    if (this.menuElement)
+                        this.menuPosition = this.menuElement.nativeElement.offsetTop + 20;
                 } else {
                     this.mobileMode = true;
-                    this.btnPosition = this.btnElement.nativeElement.offsetTop + 20;
+                    if (this.btnElement)
+                        this.btnPosition = this.btnElement.nativeElement.offsetTop + 20;
                 }
             });
         }


### PR DESCRIPTION
The Landing Page Service fails to enter editing mode due to an exception in the `LandingPageComponent`'s `setMenuPosition()` function.  It was apparently getting called before the DOM was fully set for the child elements it needed access to; as a result, the function threw an exception when attempting to access a property of the undefined element.  This PR seems to fix the problem and do the right thing: adjusting the menu position as the page transitions between mobile and desktop modes.  