### PR TITLE
Fixed keyword filter issue.

### DIFF
--- a/angular/src/app/landing/filters/filters.component.ts
+++ b/angular/src/app/landing/filters/filters.component.ts
@@ -114,7 +114,7 @@ export class FiltersComponent implements OnInit {
     forensicsNodeExpanded: boolean = true;
     comheight: string = '50px'; // parent div height
     comwidth: string;  // parent div width
-    maxDropdownLabelLength: number = 30;
+    dropdownLabelLengthLimit: number = 30;
 
     filterStyle = {'width':'100%', 'background-color': '#FFFFFF','font-weight': '400','font-style': 'italic'};
 
@@ -580,42 +580,68 @@ export class FiltersComponent implements OnInit {
      * suggestedKeywordsLkup - stores the real ketwords
      * @param event - search query that user typed into the keyword filter box
      */
-    updateSuggestedKeywords(event: any) {
+     updateSuggestedKeywords(event: any) {
         let keyword = event.query;
-        let keywordAbbr: string;
         this.suggestedKeywords = [];
         this.suggestedKeywordsLkup = {};
 
+        // Handle current keyword: update suggested keywords and lookup
         for (let i = 0; i < this.keywords.length; i++) {
             let keyw = this.keywords[i].trim();
             if (keyw.toLowerCase().indexOf(keyword.toLowerCase()) >= 0) {
-                //If the keyword length is greater than the maximum length, we want to truncate
-                //it so that the length is close the maximum length.
-                if(keyw.length > this.maxDropdownLabelLength){
-                    let wordCount = 1;
-                    while(keyw.split(' ', wordCount).join(' ').length < this.maxDropdownLabelLength) {
-                        wordCount++;
-                    }
-
-                    keywordAbbr = keyw.substring(0, keyw.split(' ', wordCount).join(' ').length);
-                    if(keywordAbbr.trim().length < keyw.length) keywordAbbr = keywordAbbr + "...";
-                }else    
-                    keywordAbbr = keyw;
-
-                let i = 1;
-                let tmpKeyword = keywordAbbr;
-                while(Object.keys(this.suggestedKeywordsLkup).indexOf(tmpKeyword) >= 0 && i < 100){
-                    tmpKeyword = keywordAbbr + "(" + i + ")";
-                    i++;
-                }
-                keywordAbbr = tmpKeyword;
-
-                this.suggestedKeywords.push(keywordAbbr);
-                this.suggestedKeywordsLkup[keywordAbbr] = keyw;
+                this.suggestedKeywords.push(this.shortenKeyword(keyw));
+                this.suggestedKeywordsLkup[this.shortenKeyword(keyw)] = keyw;
             }
         }
 
+        // Handle selected keyword: update suggested keywords lookup. Lookup array must cover all selected keywords.
+        this.selectedKeywords.forEach(kw => {
+            for (let i = 0; i < this.keywords.length; i++) {
+                let keyw = this.keywords[i].trim();
+                if (keyw.toLowerCase().indexOf(kw.toLowerCase()) >= 0) {
+                    this.suggestedKeywordsLkup[this.shortenKeyword(keyw)] = keyw;
+                }
+            }
+        })
+
         this.suggestedKeywords = this.sortAlphabetically(this.suggestedKeywords);
+    }
+
+    /**
+     * Some keywords are very long. They cause problem when display both in suggested keyword list or 
+     * selected keyword list. This function returns the first few words of the input keyword. The length 
+     * of the return string is based on this.dropdownLabelLengthLimit but not exactly. 
+     * If the length of the input keyword is less than dropdownLabelLengthLimit, the input keyword will be returned.
+     * Otherwise, It selects the first few words whose total length is just exceed the length limit followed by "...".
+     * @param keyword 
+     * @returns Keyword abbreviate
+     */
+     shortenKeyword(keyword: string) {
+        let keywordAbbr: string;
+
+        //If the keyword length is greater than the maximum length, we want to truncate
+        //it so that the length is close the maximum length.
+
+        if(keyword.length > this.dropdownLabelLengthLimit){
+            let wordCount = 1;
+            while(keyword.split(' ', wordCount).join(' ').length < this.dropdownLabelLengthLimit) {
+                wordCount++;
+            }
+
+            keywordAbbr = keyword.substring(0, keyword.split(' ', wordCount).join(' ').length);
+            if(keywordAbbr.trim().length < keyword.length) keywordAbbr = keywordAbbr + "...";
+        }else    
+            keywordAbbr = keyword;
+
+        let i = 1;
+        let tmpKeyword = keywordAbbr;
+        while(Object.keys(this.suggestedKeywordsLkup).indexOf(tmpKeyword) >= 0 && i < 100){
+            tmpKeyword = keywordAbbr + "(" + i + ")";
+            i++;
+        }
+        keywordAbbr = tmpKeyword;
+
+        return keywordAbbr;
     }
 
     /**

--- a/angular/src/app/landing/resultlist/resultlist.component.ts
+++ b/angular/src/app/landing/resultlist/resultlist.component.ts
@@ -419,13 +419,19 @@ export class ResultlistComponent implements OnInit {
 
                         break;
                     case "keyword":
+                        // Loop through each keyword in each search result. Display those that match
+                        // the keywords from keyword filter
                         this.searchResults.forEach((object) => {
                             if(object.active == true){
                                 object.active = false;
                             
                                 object["keyword"].forEach((keyword) => {
-                                        if(keyword.includes(filter.split("=")[1]))
-                                        object.active = true;
+                                    //Loop through each search keyword from keyword filter
+                                    filter.split("=")[1].split(",").forEach(kw => {
+                                        if(keyword.includes(kw)){
+                                            object.active = true;
+                                        }
+                                    })   
                                 })
                             }
                         });

--- a/angular/src/app/landing/topic/topic.component.ts
+++ b/angular/src/app/landing/topic/topic.component.ts
@@ -50,7 +50,7 @@ export class TopicComponent implements OnInit {
     ngOnInit() {
         if(this.record) {
             this.recordType = (new NERDResource(this.record)).resourceLabel();
-            console.log('this.recordType', this.recordType);
+
             if(this.recordType == "Science Theme") {
                 this.fieldName = "topic";
                 this.record['topic'].forEach(topic => {


### PR DESCRIPTION
This check in fixed following issues:

1. When user selected more than one keyword in the keyword filter, nothing showed up in the search result. 
2. After above fixed, when user selected two keywords in the keyword filter then removed one of them, the search result will be empty.

#1 was because that the search string was not parsed. In SDP, it was parsed in the server side but here we need to parse it in the memory.

#2 was because the suggested keyword lookup table only contained the suggested keywords of latest selected keyword. Once it was removed, the app was unable to locate the original keywords for search.

To test, run the app locally and browse http://localhost:4200/od/id/mds9911. 