### PR TITLE
Fixed app error when there is no theme field in nerdm record

### DIFF
--- a/angular/src/app/landing/topic/topic.component.ts
+++ b/angular/src/app/landing/topic/topic.component.ts
@@ -62,7 +62,8 @@ export class TopicComponent implements OnInit {
                 });
             }else{
                 this.fieldName = "theme";
-                this.nistTaxonomyTopics = this.record[this.fieldName];
+                if(this.record[this.fieldName] != undefined)
+                    this.nistTaxonomyTopics = this.record[this.fieldName];
             }
         }
     }


### PR DESCRIPTION
http://mml.nist.gov:8080/browse/ODD-1051

This checkin fixes the problem that the landing page fails to load if the nerdm record does not have a "theme" field.

To test it locally, run the app with useMetadataService: true and useCustomizationService: true in environment.ts then browse the following url:

http://localhost:4200/od/id/75C6467F8B205670E05324570681995A1967

Or test it in local docker.