### PR TITLE
Fix/odd1057 reposition facilitators

### DIFF
--- a/angular/src/app/landing/aboutdataset/aboutdataset.component.html
+++ b/angular/src/app/landing/aboutdataset/aboutdataset.component.html
@@ -19,11 +19,6 @@
   </ng-template>
 </div>
 
-<!-- Facilitators -->
-<div *ngIf="theme == scienceTheme" style="width: 100%;" [ngStyle]="{'margin-bottom': record.creators? '15px' : '2em'}">
-    <app-facilitators [record]="record" [inBrowser]="inBrowser"></app-facilitators>
-</div>
-
 <!-- Collection creators -->
 <div *ngIf="record.creators" style="padding-right: 10pt; margin-bottom: 1em"> 
     <b>Collection creators: </b>

--- a/angular/src/app/landing/facilitators/facilitators.component.html
+++ b/angular/src/app/landing/facilitators/facilitators.component.html
@@ -4,7 +4,6 @@
             <div class="editable_field" style="max-width:calc(100% - 4em);"
                 [ngStyle]="getFieldStyle()">
                 <span *ngIf="record['facilitators']">
-                    <b>Facilitator: </b>
                     <span *ngFor="let facilitator of record.facilitators; let i = index" (click)="openModal()">
                         {{facilitator.fn.trim()}}<span *ngIf="i < record.facilitators.length-1; else theEnd">,</span><ng-template #theEnd>..</ng-template>
                     </span>

--- a/angular/src/app/landing/sections/resourceidentity.component.html
+++ b/angular/src/app/landing/sections/resourceidentity.component.html
@@ -11,6 +11,11 @@
              title="view collection">{{isPartOf[2]}}</a> {{isPartOf[3]}}</i>
         </div>
         <app-author [record]="record" [inBrowser]="inBrowser"></app-author>
+
+        <!-- Facilitators -->
+        <div *ngIf="theme == scienceTheme" style="width: 100%;" [ngStyle]="{'margin-bottom': record.creators? '15px' : '1.5em'}">
+            <app-facilitators [record]="record" [inBrowser]="inBrowser"></app-facilitators>
+        </div>
     </div>
     
     <div class="col-8 col-md-8 col-lg-8 col-sm-12">


### PR DESCRIPTION
This is for ODD-1057 http://mml.nist.gov:8080/browse/ODD-1057.

For science theme, facilitator list moved to the top, under the title. The label "Facilitators" was removed.

To test, run it locally and test:
1. Science theme record: http://localhost:4200/od/id/mds9911
Make sure the facilitator list shows up under the title "NIST Forensics Research Data". And the list is removed from "About this Collection" section.

<img width="838" alt="Screen Shot 2022-07-20 at 3 43 49 PM" src="https://user-images.githubusercontent.com/44069356/180069148-a209cad1-0175-403d-8f40-b5ae490a2a9c.png">
<img width="966" alt="Screen Shot 2022-07-20 at 3 45 14 PM" src="https://user-images.githubusercontent.com/44069356/180069170-26fc0ad8-a7d0-4b7b-b58b-4c5a51700fa1.png">


2. Regular record: http://localhost:4200/od/id/mds2-2388
Make sure facilitator list do not show up in the landing page. Only author list under the title.



