### PR TITLE
Handle record that has no component - caused filter to fail

### DIFF
--- a/angular/src/app/landing/filters/filters.component.ts
+++ b/angular/src/app/landing/filters/filters.component.ts
@@ -473,11 +473,6 @@ export class FiltersComponent implements OnInit {
             if(lFilterString != '') lFilterString += "&";
             lFilterString += "topic.tag=";
 
-            // if(!hasDefaultTheme)
-            //     lFilterString += "topic.tag=";
-            // else
-            //     lFilterString += ",";
-
             for (let theme of this.forensicsSelectedThemesNode) {
                 if (theme != 'undefined' && typeof theme.data !== 'undefined' && theme.data !== 'undefined') {
                     themeSelected = true;

--- a/angular/src/app/landing/resultlist/resultlist.component.ts
+++ b/angular/src/app/landing/resultlist/resultlist.component.ts
@@ -392,15 +392,19 @@ export class ResultlistComponent implements OnInit {
                         break;
                     case "components.@type":
                         this.searchResults.forEach((object) => {
-                            if(object.active == true){
-                                object.active = false;
-                            
-                                object["components"].forEach((component) => {
-                                    component["@type"].forEach((cType) => {
-                                        if(cType.includes(filter.split("=")[1]))
-                                        object.active = true;
+                            if(object["components"] != undefined) {
+                                if(object.active == true){
+                                    object.active = false;
+    
+                                    object["components"].forEach((component) => {
+                                        component["@type"].forEach((cType) => {
+                                            if(cType.includes(filter.split("=")[1]))
+                                                object.active = true;
+                                        })
                                     })
-                                })
+                                }
+                            }else {
+                                object.active = false;
                             }
                         });
 
@@ -410,10 +414,8 @@ export class ResultlistComponent implements OnInit {
                             if(object.active == true){
                                 object.active = false;
                             
-                                // object["contactPoint"].forEach((contactPoint) => {
-                                    if(object["contactPoint"]["fn"].includes(filter.split("=")[1]))
-                                        object.active = true;
-                                // })
+                                if(object["contactPoint"]["fn"].includes(filter.split("=")[1]))
+                                    object.active = true;
                             }
                         });
 


### PR DESCRIPTION
Problem: when select "Record has" item in Science Theme collection, we got this error:

![Screen Shot 2022-07-25 at 12 04 44 PM](https://user-images.githubusercontent.com/44069356/180824168-3313a28a-9f05-4855-88e1-76a835beb5c3.png)

Root cause: There is one record with no "components" field.

Solution: Fixed logic to skip the record that has no "components" field.

Test: Run it locally and browse http://localhost:4200/od/id/mds9911. Click on any of the three items under "Record has" in the filters section. Make sure the right side result list display the same number of files as indicated in the filter side.

 