### PR TITLE
Modified science theme label

### DIFF
--- a/angular/src/app/landing/aboutdataset/aboutdataset.component.spec.ts
+++ b/angular/src/app/landing/aboutdataset/aboutdataset.component.spec.ts
@@ -123,7 +123,7 @@ describe('AboutdatasetComponent', () => {
         expect(el.innerHTML.includes("This dataset is part of")).toBeTruthy();
         let li = el.querySelectorAll("ul li");
         expect(li.length).toEqual(2);
-        expect(li[0].innerHTML.includes(" Science Theme ")).toBeTruthy();
+        expect(li[0].innerHTML.includes(" Collection ")).toBeTruthy();
         let html = li[1].innerHTML
         expect(li[1].innerHTML.includes("Science Theme")).toBeFalsy();
         expect(li[1].innerHTML.endsWith("collection ")).toBeFalsy();

--- a/angular/src/app/landing/aboutdataset/aboutdataset.component.ts
+++ b/angular/src/app/landing/aboutdataset/aboutdataset.component.ts
@@ -104,7 +104,7 @@ export class AboutdatasetComponent implements OnChanges {
                     title = coll['title'];
                     if (NERDResource.objectMatchesTypes(coll, "ScienceTheme")) {
                         article = "the";
-                        suffix = " Science Theme";
+                        suffix = " Collection";
                     }
                 }
                 this.isPartOf.push([

--- a/angular/src/app/landing/sections/resourceidentity.component.html
+++ b/angular/src/app/landing/sections/resourceidentity.component.html
@@ -2,7 +2,7 @@
     <div class="col-12 col-md-12 col-lg-12 col-sm-12">
         <span class="recordType">
             <b>{{recordType}}</b>
-            <span *ngIf="recordType=='Science Theme'" class="badge version"> Beta</span>
+            <span *ngIf="recordType=='Science Theme Collection'" class="badge version"> Beta</span>
         </span>
         <br>
         <app-title [record]="record" [inBrowser]="inBrowser"></app-title>

--- a/angular/src/app/landing/sections/resourceidentity.component.spec.ts
+++ b/angular/src/app/landing/sections/resourceidentity.component.spec.ts
@@ -164,7 +164,7 @@ describe('ResourceIdentityComponent', () => {
         let el = cmpel.querySelector("#ispartof");
         expect(el).toBeTruthy();
         expect(el.querySelector("ul")).toBeFalsy();
-        expect(el.innerHTML.includes(" Science Theme")).toBeTruthy();
+        expect(el.innerHTML.includes(" Collection")).toBeTruthy();
         let a = el.querySelector("a");
         expect(a).toBeTruthy();
         expect(a.href.endsWith("/ark:/88888/goobler")).toBeTruthy();

--- a/angular/src/app/landing/sections/resourceidentity.component.ts
+++ b/angular/src/app/landing/sections/resourceidentity.component.ts
@@ -91,7 +91,7 @@ export class ResourceIdentityComponent implements OnChanges {
                 title = coll['title']
                 suffix = "Collection";
                 if (NERDResource.objectMatchesTypes(coll, "ScienceTheme"))
-                    suffix = "Science Theme";
+                    suffix = "Collection";
             }
            
             this.isPartOf = [

--- a/angular/src/app/nerdm/nerdm.spec.ts
+++ b/angular/src/app/nerdm/nerdm.spec.ts
@@ -218,7 +218,7 @@ describe('NERDResource', function() {
         expect(nrdl.resourceLabel()).toEqual("Public Data Resource")
 
         nrdl.data['@type'][0] = "nrda:ScienceTheme"
-        expect(nrdl.resourceLabel()).toEqual("Science Theme")
+        expect(nrdl.resourceLabel()).toEqual("Science Theme Collection")
     });
 
 

--- a/angular/src/app/nerdm/nerdm.ts
+++ b/angular/src/app/nerdm/nerdm.ts
@@ -286,7 +286,7 @@ export class NERDResource {
                 case 'nrdp:PublicDataResource':
                     return "Public Data Resource";
                 case 'nrda:ScienceTheme':
-                    return "Science Theme";
+                    return "Science Theme Collection";
             }
         }
 


### PR DESCRIPTION
http://mml.nist.gov:8080/browse/ODD-1059

Detail changes:
  For Science Theme landing page
  At top of page,  Resource type label => Science Theme Collection

  On each Dataset page, change text for
  Part of the .... "[science theme name] Collection" both at the top and then About this Collection section
  example:  Part of the [Forensic Science Data](https://oardev.nist.gov/od/id/md) Collection

To test: run it locally and use http://localhost:4200/od/id/mds9911. Make sure it displays "Science Theme Collection" on top of the screen:
![Screen Shot 2022-08-11 at 11 28 10 AM](https://user-images.githubusercontent.com/44069356/184171241-fa32f1a9-722e-427e-8e67-85d4a59dc0cc.png)

Then click on any of the data files. In the new tab, change "data.nist.gov" to "localhost:4200". Make sure you see "Part of the Forensics Science Data Collection" at both top of the screen and the "About this Dataset" section at the bottom:

![Screen Shot 2022-08-11 at 11 31 16 AM](https://user-images.githubusercontent.com/44069356/184171846-775c06d9-ca50-4afa-9a2b-eb0ffe42f3ac.png)

![Screen Shot 2022-08-11 at 11 33 21 AM](https://user-images.githubusercontent.com/44069356/184172234-5225d3f3-3fda-4376-bedf-ea6025480f62.png)

