### PR TITLE
LPS: add title heading to dataset listing

### DIFF
--- a/angular/src/app/landing/searchresult/searchresult.component.html
+++ b/angular/src/app/landing/searchresult/searchresult.component.html
@@ -1,5 +1,7 @@
 <div #parentDiv style="background-color: white; color: black;align-content: center;width: 100%;"  (window:resize)="onResize($event)">
-    <div style="width: 100%; margin-top: 1em;" [ngStyle]="{'display': mobileMode? 'block':'flex'}">
+    <div style="margin-bottom: 0.25em; color: var(--bs-body-color)"><b id="datasetlist-heading">Datasets in this collection </b> </div>
+  
+    <div style="width: 100%; margin-top: 0em;" [ngStyle]="{'display': mobileMode? 'block':'flex'}">
         <!-- Left side filters -->
         <div [@filterStatus]="filterToggler" style="vertical-align: top;" [ngStyle]="{'width': filterWidthStr}">
                 <app-filters [md]="record" [searchValue]='searchValue' [searchTaxonomyKey]='searchTaxonomyKey' [filterWidthNum]="filterWidth" [parent]="parentDiv" [mobileMode]="mobileMode" (filterMode)="updateWidth($event)" (filterString)="updateFilterString($event)"></app-filters>

--- a/angular/src/app/landing/searchresult/searchresult.component.spec.ts
+++ b/angular/src/app/landing/searchresult/searchresult.component.spec.ts
@@ -53,4 +53,10 @@ describe('SearchresultComponent', () => {
     it('should create', () => {
         expect(component).toBeTruthy();
     });
+
+    it('Should have title', () => {
+        expect(fixture.nativeElement.querySelectorAll('#datasetlist-heading').length).toEqual(1);
+        expect(fixture.nativeElement.querySelector('#datasetlist-heading').innerText)
+            .toEqual('Datasets in this collection');
+    });
 });


### PR DESCRIPTION
This PR places a heading title for a science theme dataset listing, analogous to the "Files" heading above the file listing on a regular landing page.  