### PR TITLE
Fixed metrics url; Collapse filter when science theme landing page open

### DIFF
--- a/angular/src/app/landing/landingpage.component.ts
+++ b/angular/src/app/landing/landingpage.component.ts
@@ -131,7 +131,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
                 public metricsService: MetricsService,
                 public breakpointObserver: BreakpointObserver) 
     {
-        this.reqId = this.requestedIDfromRoute(this.route);
+        this.reqId = this.requestedIDfromRoute(this.route).replace('ark:/88434/', '');
         this.inBrowser = isPlatformBrowser(platformId);
         this.editEnabled = cfg.get('editEnabled', false) as boolean;
         this.editMode = this.EDIT_MODES.VIEWONLY_MODE;

--- a/angular/src/app/landing/resultlist/resultlist.component.ts
+++ b/angular/src/app/landing/resultlist/resultlist.component.ts
@@ -81,7 +81,7 @@ export class ResultlistComponent implements OnInit {
                     this.resultCount = searchResults['ResultCount'];
                     that.onSuccess(searchResults.ResultData);
                 },
-                error => that.onError(error)
+                error => that.onError(urls[i], error)
             );
         }
     }
@@ -217,8 +217,8 @@ export class ResultlistComponent implements OnInit {
     /**
      * If search is unsuccessful push the error message
      */
-    onError(error: any) {
-        console.error("Search URL failed to resolve: "+error.error);
+    onError(url: string, error: any) {
+        console.error("Search URL ("+url+") failed to resolve: "+error.message);
     }
 
     /**

--- a/angular/src/app/landing/searchresult/searchresult.component.html
+++ b/angular/src/app/landing/searchresult/searchresult.component.html
@@ -1,5 +1,7 @@
 <div #parentDiv style="background-color: white; color: black;align-content: center;width: 100%;"  (window:resize)="onResize($event)">
-    <div style="width: 100%; margin-top: 1em;" [ngStyle]="{'display': mobileMode? 'block':'flex'}">
+    <div *ngIf="inBrowser" style="width: 100%; margin-top: 1em;"
+         [ngStyle]="{'display': mobileMode? 'block':'flex'}">
+
         <!-- Left side filters -->
         <div [@filterStatus]="filterToggler" style="vertical-align: top;" [ngStyle]="{'width': filterWidthStr}">
                 <app-filters [md]="record" [searchValue]='searchValue' [searchTaxonomyKey]='searchTaxonomyKey' [filterWidthNum]="filterWidth" [parent]="parentDiv" [mobileMode]="mobileMode" (filterMode)="updateWidth($event)" (filterString)="updateFilterString($event)"></app-filters>

--- a/angular/src/app/landing/searchresult/searchresult.component.ts
+++ b/angular/src/app/landing/searchresult/searchresult.component.ts
@@ -20,7 +20,7 @@ export class SearchresultComponent implements OnInit {
     mobHeight: number;
     mobWidth: number;
     mobileMode: boolean = false; // set mobile mode to true if window width < 641
-    filterWidth: number;
+    filterWidth: number = 30;
     filterWidthStr: string;
     filterMode: string = "normal";
     resultWidth: any;

--- a/angular/src/app/shared/metrics-service/metrics.service.ts
+++ b/angular/src/app/shared/metrics-service/metrics.service.ts
@@ -14,11 +14,13 @@ export class MetricsService {
         private http: HttpClient, ) { 
 
         this.metricsBackend = cfg.get("APIs.metrics", "/unconfigured");
+        //If last character is not '/', add it. Otherwise all url will fail.
+        if(this.metricsBackend.slice(-1) != '/') this.metricsBackend += '/';
     }
 
     getFileLevelMetrics(ediid: string): Observable<any> {
         let url = this.metricsBackend + "files?exclude=_id&include=ediid,filepath,success_get,download_size&ediid=" + ediid;
-
+        console.log("metrics url", url)
         const request = new HttpRequest(
             "GET", url, 
             { headers: new HttpHeaders({ 'Content-Type': 'application/json', 'responseType': 'blob' }), reportProgress: true, responseType: 'blob' });

--- a/angular/src/app/shared/searchfields-list/searchfields-list.service.ts
+++ b/angular/src/app/shared/searchfields-list/searchfields-list.service.ts
@@ -20,7 +20,7 @@ export class SearchfieldsListService {
   constructor(private http: HttpClient,
     private appConfig: AppConfig,
     private cfg: AppConfig) {
-      this.RMMAPIURL = cfg.get("API.mdSearch", "/unconfigured");
+      this.RMMAPIURL = cfg.get("APIs.mdSearch", "/unconfigured");
     }
 
     ngOnInit(): void {

--- a/angular/src/app/shared/searchfields-list/searchfields-list.service.ts
+++ b/angular/src/app/shared/searchfields-list/searchfields-list.service.ts
@@ -20,7 +20,7 @@ export class SearchfieldsListService {
   constructor(private http: HttpClient,
     private appConfig: AppConfig,
     private cfg: AppConfig) {
-      this.RMMAPIURL = cfg.get("locations.mdService", "/unconfigured");
+      this.RMMAPIURL = cfg.get("API.mdSearch", "/unconfigured");
     }
 
     ngOnInit(): void {


### PR DESCRIPTION
Fixed the following two issues:
1. The link to metrics page broken: fix: treat /pdr/metrics/mds2-XXXX and /pdr/metrics/ark:/88434/mds2-XXXX the same.
2. Need to collapse the filter panel when science theme page first open.

mds2-2157 can be used to test metrics fix.