### PR TITLE
Display calculated total download size

### DIFF
--- a/angular/src/app/landing/landingpage.component.ts
+++ b/angular/src/app/landing/landingpage.component.ts
@@ -71,6 +71,8 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
     displaySpecialMessage: boolean = false;
     citationDialogWith: number = 550; // Default width
     recordLevelMetrics : RecordLevelMetrics;
+    fileLevelData: any;
+    datasetSize: number = 0;
 
     loadingMessage = '<i class="faa faa-spinner faa-spin"></i> Loading...';
 
@@ -337,11 +339,11 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
                                 //Now check if there is any metrics data
                                 this.metricsData.totalDatasetDownload = this.recordLevelMetrics.DataSetMetrics[0] != undefined? this.recordLevelMetrics.DataSetMetrics[0].record_download : 0;
                 
-                                this.metricsData.totalDownloadSize = this.recordLevelMetrics.DataSetMetrics[0] != undefined? this.recordLevelMetrics.DataSetMetrics[0].total_size : 0;
+                                this.metricsData.totalDownloadSize = this.recordLevelMetrics.DataSetMetrics[0] != undefined? this.recordLevelMetrics.DataSetMetrics[0].record_download * this.datasetSize : 0;
                     
                                 this.metricsData.totalUsers = this.recordLevelMetrics.DataSetMetrics[0] != undefined? this.recordLevelMetrics.DataSetMetrics[0].number_users : 0;
                         
-                                this.metricsData.totalUsers = this.metricsData.totalUsers == undefined? 0 : this.metricsData.totalUsers;                                    
+                                this.metricsData.totalUsers = this.metricsData.totalUsers == undefined? 0 : this.metricsData.totalUsers;  
                             }
 
                             this.metricsData.dataReady = true;
@@ -506,6 +508,13 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
      *  * set the page's title (as displayed in the browser title bar).
      */
     useMetadata(): void {
+        //Calculate the size of the dataset
+        this.md.components.forEach( (comp) => {
+            if(comp.size != undefined){
+                this.datasetSize += comp.size;
+            }
+        })
+
         this.metricsData.url = "/metrics/" + this.reqId;
         this.recordType = (new NERDResource(this.md)).resourceLabel();
 

--- a/angular/src/app/metrics/metrics.component.ts
+++ b/angular/src/app/metrics/metrics.component.ts
@@ -509,22 +509,30 @@ export class MetricsComponent implements OnInit {
      * Get total recordset level download size
      */
     get totalDownloadSize() {
-        if(this.recordLevelData.DataSetMetrics[0] != undefined){
-            return this.commonFunctionService.formatBytes(this.recordLevelData.DataSetMetrics[0].total_size, 2);
-        }else{
-            return ""
-        }
+        return this.commonFunctionService.formatBytes(this.totalDownloadSizeInByte, 2);
+        // if(this.recordLevelData.DataSetMetrics[0] != undefined){
+        //     return this.commonFunctionService.formatBytes(this.recordLevelData.DataSetMetrics[0].total_size, 2);
+        // }else{
+        //     return ""
+        // }
     }
 
     /**
      * Get total recordset level download size in bytes
      */
     get totalDownloadSizeInByte() {
-        if(this.recordLevelData.DataSetMetrics[0] != undefined){
-            return this.recordLevelData.DataSetMetrics[0].total_size;
-        }else{
-            return ""
+        let totalDownload = 0;
+        if(this.fileLevelData != undefined) {
+            this.fileLevelData.FilesMetrics.forEach( (file) => {
+                totalDownload += file.success_get * file.download_size;
+            });
         }
+
+        if(this.recordLevelData != undefined) {
+            totalDownload += this.recordLevelData.DataSetMetrics[0].record_download * this.totalFileSize;
+        }
+
+        return totalDownload;
     }
 
      /**

--- a/angular/src/app/shared/metrics-service/metrics.service.ts
+++ b/angular/src/app/shared/metrics-service/metrics.service.ts
@@ -14,6 +14,10 @@ export class MetricsService {
         private http: HttpClient, ) { 
 
         this.metricsBackend = cfg.get("APIs.metrics", "/unconfigured");
+        if (this.metricsBackend == "/unconfigured")
+        throw new Error("APIs.metrics endpoint not configured!");
+
+        if (! this.metricsBackend.endsWith("/")) this.metricsBackend += "/"
     }
 
     getFileLevelMetrics(ediid: string): Observable<any> {

--- a/angular/src/app/shared/search-service/search-service.service.ts
+++ b/angular/src/app/shared/search-service/search-service.service.ts
@@ -45,12 +45,13 @@ export class SearchService {
         this.rmmBackend = cfg.get("APIs.mdSearch", "/unconfigured");
         if (this.rmmBackend == "/unconfigured")
             throw new Error("APIs.mdSearch endpoint not configured!");
+
+        if (! this.rmmBackend.endsWith("/")) this.rmmBackend += "/"
         this.portalBase = cfg.get("locations.portalBase", "/unconfigured");
     }
 
     searchById(searchValue: string, browserside: boolean = false) {
         let backend: string = this.rmmBackend
-        if (! backend.endsWith("/")) backend += "/"
 
         if (searchValue.startsWith('ark:'))
             backend += 'records?@id=';


### PR DESCRIPTION
http://mml.nist.gov:8080/browse/ODD-1064

This fix calculates the total download size from total number of dataset downloads and total number of file downloads. Then display the calculated number instead of the number from metadata.

To test locally, set useMetadataService: true, useCustomizationService: true, and editEnabled: false in environment.ts. 
