### PR TITLE
LPS: TopicComponent: guard against missing topic/theme properties

### DIFF
--- a/angular/src/app/landing/topic/topic.component.ts
+++ b/angular/src/app/landing/topic/topic.component.ts
@@ -67,17 +67,23 @@ export class TopicComponent implements OnInit {
             this.scienceThemeTopics = [];
             this.nistTaxonomyTopics = [];
 
-            this.record['topic'].forEach(topic => {
-                if(topic['scheme'].indexOf(this.standardNISTTaxonomyURI) < 0){
-                    if(this.scienceThemeTopics.indexOf(topic.tag) < 0)
-                        this.scienceThemeTopics.push(topic.tag);
-                }
-            });
+            if (this.record['topic']) {
+                this.record['topic'].forEach(topic => {
+                    if (topic['scheme']) {
+                        if(topic['scheme'].indexOf(this.standardNISTTaxonomyURI) < 0){
+                            if(this.scienceThemeTopics.indexOf(topic.tag) < 0)
+                                this.scienceThemeTopics.push(topic.tag);
+                        }
+                    }
+                });
+            }
 
-            this.record['theme'].forEach(topic => {
-                if(this.nistTaxonomyTopics.indexOf(topic) < 0)
-                    this.nistTaxonomyTopics.push(topic);
-            });
+            if (this.record['theme']) {
+                this.record['theme'].forEach(topic => {
+                    if(this.nistTaxonomyTopics.indexOf(topic) < 0)
+                        this.nistTaxonomyTopics.push(topic);
+                });
+            }
         }
     }
 


### PR DESCRIPTION
This PR addresses ODD-1069 ("LPS: Topic component throws exception when scheme is missing") in which the implementation of `TopicComponent`'s `updateResearchTopics()` assumed the record has both `topic` and `theme` properties and that a `topic` always had a `scheme`.  This fixes the issue by adding guards that test for their existence.  