### PR TITLE
Align 'Sort by' dropdown box with page and search boxes

### DIFF
--- a/angular/src/app/landing/landingpage.component.html
+++ b/angular/src/app/landing/landingpage.component.html
@@ -46,7 +46,7 @@
                             (scroll)="goToSection($event)">
                         </tools-menu>
 
-                        <app-metricsinfo *ngIf="recordType!='Science Theme'" [inBrowser]="inBrowser" [record]="md"
+                        <app-metricsinfo *ngIf="theme != scienceTheme" [inBrowser]="inBrowser" [record]="md"
                             [metricsData]="metricsData" [showMetrics]="showMetrics">
                         </app-metricsinfo>
 

--- a/angular/src/app/landing/landingpage.component.ts
+++ b/angular/src/app/landing/landingpage.component.ts
@@ -93,7 +93,6 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
     menuPosition: number = 20;
     menuBottom: string = "1em";
     showMetrics: boolean = false;
-    recordType: string = "";
     imageURL: string;
     theme: string;
     scienceTheme = Themes.SCIENCE_THEME;
@@ -507,7 +506,6 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
      */
     useMetadata(): void {
         this.metricsData.url = "/metrics/" + this.reqId;
-        this.recordType = (new NERDResource(this.md)).resourceLabel();
 
         // set the document title
         this.setDocumentTitle();

--- a/angular/src/app/landing/resultlist/resultlist.component.html
+++ b/angular/src/app/landing/resultlist/resultlist.component.html
@@ -22,7 +22,7 @@
             <div class="td" style="width: 30px;padding-right: 5px;">
                 <p-dropdown [options]="options" [(ngModel)]="optionSelected" optionLabel="name"
                     (onChange)="onSortByChange($event)" placeholder="Sorted by"
-                    [style]="{'text-align': 'left', 'height':'35px','width': resultWidthNum > 500?'140px':'60px','margin-top':'4px','margin-bottom':'0px'}"></p-dropdown>
+                    [style]="{'text-align': 'left', 'height':'35px','vertical-align':'top','width': resultWidthNum > 500?'140px':'60px','margin-top':'-9px','margin-bottom':'0px'}"></p-dropdown>
             </div>
 
             <!-- Search text -->


### PR DESCRIPTION
http://mml.nist.gov:8080/browse/ODD-1071

This fix aligns 'Sort by' dropdown box with page and search boxes. The result should look like attached screenshots in both Chrome and Firefox.

![Screen Shot 2022-09-01 at 5 06 56 PM](https://user-images.githubusercontent.com/44069356/188013288-bef73e89-0274-453c-93ed-dc8a88c6bbc9.png)
