### PR TITLE
1.NIST topic list closes on start up. 2.Fixed filter logic.

### DIFF
--- a/angular/src/app/landing/filters/filters.component.ts
+++ b/angular/src/app/landing/filters/filters.component.ts
@@ -19,7 +19,7 @@ const SEARCH_SERVICE = 'SEARCH_SERVICE';
     providers: [TaxonomyListService, SearchfieldsListService],
     animations: [
         trigger('expand', [
-            state('closed', style({height: '40px'})),
+            state('closed', style({height: '50px'})),
             state('collapsed', style({height: '183px'})),
             state('expanded', style({height: '*'})),
             transition('expanded <=> collapsed', animate('625ms')),
@@ -112,7 +112,7 @@ export class FiltersComponent implements OnInit {
     isActive: boolean = true;
     filterClass: string;
     resultsClass: string;
-    nodeExpanded: boolean = true;
+    nodeExpanded: boolean = false;
     forensicsNodeExpanded: boolean = true;
     comheight: string = '50px'; // parent div height
     comwidth: string;  // parent div width
@@ -370,7 +370,7 @@ export class FiltersComponent implements OnInit {
 
         this.themesTree = [{
             label: 'NIST Research Topics -',
-            "expanded": true,
+            "expanded": false,
             children: this.themesWithCount
         }];
 

--- a/angular/src/app/landing/filters/filters.component.ts
+++ b/angular/src/app/landing/filters/filters.component.ts
@@ -71,7 +71,7 @@ export class FiltersComponent implements OnInit {
     uniqueThemes: string[] = [];
     themesWithCount: TreeNode[] = [];
     themesTree: TreeNode[] = [];
-    showMoreLink: boolean = false;
+    showMoreLink: boolean = true;
     selectedThemesNode: any[] = [];
     standardNISTTaxonomyURI: string = "https://data.nist.gov/od/dm/nist-themes/";
 
@@ -1053,12 +1053,6 @@ export class FiltersComponent implements OnInit {
                 label: sortable[key][0] + "-" + sortable[key][1],
                 data: sortable[key][0]
             });
-        }
-
-        if (sortable.length > 5) {
-            this.forensicsShowMoreLink = true;
-        } else {
-            this.forensicsShowMoreLink = false;
         }
     }
 

--- a/angular/src/app/landing/resultlist/resultlist.component.ts
+++ b/angular/src/app/landing/resultlist/resultlist.component.ts
@@ -366,8 +366,11 @@ export class ResultlistComponent implements OnInit {
                                 object.active = false;
 
                                 object["@type"].forEach((oType) => {
-                                    if(oType.includes(filter.split("=")[1]))
-                                        object.active = true;
+                                    let types = filter.split("=")[1].split(",");
+                                    types.forEach(type => {
+                                        if(oType.toLowerCase().includes(type.toLowerCase()))
+                                            object.active = true;
+                                    });
                                 })
                             } 
                         });
@@ -398,8 +401,11 @@ export class ResultlistComponent implements OnInit {
     
                                     object["components"].forEach((component) => {
                                         component["@type"].forEach((cType) => {
-                                            if(cType.includes(filter.split("=")[1]))
-                                                object.active = true;
+                                            let types = filter.split("=")[1].split(",");
+                                            types.forEach(type => {
+                                                if(cType.toLowerCase().includes(type.toLowerCase()))
+                                                    object.active = true;
+                                            });
                                         })
                                     })
                                 }


### PR DESCRIPTION
http://mml.nist.gov:8080/browse/ODD-1068

This checkin made following 2 changes:

1. In filters section on forensics landing page
   1) Expand forensics research topics
   2) Collapse completely NIST research topics
2. Fixed the issue that in "Type of resource" and "Record has" sections, selecting more than one item gets no result.

To test it locally, 
1. Set useMetadataService: true, useCustomizationService: true, editEnabled: false in environment.ts.
2. Change "data.nist.gov" to "oardev.nist.gov" in environment.ts.
3. browse http://localhost:4200/lps/pdr0-0001.