### PR TITLE
Made expansion symbols consistant; Added tooltip and alter text

### DIFF
--- a/angular/src/app/landing/author/author.component.html
+++ b/angular/src/app/landing/author/author.component.html
@@ -33,7 +33,7 @@
                         </ng-template>
                     </span>
                     <i style="margin-left: 0.5rem;" class="faa"
-                        [ngClass]="{'faa-plus-square-o': !clickAuthors, 'faa-minus-square-o': clickAuthors}"
+                        [ngClass]="{'faa-caret-right': !clickAuthors, 'faa-caret-down': clickAuthors}"
                         aria-hidden="true"
                         (click)="isCollapsedContent = !isCollapsedContent; clickAuthors = expandClick();"></i>
                 </div>

--- a/angular/src/app/landing/contact/contact.component.html
+++ b/angular/src/app/landing/contact/contact.component.html
@@ -15,11 +15,10 @@
                         {{record.contactPoint.fn}}</a>
                     <span *ngIf="!isEmail">{{record.contactPoint.fn}}</span>
                 </strong>..
-                <i style="cursor: pointer;" class="faa"
-                    [ngClass]="{'faa-plus-square-o': !clickContact, 'faa-minus-square-o': clickContact}"
-                    aria-hidden="true"
-                    (click)="closeContent = !closeContent; clickContact=expandContact();"></i>
-                <div [collapse]="!closeContent" class="card card-body bg-faded">
+                <i style="cursor: pointer; margin-left: 5px;" class="faa"
+                    [ngClass]="expandIconClass"
+                    aria-hidden="true" data-toggle="tooltip" [title]="expandButtonAlterText" [aria-label]="expandButtonAlterText" (click)="toggleExpand()"></i>
+                <div [collapse]="!contactExpanded" class="card card-body bg-faded">
                     <span class="" *ngIf="record.contactPoint.fn">
                         <span>{{record.contactPoint.fn}}</span>
                     </span>

--- a/angular/src/app/landing/contact/contact.component.ts
+++ b/angular/src/app/landing/contact/contact.component.ts
@@ -15,6 +15,9 @@ export class ContactComponent implements OnInit {
     @Input() record: any[];
     @Input() inBrowser: boolean;   // false if running server-side
     fieldName = 'contactPoint';
+    contactExpanded = false;
+    expandButtonAlterText: string = "Expand contact details";
+    expandIconClass: string = "faa-caret-right";
 
     tempInput: any = {};
     isEmail = false;
@@ -47,6 +50,12 @@ export class ContactComponent implements OnInit {
     ngOnInit() {
         if ("hasEmail" in this.record['contactPoint'])
             this.isEmail = true;
+    }
+
+    toggleExpand() {
+        this.contactExpanded = !this.contactExpanded;
+        this.expandIconClass = this.contactExpanded? "faa-caret-down" : "faa-caret-right";
+        this.expandButtonAlterText = this.contactExpanded? "Collapse contact details" : "Expand contact details";
     }
 
     getFieldStyle() {

--- a/angular/src/app/landing/facilitators/facilitators.component.css
+++ b/angular/src/app/landing/facilitators/facilitators.component.css
@@ -6,7 +6,6 @@
 
 .facilitator-detail {
     width: 100%; 
-    padding:.5em;
     overflow: hidden; 
     padding-left: 1em;
     background-color: rgb(243, 248, 253);

--- a/angular/src/app/landing/facilitators/facilitators.component.html
+++ b/angular/src/app/landing/facilitators/facilitators.component.html
@@ -7,13 +7,12 @@
                     <span *ngFor="let facilitator of record.facilitators; let i = index" (click)="openModal()">
                         {{facilitator.fn.trim()}}<span *ngIf="i < record.facilitators.length-1; else theEnd">,</span><ng-template #theEnd>..</ng-template>
                     </span>
-                    <i style="margin-left: 0.5rem;" class="faa"
-                        [ngClass]="{'faa-plus-square-o': !clickFacilitators, 'faa-minus-square-o': clickFacilitators}"
-                        aria-hidden="true"
-                        (click)="isCollapsedContent = !isCollapsedContent; clickFacilitators = expandClick();"></i>
+                    <i style="margin-left: 0.5rem; cursor: pointer;" class="faa"
+                        [ngClass]="expandIconClass" aria-hidden="true" data-toggle="tooltip" [title]="expandButtonAlterText" [aria-label]="expandButtonAlterText"
+                        (click)="toggleExpand()"></i>
                 </span>
 
-                <div [@detailExpand]="!isCollapsedContent ? 'expanded' : 'collapsed'" class="facilitator-detail">
+                <div [@detailExpand]="expanded ? 'expanded' : 'collapsed'" class="facilitator-detail">
                     <div class="facilitatorsdetail" *ngIf="record.facilitators">
                         <div *ngFor="let facilitator of record.facilitators; let i = index" style="padding-left: 1em;">
                             <div>

--- a/angular/src/app/landing/facilitators/facilitators.component.ts
+++ b/angular/src/app/landing/facilitators/facilitators.component.ts
@@ -7,9 +7,9 @@ import { trigger, state, style, animate, transition } from '@angular/animations'
     styleUrls: ['./facilitators.component.css'],
     animations: [
         trigger('detailExpand', [
-        state('collapsed', style({height: '0px', minHeight: '0', display: 'none'})),
+        state('collapsed', style({height: '0px', minHeight: '0'})),
         state('expanded', style({height: '*'})),
-        transition('expanded <=> collapsed', animate(625)),
+        transition('expanded <=> collapsed', animate('625ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
         //   transition('expanded <=> collapsed', animate('625ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
         ])
     ]
@@ -18,6 +18,9 @@ export class FacilitatorsComponent implements OnInit {
     facilitators: any[] = [];
     clickFacilitators: boolean = false;
     isCollapsedContent: boolean = true;
+    expandButtonAlterText: string = "Open dataset details";
+    expandIconClass: string = "faa-caret-right";
+    expanded = false;
 
     @Input() record: any[];
     @Input() inBrowser: boolean;   // false if running server-side
@@ -35,9 +38,14 @@ export class FacilitatorsComponent implements OnInit {
         return "";
     }
 
-    clicked = false;
-    expandClick() {
-        this.clicked = !this.clicked;
-        return this.clicked;
+    /**
+     * Toggle the visibility of the facilitator details;
+     * Set icon class for the expand button;
+     * Set expand button alter text.
+     */
+    toggleExpand() {
+        this.expanded = !this.expanded;
+        this.expandIconClass = this.expanded? "faa-caret-down" : "faa-caret-right";
+        this.expandButtonAlterText = this.expanded? "Close facilitator details" : "Open facilitator details";
     }
 }

--- a/angular/src/app/landing/resultlist/resultlist.component.html
+++ b/angular/src/app/landing/resultlist/resultlist.component.html
@@ -58,16 +58,14 @@
                 <a href="{{PDRAPIURL}}{{resultItem.ediid}}" target="_blank" class="title">
                     {{resultItem.title}}
                 </a>
-                <span>
-                    <div [attr.aria-label]="expandButtonAlterText" style="margin-left: .5em;cursor: pointer;width: 20px;height: 20px;background-size:cover;display: inline-block;"
-                        (click)="toggleDetails(resultItem, i)"
-                        [ngStyle]="{ 'background-image': 'url('+resultItem.iconurl+')','margin-bottom':'-4px'}"
-                        >
-                    </div>
+                <span style="margin-left: 5px;">
+                    <i [ngClass]="resultItem.expandIcon"
+                        style="cursor: pointer;color: #1471AE;" data-toggle="tooltip"
+                        [title]="expandButtonAlterText(resultItem)" [aria-label]="expandButtonAlterText(resultItem)" (click)="toggleDetails(resultItem, i)"></i>
                 </span>
             </div>
 
-            <div [@detailExpand]="resultItem.DetailsDisplayed ? 'expanded' : 'collapsed'" style="overflow: hidden;">
+            <div [@detailExpand]="resultItem.isExpanded ? 'expanded' : 'collapsed'" style="overflow: hidden;">
                 <div class="ui-grid-row" style="margin-bottom:.5em">
                     {{resultItem.description}}
                 </div>

--- a/angular/src/app/landing/resultlist/resultlist.component.ts
+++ b/angular/src/app/landing/resultlist/resultlist.component.ts
@@ -11,7 +11,7 @@ import { connectableObservableDescriptor } from 'rxjs/internal/observable/Connec
 @Component({
   selector: 'app-resultlist',
   templateUrl: './resultlist.component.html',
-  styleUrls: ['./resultlist.component.css'],
+  styleUrls: ['../landing.component.css', './resultlist.component.css'],
   animations: [
         trigger('detailExpand', [
         state('void', style({height: '0px', minHeight: '0'})),
@@ -44,12 +44,13 @@ export class ResultlistComponent implements OnInit {
     optionSelected: string;
     searchPhases: string = "";
     searchFields: string[] = ["title", "description", "keyword"];
-    showResult: boolean = true;
-    PDRAPIURL: string = "https://data.nist.gov/od/id/";
-    noSearchResult: boolean = false;
-    expandIcon: string = 'url(assets/images/open_200x200.png)';
+    PDRAPIURL: string = "https://data.nist.gov/lps/";
     isEmail: boolean = false;
-    expandButtonAlterText: string = "Open dataset details";
+
+    //Result display
+    showResult: boolean = true;
+    noSearchResult: boolean = false;
+    // expandButtonAlterText: string = "Open dataset details";
 
     //Pagination
     totalResultItems: number = 0;
@@ -106,8 +107,8 @@ export class ResultlistComponent implements OnInit {
      */
     onSuccess(searchResults: any[]) {
         searchResults.forEach((object) => {
-            object['DetailsDisplayed'] = false;
-            object['iconurl'] = 'assets/images/open_200x200.png';
+            object['expandIcon'] = "faa faa-caret-right";
+            object['isExpanded'] = false;
             object['active'] = true;
         })
 
@@ -152,47 +153,41 @@ export class ResultlistComponent implements OnInit {
     }
 
     /**
-     * Return the background image url of the icon next to the file name.
-     * If the details is hidden, display the "open" icon. Otherwise "close" icon.
-     * @returns 
-     */
-    detailExpandIcon(resultItem: any) {
-        let url;
-        if(resultItem.DetailsDisplayed){
-            url = 'url(assets/images/close_200x200.png)';
-        }else{
-            url = 'url(assets/images/open_200x200.png)';
-        }  
-
-        setTimeout(() => {
-            return url;
-        }, 0);
-    }
-
-    /**
      *  Expand the row to display file details. It's little tricky when hiding the details. 
      *  We have to delay the action to let the animation to finish. 
      * @param fileNode       the TreeNode for the file to provide details for
      */
     toggleDetails(fileNode: any, index: number) {
+        let currentFileNode = this.searchResultsForDisplay[this.currentIndex];
         //Close current details window if it's open
-        if(index != this.currentIndex && this.searchResultsForDisplay[this.currentIndex]) {
-            this.searchResultsForDisplay[this.currentIndex]['DetailsDisplayed'] = false;
-            this.searchResultsForDisplay[this.currentIndex]['iconurl'] = 'assets/images/open_200x200.png';
+        if(index != this.currentIndex && currentFileNode != undefined) {
+            currentFileNode.expandIcon = "faa faa-caret-right";
+            currentFileNode.isExpanded = false;
         }
+
         this.currentIndex = index;
 
-        if(fileNode.DetailsDisplayed){
-            fileNode.DetailsDisplayed = false;
-            fileNode.iconurl = 'assets/images/open_200x200.png';
-            this.expandButtonAlterText = "Open dataset details";
+        if(fileNode.isExpanded){
+            fileNode.isExpanded = false;
+            fileNode.expandIcon = "faa faa-caret-right";
         }else{
-            fileNode.DetailsDisplayed = true;
-            fileNode.iconurl = 'assets/images/close_200x200.png';
-            this.expandButtonAlterText = "Close dataset details";
+            fileNode.isExpanded = true;
+            fileNode.expandIcon = "faa faa-caret-down";            
         }
     }
 
+    /**
+     * This function returns alter text/tooltip text for the expand symbol next to the given treenode title
+     * @param fileNode the TreeNode
+     * @returns 
+     */
+    expandButtonAlterText(fileNode: any) {
+        if(fileNode.isExpanded)
+            return "Close dataset details";
+        else
+            return "Open dataset details";
+    }
+    
     /**
      * Return class name based on given column number and window size
      * @param column 
@@ -334,8 +329,8 @@ export class ResultlistComponent implements OnInit {
     resetResult() {
         if(this.searchResults) {
             this.searchResults.forEach((object) => {
-                object.DetailsDisplayed = false;
-                object.iconurl = 'assets/images/open_200x200.png';
+                object.expandIcon = "faa faa-caret-right";
+                object.isExpanded = false;
                 object.active = true;
             })
         }

--- a/angular/src/app/landing/sections/resourcedata.component.css
+++ b/angular/src/app/landing/sections/resourcedata.component.css
@@ -8,12 +8,11 @@
 }
 
 .description {
-    padding: 10px 10px 10px 0px;
+    padding: 10px 10px 0px 0px;
 }
 
 #accessPages {
     margin-top: 1em;
-    margin-bottom: .5em;
 }
 
 .indent-content {

--- a/angular/src/app/landing/sections/resourcedata.component.html
+++ b/angular/src/app/landing/sections/resourcedata.component.html
@@ -37,7 +37,7 @@
         <div *ngIf="accessPages.length > 0">
             <b>Data and related material can be found at the following locations:</b>
             <br>
-            <div [ngStyle]="{'margin-top': '10px', 'background-color': apage['backcolor']}"
+            <div [ngStyle]="{'padding-top': '10px', 'background-color': apage['backcolor']}"
                 *ngFor="let apage of accessPages" (mouseover)="apage['backcolor'] = '#f2f2f2'"
                 (mouseout)="apage['backcolor'] = 'white'">
                 <div class="indent-content"
@@ -53,13 +53,13 @@
                                                                 'Resource title: ' + record.title,
                                                                 apage['accessURL'])">&nbsp;&nbsp;{{apage['title']}}</a>
                             </ng-template>
-                        </span></i>
-                    <div *ngIf="apage['description']">
-                        <div style="cursor: pointer;color: #1471AE;" (click)="apage[showDesc] = !apage[showDesc]"><i
-                                class="faa faa-caret-right" *ngIf="!apage[showDesc]"></i><i class="faa faa-caret-down"
-                                *ngIf="apage[showDesc]"></i> About this link
-                        </div>
-                        <div class="description" *ngIf="apage[showDesc]" [@enterAnimation]>{{apage['description']}}
+                        </span>
+                    </i>
+                    <i style="margin-left: 0.5rem; cursor: pointer;" (click)="apage['showDesc'] = !apage['showDesc']" class="faa" [ngClass]="{'faa-caret-right': !apage['showDesc'], 'faa-caret-down': apage['showDesc']}" data-toggle="tooltip" [title]="expandButtonAlterText(apage)" [aria-label]="expandButtonAlterText(apage)">
+                    </i>
+
+                    <div *ngIf="apage['description']" class="description" >
+                        <div [@detailExpand]="apage['showDesc'] ? 'expanded' : 'collapsed'" style="overflow: hidden;">{{apage['description']}}
                         </div>
                     </div>
                 </div>

--- a/angular/src/app/landing/sections/resourcedata.component.ts
+++ b/angular/src/app/landing/sections/resourcedata.component.ts
@@ -18,19 +18,13 @@ import { Themes, ThemesPrefs } from '../../shared/globals/globals';
         '../landing.component.css'
     ],
     animations: [
-        trigger(
-          'enterAnimation', [
-            transition(':enter', [
-              style({height: '0px', opacity: 0}),
-              animate('500ms', style({height: '100%', opacity: 1}))
-            ]),
-            transition(':leave', [
-              style({height: '100%', opacity: 1}),
-              animate('500ms', style({height: 0, opacity: 0}))
-            //   animate('500ms', style({transform: 'translateY(0)', opacity: 1}))
+        trigger('detailExpand', [
+            state('void', style({height: '0px', minHeight: '0px'})),
+            state('collapsed', style({height: '0px', minHeight: '0px'})),
+            state('expanded', style({height: '*'})),
+            transition('expanded <=> collapsed', animate('625ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
+            transition('expanded <=> void', animate('625ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
             ])
-          ]
-        )
     ]
 })
 export class ResourceDataComponent implements OnChanges {
@@ -61,6 +55,18 @@ export class ResourceDataComponent implements OnChanges {
 
     ngOnInit(): void {
         this.recordType = (new NERDResource(this.record)).resourceLabel();
+    }
+
+    /**
+     * This function returns alter text/tooltip text for the expand symbol next to the given treenode title
+     * @param fileNode the TreeNode
+     * @returns 
+     */
+    expandButtonAlterText(accessPage: any) {
+        if(accessPage['showDesc'])
+            return "Close access page description";
+        else
+            return "Open access page description";
     }
 
     ngOnChanges(ch : SimpleChanges) {

--- a/angular/src/app/landing/sections/resourceidentity.component.html
+++ b/angular/src/app/landing/sections/resourceidentity.component.html
@@ -2,7 +2,7 @@
     <div class="col-12 col-md-12 col-lg-12 col-sm-12">
         <span class="recordType">
             <b>{{recordType}}</b>
-            <span *ngIf="recordType=='Science Theme Collection'" class="badge version"> Beta</span>
+            <span *ngIf="theme == scienceTheme" class="badge version"> Beta</span>
         </span>
         <br>
         <app-title [record]="record" [inBrowser]="inBrowser"></app-title>

--- a/angular/src/app/landing/version/version.component.html
+++ b/angular/src/app/landing/version/version.component.html
@@ -2,9 +2,9 @@
     <span class="" *ngIf="record.version" style="padding-right: 10pt;">
           Version: <strong>{{majorVersion(record.version)}}</strong></span>
     <span class="" *ngIf="record.versionHistory || record.releaseHistory" style="padding-right: 15pt;">...
-        <i style="cursor: pointer;" class="faa" aria-hidden="true"
-            [ngClass]="{'faa-plus-square-o': !clickHistory, 'faa-minus-square-o': clickHistory}"
-            (click)="closeHistory = !closeHistory; clickHistory = expandHistory();"></i>
+        <i style="cursor: pointer; margin-left: .5em;" class="faa" aria-hidden="true"
+        data-toggle="tooltip" [title]="expandButtonAlterText" [aria-label]="expandButtonAlterText"
+            [ngClass]="expandIconClass" (click)="expandHistory()"></i>
     </span>
     <span class="" *ngIf="record.firstIssued" style="padding-right: 10pt;">
        First Released: <strong>{{record.firstIssued.slice(0,10)}}</strong></span>
@@ -13,7 +13,7 @@
     <ng-template #issuedate>
        Issued: <strong>{{record.issued.slice(0,10)}}</strong></ng-template>
 
-    <div class="card customcard" [collapse]="!closeHistory">
+    <div class="card customcard" [collapse]="!visibleHistory">
         <div class="" *ngIf="record.annotated; else issueddate" style="padding-right: 10pt;">
              Description Last Updated: <strong>{{record.annotated.slice(0,10)}}</strong></div>
         <div><b>Release History:</b>

--- a/angular/src/app/landing/version/version.component.ts
+++ b/angular/src/app/landing/version/version.component.ts
@@ -33,6 +33,9 @@ export class VersionComponent implements OnChanges {
     public EDIT_MODES: any = LandingConstants.editModes;
     editMode: string;
 
+    expandButtonAlterText: string = "Open version history";
+    expandIconClass: string = "faa-caret-right";
+
     @Input() record: NerdmRes = null;
 
     /**
@@ -61,7 +64,8 @@ export class VersionComponent implements OnChanges {
      */
     expandHistory() {
         this.visibleHistory = !this.visibleHistory;
-        return this.visibleHistory;
+        this.expandIconClass = this.visibleHistory? "faa-caret-down" : "faa-caret-right";
+        this.expandButtonAlterText = this.visibleHistory? "Close version history" : "Open version history";
     }
 
     /**


### PR DESCRIPTION
http://mml.nist.gov:8080/browse/ODD-1066

This check in has following changes:
1. Set all expansion symbols to the same triangle symbols.
2. Unified the behavior of expansion animation.
3. Added tooltips and alter text to the expansion symbols.
4. Changed the condition  recordType=='Science Theme Collection' to theme == scienceTheme so it won't rely on theme label (otherwise any change to the label will cost app to fail).