### PR TITLE
Add Google Analytics service to search result link

### DIFF
--- a/angular/src/app/landing/resultlist/resultlist.component.spec.ts
+++ b/angular/src/app/landing/resultlist/resultlist.component.spec.ts
@@ -10,6 +10,7 @@ import { DropdownModule } from "primeng/dropdown";
 import { FormsModule } from '@angular/forms';
 import { InputTextareaModule } from 'primeng/inputtextarea';
 import { testdata } from '../../../environments/environment';
+import { GoogleAnalyticsService } from '../../shared/ga-service/google-analytics.service';
 
 describe('ResultlistComponent', () => {
   let component: ResultlistComponent;
@@ -30,6 +31,7 @@ describe('ResultlistComponent', () => {
         declarations: [ ResultlistComponent ],
         providers: [
             SearchService,
+            GoogleAnalyticsService,
             { provide: AppConfig,       useValue: cfg }
         ]
     })

--- a/angular/src/app/landing/resultlist/resultlist.component.ts
+++ b/angular/src/app/landing/resultlist/resultlist.component.ts
@@ -7,6 +7,7 @@ import { timeout } from 'rxjs-compat/operator/timeout';
 import { ThisReceiver } from '@angular/compiler';
 import * as e from 'express';
 import { connectableObservableDescriptor } from 'rxjs/internal/observable/ConnectableObservable';
+import { GoogleAnalyticsService } from '../../shared/ga-service/google-analytics.service';
 
 @Component({
   selector: 'app-resultlist',
@@ -66,7 +67,9 @@ export class ResultlistComponent implements OnInit {
     @Input() resultWidth: string = '400px';
     @Input() filterString: string = '';
 
-    constructor(private searchService: SearchService, private cfg: AppConfig) { }
+    constructor(private searchService: SearchService, 
+        private cfg: AppConfig,
+        public gaService: GoogleAnalyticsService) { }
 
     ngOnInit(): void {
         this.PDRAPIURL = this.cfg.get('locations.landingPageService',


### PR DESCRIPTION
http://mml.nist.gov:8080/browse/ODD-1076

Issue: in following page when user clicks on the "Home Page" button of "NIST Short Tandem Repeat DNA Internet DataBase", the "Oops!" error page will display:

https://testdata.nist.gov/od/id/pdr0-0001

Root cause: if landingPage field of a search result item is blank, and user click on "Visit Home Page", the Google Analytics service function will be called and failed because GA service was not defined in this component.

Solution: Add GA service to this component.