### PR TITLE
Improve reporting of error messages during DOI updates

### DIFF
--- a/docker/pdrtest/Dockerfile
+++ b/docker/pdrtest/Dockerfile
@@ -9,7 +9,7 @@
 #
 ##########################################
 
-FROM oar-metadata/ejsonschema
+FROM oar-metadata/ejsonschema-py2
 
 RUN apt-get update && apt-get install -y python-yaml nginx curl wget less sudo \
                                          uwsgi uwsgi-plugin-python zip \

--- a/python/nistoar/pdr/preserv/service/siphandler.py
+++ b/python/nistoar/pdr/preserv/service/siphandler.py
@@ -1227,7 +1227,8 @@ class MIDAS3SIPHandler(SIPHandler):
                 log.info("Submitted DOI record to DataCite")
             except Exception as ex:
                 msg = "Failed to submit DOI record with name=" + \
-                      self.bagger.name + " to DataCite: " + str(ex)
+                      self.bagger.name + " to DataCite: "
+                msg += _explain_error(ex)
                 log.exception(msg)
                 log.info("DOI minter service endpoint: %s", self._doiminter.dccli._ep)
 
@@ -1345,4 +1346,8 @@ class MIDAS3SIPHandler(SIPHandler):
         return _midadid_to_dirname(id)
 
 
-    
+def _explain_error(ex):
+    if hasattr(ex, 'errdata') and hasattr(ex.errdata, 'explain'):
+        return ex.errdata.explain()
+    return str(ex)
+


### PR DESCRIPTION
This PR leverages the [updates to oar-metadata (PR#53)](https://github.com/usnistgov/oar-metadata/pull/53) to provide more information in the preservation log when there is a failure while registering/updating a DOI. 