### PR TITLE
use author fullname (fn) if it is available

### DIFF
--- a/angular/src/app/nerdm/nerdm.ts
+++ b/angular/src/app/nerdm/nerdm.ts
@@ -87,12 +87,18 @@ export class NERDResource {
         if (this.data['authors']) {
             for (let i = 0; i < this.data['authors'].length; i++) {
                 let author = this.data['authors'][i];
-                if (author.familyName !== null && author.familyName !== undefined)
-                    out += author.familyName + ', ';
-                if (author.givenName !== null && author.givenName !== undefined)
-                    out += author.givenName;
-                if (author.middleName !== null && author.middleName !== undefined && author.middleName.trim() != "")
-                    out += ' ' + author.middleName.trim();
+                if (author.fn !== null && author.fn !== undefined && author.fn.trim() != "") {
+                    out += author.fn.trim()
+                }
+                else {
+                    // If full name (fn) is not provided, try to reconstruct it:
+                    if (author.familyName !== null && author.familyName !== undefined)
+                        out += author.familyName + ', ';
+                    if (author.givenName !== null && author.givenName !== undefined)
+                        out += author.givenName;
+                    if (author.middleName !== null && author.middleName !== undefined && author.middleName.trim() != "")
+                        out += ' ' + author.middleName.trim();
+                }
                 if (i != this.data['authors'].length - 1)
                     out += ', ';
             }


### PR DESCRIPTION
If an author record contains a fullname (fn) field, use that directly instead of reconstructing a full name from components (firstName, lastName and middleName).

It seems like fn should be preferred,  if it has been provided, given that the algorithms for constructing a full-name representation can depend on cultural, regional or even personal preferences.