### PR TITLE
Fix LPS rendering failure when no components in metadata

### DIFF
--- a/angular/src/app/landing/landingpage.component.spec.ts
+++ b/angular/src/app/landing/landingpage.component.spec.ts
@@ -51,7 +51,7 @@ describe('LandingPageComponent', () => {
         cfg.appVersion = "2.test";
         cfg.editEnabled = false;
 
-        nrd10 = testdata['test1'];
+        nrd10 = JSON.parse(JSON.stringify(testdata['test1']));
         /*
         nrd = {
             "@type": [ "nrd:SRD", "nrdp:DataPublication", "nrdp:DataPublicResource" ],
@@ -100,6 +100,16 @@ describe('LandingPageComponent', () => {
     });
 
     it("includes landing display", function() {
+        setupComponent();
+        expect(component).toBeTruthy();
+        let cmpel = fixture.nativeElement;
+        let el = cmpel.querySelector("h2");
+        expect(el).toBeTruthy();
+        expect(el.textContent).toContain(nrd10.title);
+    });
+
+    it("components property not required in NERDm record", function() {
+        delete nrd10["components"];
         setupComponent();
         expect(component).toBeTruthy();
         let cmpel = fixture.nativeElement;

--- a/angular/src/app/landing/landingpage.component.ts
+++ b/angular/src/app/landing/landingpage.component.ts
@@ -508,11 +508,13 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
      */
     useMetadata(): void {
         //Calculate the size of the dataset
-        this.md.components.forEach( (comp) => {
-            if(comp.size != undefined){
-                this.datasetSize += comp.size;
-            }
-        })
+        if (this.md.components) {
+            this.md.components.forEach( (comp) => {
+                if(comp.size != undefined){
+                    this.datasetSize += comp.size;
+                }
+            })
+        }
 
         this.metricsData.url = "/metrics/" + this.reqId;
 


### PR DESCRIPTION
This fixes a bug discovered by @pjl1000:  the landing page will fail to render if the NERDm record does not include a components property.  (Note that this is not a required property.)  The fix requires the addition of a guard into  the `useMetadata()` function in `LandingPageComponent` that ensures the property's existence before attempting to calculate the total size of all files combined.  
