### PR TITLE
Fix/odd1086 minor fixes

### DIFF
--- a/angular/src/app/landing/data-files/data-files.component.html
+++ b/angular/src/app/landing/data-files/data-files.component.html
@@ -1,7 +1,7 @@
 <!-- This bloack is for the data access session of landing page -->
 <!-- <div id="filelisting"> -->
 <div id="filelisting" *ngIf="displayMode != 'restrict_preview'"
-    [ngClass]="displayMode == 'restrict' ? 'restrict-public' : ''">
+    [ngClass]="displayMode == 'restrict' ? 'restrict-public' : ''" style="background-color: white;">
     <div *ngIf="displayMode == 'restrict'">Note: This dataset is designated as restricted public data; this file list
         will not be shown in the public version of this page.</div>
 
@@ -11,7 +11,7 @@
             <div class="flex-container" style="margin-top: 2em;">
                 <!-- 'Download all' and 'Add all to cart' buttons disabled if this is internal landing page -->
                 <div *ngIf="editEnabled; else editDisabled"
-                    style="flex: 0 0 120px; text-align: left; padding-bottom: 0em;">
+                    style="flex: 0 0 140px; text-align: left; padding-bottom: 0em;">
                     <span><b id="filelist-heading">Files </b> </span>
                     <span class="faa-stack fa-lg icon-download grey-color">
                         <i class="faa faa-circle-thin faa-stack-2x" aria-hidden="true"></i>
@@ -25,11 +25,12 @@
                     </span>
                 </div>
                 <ng-template #editDisabled>
-                    <div style="flex: 0 0 130px; text-align: left; padding-bottom: 0em;">
+                    <div style="flex: 0 0 140px; text-align: left; padding-bottom: 0em;">
                         <span><b id="filelist-heading">Files </b> </span>
+
                         <a class="faa-stack fa-lg icon-download" *ngIf="!editEnabled" (click)="downloadAllFiles()"
-                            data-toggle="tooltip" title="Download all files"
-                            [ngStyle]="{'color':getDownloadAllBtnColor(),'cursor':'pointer'}">
+                        data-toggle="tooltip" title="Download all files"
+                        [ngStyle]="{'color':getDownloadAllBtnColor(),'cursor':'pointer'}">
                             <i class="faa faa-circle-thin faa-stack-2x" aria-hidden="true"></i>
                             <!-- <i class="faa faa-download faa-stack-1x" aria-hidden="true"></i> -->
                             <i *ngIf="!isAddingToDownloadAllCart; else show_spinner1"
@@ -37,8 +38,10 @@
                             <ng-template #show_spinner1><i class="faa faa-spinner faa-spin faa-stack-1x spinner"
                                     aria-hidden="true"></i></ng-template>
                         </a>
+
                         <a id="routeToDatacart" target="_blank" [routerLink]="['/datacart', 'popup']"
-                            style="display:none"></a>
+                        style="display:none"></a>
+
                         <span *ngIf="!editEnabled" class="faa-stack fa-lg icon-cart"
                             (click)="toggleAllFilesInGlobalCart(files)" [ngStyle]="{'color':getAddAllToDataCartBtnColor(), 'cursor': 'pointer',
                                 'margin-right': '1em'}" data-toggle="tooltip" [title]="getCartProcessTooltip()">

--- a/angular/src/app/landing/data-files/data-files.component.ts
+++ b/angular/src/app/landing/data-files/data-files.component.ts
@@ -244,7 +244,7 @@ export class DataFilesComponent implements OnInit, OnChanges {
         if(this.mouseDragging) {
             let diff = this.mouse.y - this.prevMouseY;
             this.treeTableHeight = this.prevTreeTableHeight + diff;
-            this.treeTableHeight = this.treeTableHeight < 26? 25 : this.treeTableHeight > 500? 500 : this.treeTableHeight;
+            this.treeTableHeight = this.treeTableHeight < 26? 25 : this.treeTableHeight;
         }
     }
 

--- a/angular/src/app/landing/sections/resourceidentity.component.html
+++ b/angular/src/app/landing/sections/resourceidentity.component.html
@@ -1,6 +1,5 @@
 <div class="grid" id="identity">
     <div style="width:100%">
-    <!-- <div class="col-12 col-md-12 col-lg-12 col-sm-12"> -->
         <span class="recordType">
             <b>{{recordType}}</b>
             <span *ngIf="theme == scienceTheme" class="badge version"> Beta</span>
@@ -36,9 +35,7 @@
         <div *ngIf="theme == scienceTheme" style="width: 100%;" [ngStyle]="{'margin-bottom': record.creators? '15px' : '1.5em'}">
             <app-facilitators [record]="record" [inBrowser]="inBrowser"></app-facilitators>
         </div>
-    <!-- </div> -->
     
-    <!-- <div class="col-8 col-md-8 col-lg-8 col-sm-12"> -->
         <app-contact [record]="record" [inBrowser]="inBrowser"></app-contact>
 
         <span>Identifier: </span>

--- a/angular/src/app/landing/sections/resourceidentity.component.html
+++ b/angular/src/app/landing/sections/resourceidentity.component.html
@@ -1,5 +1,6 @@
 <div class="grid" id="identity">
-    <div class="col-12 col-md-12 col-lg-12 col-sm-12">
+    <div style="width:100%">
+    <!-- <div class="col-12 col-md-12 col-lg-12 col-sm-12"> -->
         <span class="recordType">
             <b>{{recordType}}</b>
             <span *ngIf="theme == scienceTheme" class="badge version"> Beta</span>
@@ -10,15 +11,34 @@
           <i style="font-size: smaller;">Part of {{isPartOf[0]}} <a href="{{isPartOf[1]}}"
              title="view collection">{{isPartOf[2]}}</a> {{isPartOf[3]}}</i>
         </div>
+    </div>
+
+    <div style="width:100%">
+        <span *ngIf="showHomePageLink" style="float: right;">
+            <span *ngIf="inBrowser; else visitHomeOnServer">
+                <a href={{record.landingPage}} target="_blank">
+                    <button type="button" pButton type="submit" [disabled]="!inViewMode"
+                        class="home_button p-button p-component ui-button-text-empty"
+                        [ngStyle]="{'background-color': visitHomePageBtnStyle()}"
+                        (click)="googleAnalytics(record.landingPage, $event, 'Resource title: '+record.title)">
+                        <i class="faa faa-external-link"
+                            style="color: #fff;padding-left: .5em;padding-right: .5em;"></i>
+                        Visit Home Page
+                    </button>
+                </a> 
+            </span>
+            <ng-template #visitHomeOnServer>Visit Home Page</ng-template>
+        </span>
+
         <app-author [record]="record" [inBrowser]="inBrowser"></app-author>
 
         <!-- Facilitators -->
         <div *ngIf="theme == scienceTheme" style="width: 100%;" [ngStyle]="{'margin-bottom': record.creators? '15px' : '1.5em'}">
             <app-facilitators [record]="record" [inBrowser]="inBrowser"></app-facilitators>
         </div>
-    </div>
+    <!-- </div> -->
     
-    <div class="col-8 col-md-8 col-lg-8 col-sm-12">
+    <!-- <div class="col-8 col-md-8 col-lg-8 col-sm-12"> -->
         <app-contact [record]="record" [inBrowser]="inBrowser"></app-contact>
 
         <span>Identifier: </span>
@@ -44,24 +64,6 @@
             </div>
         </div>
         <pdr-version [record]="record"></pdr-version>
-    </div>
-
-    <div class="col-4 col-md-4 col-lg-4 col-sm-12">
-        <span *ngIf="showHomePageLink" style="float: right;">
-            <span *ngIf="inBrowser; else visitHomeOnServer">
-                <a href={{record.landingPage}} target="_blank">
-                    <button type="button" pButton type="submit" [disabled]="!inViewMode"
-                        class="home_button p-button p-component ui-button-text-empty"
-                        [ngStyle]="{'background-color': visitHomePageBtnStyle()}"
-                        (click)="googleAnalytics(record.landingPage, $event, 'Resource title: '+record.title)">
-                        <i class="faa faa-external-link"
-                            style="color: #fff;padding-left: .5em;padding-right: .5em;"></i>
-                        Visit Home Page
-                    </button>
-                </a> 
-            </span>
-            <ng-template #visitHomeOnServer>Visit Home Page</ng-template>
-        </span>
     </div>
 </div>
 

--- a/angular/src/assets/sample-data/mds2-2116.json
+++ b/angular/src/assets/sample-data/mds2-2116.json
@@ -1,0 +1,21141 @@
+{
+  "_schema": "https://data.nist.gov/od/dm/nerdm-schema/v0.7#",
+  "@context": [
+    "https://data.nist.gov/od/dm/nerdm-pub-context.jsonld",
+    {
+      "@base": "ark:/88434/mds2-2116"
+    }
+  ],
+  "@type": [
+    "nrdp:DataPublication",
+    "nrdp:PublicDataResource",
+    "dcat:Dataset"
+  ],
+  "_extensionSchemas": [
+    "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/PublicDataResource"
+  ],
+  "@id": "ark:/88434/mds2-2116",
+  "title": "RF Dataset of Incumbent Radar Systems in the 3.5 GHz CBRS Band",
+  "contactPoint": {
+    "fn": "Raied Caromi",
+    "hasEmail": "mailto:raied.caromi@nist.gov"
+  },
+  "modified": "2019-08-27 00:00:00",
+  "ediid2": "ark:/88434/mds2-2116",
+  "ediid": "test0",
+  "landingPage": "https://data.nist.gov/od/id/mds2-2116",
+  "description": [
+    "The RF dataset can be used to develop and test detection algorithms for the 3.5 GHz CBRS or similar bands where the primary users of the band are federal incumbent radar systems. The dataset consists of synthetically generated radar waveforms with added white Gaussian noise. The RF dataset is suitable for development and testing of machine/deep learning detection algorithms. A large number of parameters of the waveforms are randomized across the dataset. Due to its large size, the dataset is divided into groups, and each group consists of multiple files. For more information about the dataset, refer to:  R. Caromi, M. Souryal, and T. Hall, \"RF Dataset of Incumbent Radar Systems in the 3.5 GHz CBRS Band,\"  Journal of Research of the National Institute of Standards and Technology. (in press). In addition, the metadata of the dataset is summarized in \"Data Dictionary of 3.5 GHz Radar Waveforms\" [pdf] accompanying the data. For more information about the motivation behind this RF dataset, refer to:  T. Hall, R. Caromi, M. Souryal, and A. Wunderlich, \"Reference Datasets for Training and Evaluating RF Signal Detection and Classification Models,\" to appear in Proc. IEEE GLOBECOM Workshop on Advancements in Spectrum Sharing, Dec. 2019."
+  ],
+  "keyword": [
+    "3.5 GHz; CBRS; incumbent radar detection; RF dataset; classification; deep learning; machine learning; spectrum sharing"
+  ],
+  "theme": [
+    "Advanced Communications:Wireless (RF)"
+  ],
+  "topic": [],
+  "accessLevel": "public",
+  "license": "https://www.nist.gov/open/license",
+  "components": [
+    {
+      "accessURL": "https://doi.org/10.18434/M32116",
+      "title": "DOI Access for RF Dataset of Incumbent Radar Systems in the 3.5 GHz CBRS Band",
+      "@type": [
+        "nrd:Hidden",
+        "dcat:Distribution"
+      ],
+      "@id": "#doi:10.18434/M32116"
+    },
+    {
+      "@id": "cmps/Instructions%20to%20download%20the%20RF%20dataset.txt.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "Instructions to download the RF dataset.txt.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/Instructions%20to%20download%20the%20RF%20dataset.txt.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/Instructions to download the RF dataset.txt",
+      "description": "SHA-256 checksum value for Instructions to download the RF dataset.txt",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "application/octet-stream",
+      "size": 64,
+      "checksum": {
+        "hash": "971e2927da39addadc0a2df4880e2813148f81b31d7d92c945fe3e7821fadf2f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/downloadDataset.py",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "downloadDataset.py",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/downloadDataset.py",
+      "mediaType": "text/x-python-code",
+      "size": 10621,
+      "checksum": {
+        "hash": "3a5592b4d0c8225b1056d368b0377b0877cfe614b3bb5639504dcf9f2a9d5f29",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/Instructions%20to%20download%20the%20RF%20dataset.txt",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "Instructions to download the RF dataset.txt",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/Instructions%20to%20download%20the%20RF%20dataset.txt",
+      "mediaType": "text/plain",
+      "size": 656,
+      "checksum": {
+        "hash": "8015f3b90b216baeb4b1c1e9105da5d10edd40bd5047093a09f844ffc781ee22",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/downloadDataset.m.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "downloadDataset.m.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/downloadDataset.m.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/downloadDataset.m",
+      "description": "SHA-256 checksum value for downloadDataset.m",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "12d573b99739c68364d31f240fc039a8407843a255444de60d9591942e8d25f0",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/downloadDataset.m",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "downloadDataset.m",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/downloadDataset.m",
+      "mediaType": "text/x-matlab-code",
+      "size": 7687,
+      "checksum": {
+        "hash": "7544d5f13a18574248e92d6f2c8c38ad16f878e33b625e7b1ba895a1a7081768",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms",
+      "@type": [
+        "nrdp:Subcollection"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/Subcollection"
+      ],
+      "filepath": "SimulatedRadarWaveforms"
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/ReadMe.txt.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/ReadMe.txt.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/ReadMe.txt.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/ReadMe.txt",
+      "description": "SHA-256 checksum value for ReadMe.txt",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "a8ffebf16270788e88a072e003501e6e7fe311cebd326611c63ca4b2da19da18",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1",
+      "@type": [
+        "nrdp:Subcollection"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/Subcollection"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1"
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_14.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_14.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_14.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463727105,
+      "checksum": {
+        "hash": "c1da929dc8e83e5be658d6ca3b91f138167cd226edee587137c2e6abe96fe444",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_19.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_19.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_19.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_19.mat",
+      "description": "SHA-256 checksum value for group1_subset_19.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "7bf9a43b46b69cc1e2044febd3024d59650c49d285f00a2bac49db28c8c92992",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_29.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_29.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_29.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_29.mat",
+      "description": "SHA-256 checksum value for group1_subset_29.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "6957fd81a9215bca228895df814148e1b62248a012eec5e20f9db0069d805578",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_2.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_2.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_2.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731879,
+      "checksum": {
+        "hash": "a432b303553546fe4aa04aba2d47435accb8c64e8a3c62f0f9cb2ee8c8e7d11e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_30.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_30.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_30.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_30.mat",
+      "description": "SHA-256 checksum value for group1_subset_30.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "04a0db677771bbe7fa3e59eb2d829d47bdfb9b3b063809fa433e6eb20209b1a6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_28.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_28.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_28.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463733023,
+      "checksum": {
+        "hash": "96d5907f8349aa0dc5cf208095a621be5240b5180f988c722d00f346bd8420ac",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_9.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_9.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_9.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463742493,
+      "checksum": {
+        "hash": "ca3e6c6a3c357b36062b61cb53d0ed37a77a28e2302f233eb83a89d98807fd4e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_48.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_48.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_48.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_48.mat",
+      "description": "SHA-256 checksum value for group1_subset_48.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "2765de1bd624152737bf10a300719c4bb5bfdaf5bfa0763aa7cbe622fb566ce2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_45.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_45.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_45.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_45.mat",
+      "description": "SHA-256 checksum value for group1_subset_45.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "85fb1f6062e75ba082db3e0b2a1e20784560f54eff0690fa21f60abf80141a86",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_42.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_42.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_42.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463727212,
+      "checksum": {
+        "hash": "7cd874ae692b33645a9426c877d5b82317618c6dc9bfff2dc52aeaa4a981ad40",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_50.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_50.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_50.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_50.mat",
+      "description": "SHA-256 checksum value for group1_subset_50.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "2dc5b5b7d520f823d7d9fb930e34647ad019a1f6ff2482dc25174fd01ff15767",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_44.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_44.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_44.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_44.mat",
+      "description": "SHA-256 checksum value for group1_subset_44.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "4fc92b68010cbd2744f27bc9dd0571e334465c8cfbaad65d3b6dc35cccef06d2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_35.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_35.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_35.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732718,
+      "checksum": {
+        "hash": "14a022d05d71ab4fcf74b13afdaf5701e28ad0e51e6018a254482b11047769f2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_46.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_46.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_46.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_46.mat",
+      "description": "SHA-256 checksum value for group1_subset_46.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "3ee2044aa0ba9176a76977b29db095887b8b2ebee88e4acef3d14c4df7294d6d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_39.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_39.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_39.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_39.mat",
+      "description": "SHA-256 checksum value for group1_subset_39.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "bce1ed4c88ca97537d29c60a577479957ad80c62ebcac7e752397d3ab1ef58d8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_18.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_18.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_18.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_18.mat",
+      "description": "SHA-256 checksum value for group1_subset_18.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5777f1718fddb8638346a9c63f69bf6dddbd28268b06d824b04281c5bb1f097c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_48.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_48.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_48.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463727553,
+      "checksum": {
+        "hash": "57b6cec92cfe7e19274238c51f0d5befb63188f14c77c2f791c77fa06735caf2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_2.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_2.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_2.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_2.mat",
+      "description": "SHA-256 checksum value for group1_subset_2.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "8e585259d1c42d2328e3f7e5435ed30edc1d0530c85e8a3d258bf99c3b0ee0ef",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_47.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_47.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_47.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731797,
+      "checksum": {
+        "hash": "f2bc9153e7e815795c73eaca03d0b6da25c91b5f4f7c6c35eb24b40ed60f6437",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_24.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_24.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_24.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_24.mat",
+      "description": "SHA-256 checksum value for group1_subset_24.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "72fe32fd606786715f8ac9f4a37074075964b9b28e171972dfe74c7af8ba140b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo",
+      "@type": [
+        "nrdp:Subcollection"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/Subcollection"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo"
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_6.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_6.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_6.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_6.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_6.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "358b4e932faad3ebc8d8195b8bda1426a5a36c95b1ab69b59ad54f451318bc38",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_33.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_33.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_33.csv",
+      "mediaType": "text/csv",
+      "size": 19540,
+      "checksum": {
+        "hash": "936a7940a18133320b423b9441ccb60f89525db71fa4459fe2a4bde1c29377a2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_10.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_10.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_10.csv",
+      "mediaType": "text/csv",
+      "size": 19805,
+      "checksum": {
+        "hash": "4cade3bdc7b67687e9045d045674c96bb1949455dfdee7db9698ace63192ed5c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_18.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_18.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_18.csv",
+      "mediaType": "text/csv",
+      "size": 19500,
+      "checksum": {
+        "hash": "4822aa1a190ac8bf4bee62e17d5b85dd2c0561f3d8ca2ccabfca5c13ffcb67f3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_2.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_2.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_2.csv",
+      "mediaType": "text/csv",
+      "size": 19433,
+      "checksum": {
+        "hash": "2ff96d1c6b7f782c7c3bad6a279a7512f70b6748e3fb27ae130dc14571ddacf7",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_28.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_28.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_28.csv",
+      "mediaType": "text/csv",
+      "size": 19498,
+      "checksum": {
+        "hash": "f3dc8ebaf83c581e4d33fde0df316ad0c2c124c14fad2ecb2aaef29dc7e0247b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_34.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_34.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_34.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_34.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_34.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "29e04120db4c75961f8f856aaedf1703f06688c4697a3486519afb888badaa4c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_20.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_20.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_20.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_20.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_20.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "e021e757d41e8d541117662c06d0aace8bd466d1d5ed2ebe37edeb1de7d2aa69",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_7.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_7.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_7.csv",
+      "mediaType": "text/csv",
+      "size": 19335,
+      "checksum": {
+        "hash": "f287377146958d4b7071cf5f146f3bc473160e8146a850e28d485a730a87519f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_5.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_5.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_5.csv",
+      "mediaType": "text/csv",
+      "size": 20315,
+      "checksum": {
+        "hash": "aa64f94edffa9c0d728521bc4c641bd31245320a46d9f53974a65b34b145da8e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_12.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_12.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_12.csv",
+      "mediaType": "text/csv",
+      "size": 19268,
+      "checksum": {
+        "hash": "4d44fa94ee86c722a982568c4b1be072ac99ff6dc7a949753c6e022f30ad0bb9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_38.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_38.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_38.csv",
+      "mediaType": "text/csv",
+      "size": 19619,
+      "checksum": {
+        "hash": "76e20a279b962990198a5fb7582a6b706ab3d620580eb14cd4497daa116367dc",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_21.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_21.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_21.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_21.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_21.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "2017ddb57e50c0f2770e9946f08431b21a78eb8e06d59567a59ef4d40084f1ad",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_32.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_32.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_32.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_32.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_32.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "e6e4aa713212fcbe6ed29b611a73909fd958b320a55f84a59de4ec5ae848285f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_26.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_26.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_26.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_26.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_26.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5fe415623c1ddaaef763574d39c812da1ad57b0b85afd57618cdba4c21dbd0f9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_23.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_23.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_23.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_23.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_23.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b228a80db2458691e1546fb89a0b2ddcb40bf7c7ae5f24605052ef5c1ec06e97",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_15.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_15.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_15.csv",
+      "mediaType": "text/csv",
+      "size": 19518,
+      "checksum": {
+        "hash": "f365c671e443f2011bdd686dc1a54bc1e571515e318c6eaf342ad7293ad8e43c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_29.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_29.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_29.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_29.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_29.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "bb0ee053164ef6f9d1b7e07629faef2b4676fe2139e30ad7d364cdb2c72a3ece",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_40.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_40.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_40.csv",
+      "mediaType": "text/csv",
+      "size": 19410,
+      "checksum": {
+        "hash": "d44ef02d847eda2791a080dace07fbf10dcf1ad33247f9f803d9c5055c2306bd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_46.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_46.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_46.csv",
+      "mediaType": "text/csv",
+      "size": 19498,
+      "checksum": {
+        "hash": "301d6da768ed553ee96e41a3744e6d2e8730d7aec0b4900f4b462abd741a82f6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_3.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_3.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_3.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_3.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_3.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "0b1b385af4c1788932fcc2e6d733554c06d14186d6cdf34dd8e5b0275ad285a2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_20.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_20.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_20.csv",
+      "mediaType": "text/csv",
+      "size": 19824,
+      "checksum": {
+        "hash": "a60329ebcd7289f55515a5267c37ae8177c2d09ceda4b5eb98a41a4d896a2f78",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_10.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_10.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_10.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_10.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_10.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "003acd573230ec0684215db44ab10a54c6dc77e842ea0748aac1a3be780e2b4c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_49.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_49.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_49.csv",
+      "mediaType": "text/csv",
+      "size": 19284,
+      "checksum": {
+        "hash": "59910f16693831e929251073384a4cb18f6124b32e21500b7539171cfb34799d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_24.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_24.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_24.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_24.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_24.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "64a1ee34b3fb3e5f888e9b45b8ecb2140640a3c072befe0f7a5551ae7999a7a2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_32.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_32.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_32.csv",
+      "mediaType": "text/csv",
+      "size": 19485,
+      "checksum": {
+        "hash": "03f543a43ab60d7d140ffae1958fb26f2efb23281534e44680128f825b94196a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_4.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_4.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_4.csv",
+      "mediaType": "text/csv",
+      "size": 19177,
+      "checksum": {
+        "hash": "9b93353c12b7f803a09056bf34552d979a7b79b0836bf2ca1632de425507264b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_21.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_21.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_21.csv",
+      "mediaType": "text/csv",
+      "size": 19145,
+      "checksum": {
+        "hash": "ee1e3836f3b9bdbd93cf9f0fe826e2b0f2cde988080edfbbcef74abfd4183d0b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_22.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_22.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_22.csv",
+      "mediaType": "text/csv",
+      "size": 19613,
+      "checksum": {
+        "hash": "3ee4d0d522b7b051a89d758efb4f56ff4ff303aaf04740fd440b11ef7c74e4cb",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_12.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_12.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_12.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_12.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_12.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "e64938d128b2cfb932ae7833d81ff1c77daaf0a666dd3f909fd57ae62fabc8b8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_22.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_22.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_22.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_22.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_22.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "cc63fa4b54a46a4fde3dd68e463a712b803ec0d19bd09dd15883d462eea3ca5c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_3.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_3.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_3.csv",
+      "mediaType": "text/csv",
+      "size": 20037,
+      "checksum": {
+        "hash": "002ba0987d45cf200befa6f9effc1dd8d586238ff1e09f8baa4e90d1785f1200",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_14.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_14.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_14.csv",
+      "mediaType": "text/csv",
+      "size": 19264,
+      "checksum": {
+        "hash": "c49acc8cac255ee49613eeae63a3690a651a7b49ca317f0a1579bb54d53db195",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_44.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_44.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_44.csv",
+      "mediaType": "text/csv",
+      "size": 19486,
+      "checksum": {
+        "hash": "958d4c8c72382cdb3d0e5e599209872a4b40dbfa19f82d5c97018d572db421a8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_35.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_35.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_35.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_35.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_35.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b56cc991d53c6d9c43e16f44bd61fc32f105632bc7dfe0f06b6ea5fdc2c124f5",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_11.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_11.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_11.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_11.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_11.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "1754e0d2f3eed2d2eb361941d4654607c69b8d1fa2c0064327564bd22f5c79fb",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_34.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_34.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_34.csv",
+      "mediaType": "text/csv",
+      "size": 20055,
+      "checksum": {
+        "hash": "9be50e2cfc92aee3058171b1460e5518a11c776bebbaf604c2ee45ad3c6a7296",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_14.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_14.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_14.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_14.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_14.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "8d3796f4a0e00baff6ea4245dfe31c236dd01ee1d56092b405c8b9da1de54a7f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_2.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_2.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_2.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_2.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_2.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "916143f25fb5b9aa2d2231c7397a583413b515f1de14c58a6a4c883e556ec523",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_39.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_39.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_39.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_39.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_39.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "bae87c71fbda3fd6b98e5977ab63e3394916fed79bf96fb86f5f1f679edde8fd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_45.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_45.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_45.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_45.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_45.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "28a1eada21e09054070623218740b603dcba1485c4ed176362128ea2e78b4130",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_8.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_8.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_8.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_8.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_8.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "4eebd12b444ab03366b51b16e235e29db3109dfe23f9c755532c83c4449cfbc0",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_49.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_49.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_49.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_49.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_49.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "918ba3c8c821d351d1ce49eadaabe0b413c6ee6ea8b7e39bbc153b85c68baa29",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_43.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_43.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_43.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_43.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_43.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "86e2c6f23ca6552cf08fdeaa14cb483df708bf88faafc5d9dcd04bc7b997df5a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_44.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_44.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_44.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_44.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_44.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "f846fdee9efcbba1f6e5e635e362bc71f6985a428ba5e3bd12eddc42cea83fd7",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_46.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_46.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_46.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_46.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_46.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "06c44aff3370e913d5ae2d4bbbb889f4ecbeb18c10ee11c19111b6a6c2f4bc60",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_48.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_48.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_48.csv",
+      "mediaType": "text/csv",
+      "size": 19319,
+      "checksum": {
+        "hash": "504bcd5c44a947e0870d976c230746190d9fd444691285c4e47671529ab224af",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_47.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_47.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_47.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_47.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_47.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "6aa34e7e92e7b447696720c9f15d591542c6ce39acc2f7a0e4c5bec96faa7401",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_33.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_33.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_33.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_33.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_33.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "0aa43afebd6d5d35894814ae2c16291b4de1d2b0b69abe2fec6e030cff48063d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_31.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_31.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_31.csv",
+      "mediaType": "text/csv",
+      "size": 19226,
+      "checksum": {
+        "hash": "09573c67ecf7bc8c887cd6aba2a9e9e25ef7ef0d1466e1a78668be3efc263ca4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_24.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_24.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_24.csv",
+      "mediaType": "text/csv",
+      "size": 19315,
+      "checksum": {
+        "hash": "9222c016b157884ad56d02d01c955af557a559105211d5464616963576633d49",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_7.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_7.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_7.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_7.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_7.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "ed1556c0ecde65e750afa4f2cd4554c496a972cc8a2f0fc0453ba9d097265110",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_13.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_13.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_13.csv",
+      "mediaType": "text/csv",
+      "size": 19286,
+      "checksum": {
+        "hash": "f2a058dfe51d62901e597c5ede4979c64fcb569ec9cd080cef77719fe68e5627",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_1.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_1.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_1.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_1.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_1.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "65d4658ea809446f78c526df5c4abe13b854ec39f1367c90466e7a2af518eeda",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_50.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_50.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_50.csv",
+      "mediaType": "text/csv",
+      "size": 19902,
+      "checksum": {
+        "hash": "702e73c61fd33cb939f784f8e8ae1e65ddf84e7695f9b3cbf705b1c447d8958c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_30.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_30.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_30.csv",
+      "mediaType": "text/csv",
+      "size": 19347,
+      "checksum": {
+        "hash": "b93aeff7871ed309448038e3e9ec0ff6a799f873d03a5448a07d30183ee59992",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_25.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_25.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_25.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_25.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_25.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "d7e5e3737658fba249cc272e789ce08a52d6e61d0b88a860ab9794df4e43b8aa",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_43.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_43.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_43.csv",
+      "mediaType": "text/csv",
+      "size": 19136,
+      "checksum": {
+        "hash": "a673dcbdb0cd6cee6fece604ad74cf1e215c382437833bde4819703c1897e206",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_6.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_6.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_6.csv",
+      "mediaType": "text/csv",
+      "size": 19804,
+      "checksum": {
+        "hash": "a3676fa5fe4a97f3f639ecb0317281cea4e9d4b04d108a576e5b4171d5d249f8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_8.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_8.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_8.csv",
+      "mediaType": "text/csv",
+      "size": 19287,
+      "checksum": {
+        "hash": "a4f5e67f03c2bcb4aba7942cc99e4fe4559f7277d1794536d41d7673ddeb02fa",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_38.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_38.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_38.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_38.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_38.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9ef405c125d73e3b16301207e81f1184603088c4c123a9341b263b83ce216a63",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_28.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_28.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_28.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_28.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_28.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "f00cdba0d006c7c6d6a5679cdd27489f9e490329fcf0d02414225787943234b1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_19.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_19.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_19.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_19.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_19.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b7f1f0ea76e995315f9ec660f790c934be6b76bd62df5adea63dc95f5ee41a64",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_27.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_27.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_27.csv",
+      "mediaType": "text/csv",
+      "size": 20227,
+      "checksum": {
+        "hash": "1bc0bb0eab1519c844b58c723d0cfd886a62e703cdd5c90a74a4b21e01327cd6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_27.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_27.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_27.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_27.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_27.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "8b6a33a132c2799ff2136d6c04685e8052b569925f173bb00e09f68db2b79192",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_26.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_26.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_26.csv",
+      "mediaType": "text/csv",
+      "size": 19663,
+      "checksum": {
+        "hash": "86fbbfe9023bd6ce2004f6f33832cabc5446cc806df28c4d16f3cd4cc2985164",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_42.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_42.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_42.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_42.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_42.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "4baf4bced28c0a06125b78d910a1a64fae77d42304ae3004dd9791c9c26f1bcf",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_37.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_37.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_37.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_37.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_37.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "2720396af845bf829689ff978e206f53155ea505602c94f2df5a2e651b0ec9c9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_13.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_13.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_13.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_13.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_13.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "d2b2bd4ceeff18a029c19c4faa4d9e24edca6220206e2c4f7e57d0938671c9d4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_17.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_17.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_17.csv",
+      "mediaType": "text/csv",
+      "size": 19574,
+      "checksum": {
+        "hash": "dcd622dc8d0311cb4ae4b4b13423e42660dee8b909277c28001820c16f0bbb8f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_15.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_15.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_15.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_15.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_15.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "03493b83fbab1403e2fe58087af5e70ae4fbbbfe8e5d938083745496d4fa07cc",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_30.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_30.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_30.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_30.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_30.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b0a49299994566980a348f0e89210cef5b046db7ce381f1f78346f9dc4591310",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_50.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_50.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_50.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_50.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_50.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "994e9100c119d128063b55c7e462f5d7561809752b7c4ae2e33b9035d16ae0ce",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_16.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_16.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_16.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_16.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_16.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "dc69d8f8a6132f508ac5c95f1a85e2a397ec0e7ba9fd617a8c2f8d606b44d58e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_45.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_45.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_45.csv",
+      "mediaType": "text/csv",
+      "size": 19761,
+      "checksum": {
+        "hash": "7776c4ff38bede89762dbfa575bd6c86a2ae3678068fdf872c1b51c6cf8313c4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_23.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_23.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_23.csv",
+      "mediaType": "text/csv",
+      "size": 18870,
+      "checksum": {
+        "hash": "09d41db18f956b45f850e0dc976aabf1cc6895c3c7ae251a1b5a963a1fecd1ca",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_47.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_47.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_47.csv",
+      "mediaType": "text/csv",
+      "size": 19442,
+      "checksum": {
+        "hash": "f59ca162e137c1561217075ffe8c3878fbbc9981571305ca4bd8130b2e8f44c6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_16.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_16.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_16.csv",
+      "mediaType": "text/csv",
+      "size": 19219,
+      "checksum": {
+        "hash": "879f3aa10040c231a1816df62932afe1a124e4089d3d98fcf65ecd331db89157",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_48.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_48.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_48.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_48.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_48.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b3e219f373162d4a0d362bd4fc23728e97b6fd2137812df59328b2fe7ab6b487",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_1.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_1.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_1.csv",
+      "mediaType": "text/csv",
+      "size": 19761,
+      "checksum": {
+        "hash": "ae77c6d221aa1bc44238f64059ecf0c3a2ad955b8c440159e861ea7b93d336f1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_5.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_5.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_5.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_5.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_5.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "90f334d3adca9ce54d2c39a2e7e9cc53f039b39282861229e6bcfd2bd4cfbcfe",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_36.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_36.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_36.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_36.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_36.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5d14df6712f4d7304cc3ab8e3f1c9ef6d6d9ec79e874206e91a85664654f12f3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_42.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_42.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_42.csv",
+      "mediaType": "text/csv",
+      "size": 20260,
+      "checksum": {
+        "hash": "c57523fc13449a64d730674baec06a988175e6f113bbf61a3f9efd702556a14f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_29.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_29.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_29.csv",
+      "mediaType": "text/csv",
+      "size": 19775,
+      "checksum": {
+        "hash": "13470fbd2ff5bebef88ac6afbc3eafc0f9e62f50ad9589c39278b3bda3e358a7",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_41.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_41.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_41.csv",
+      "mediaType": "text/csv",
+      "size": 19762,
+      "checksum": {
+        "hash": "93d255cedb1aeae834b00db4595c8e3e8db01b5c721b35f899aebfd26b5c57e4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_36.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_36.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_36.csv",
+      "mediaType": "text/csv",
+      "size": 19384,
+      "checksum": {
+        "hash": "c07c8055a5bcd7d9e758df9b896f16fd6a7e9f63e2e8659699f4ed7e13be62a6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_11.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_11.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_11.csv",
+      "mediaType": "text/csv",
+      "size": 19890,
+      "checksum": {
+        "hash": "f3705337e055ee779b75a10f4b6aa57093cb2a8506b945ad59458f0e96b99a23",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_18.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_18.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_18.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_18.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_18.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9d8c510cf6db75ca8b9df5f22d33680f6657100d35a2d804f10eb60be004b5dd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_9.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_9.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_9.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_9.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_9.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "2644b58ef554cdf06ccb50298f2b18783df8120f04cab160c2374913e874c61a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_39.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_39.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_39.csv",
+      "mediaType": "text/csv",
+      "size": 19461,
+      "checksum": {
+        "hash": "829115a57d12ce63397bec3be805f071fa7024ab27a507d5e8dd1b7b0599dfac",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_40.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_40.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_40.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_40.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_40.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "334fcb9658370fe8a77782af8c7ae0b96b606c09801ee47e678a584f50eaecc5",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_25.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_25.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_25.csv",
+      "mediaType": "text/csv",
+      "size": 19016,
+      "checksum": {
+        "hash": "1f9e6f0a230210e2caa1f936098ffa3a40152efa6ca34452b1bd5736583d2534",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_4.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_4.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_4.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_4.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_4.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "3a2fdf91d4728dc060b637a8f53bb7f70143d2bdbb21944913f3acf8de37099c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_37.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_37.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_37.csv",
+      "mediaType": "text/csv",
+      "size": 19544,
+      "checksum": {
+        "hash": "3bfd4504e2cd3afb69bcc0f97008970b966854e409228cfe0201f3855552cadb",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_9.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_9.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_9.csv",
+      "mediaType": "text/csv",
+      "size": 19131,
+      "checksum": {
+        "hash": "211bc466f122a6b3acb938ddb32972f967c7bd45026610e1cbbe0bec258d4b85",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_17.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_17.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_17.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_17.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_17.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "df2806424c9dce3b25bd2584b09fa67aeba28522e5851ddc69051d890d77c8ac",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_31.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_31.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_31.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_31.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_31.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "56b41488a2b8a25ad3b7f3a29f6778633832595e583804fbb8968eb0271306a4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_19.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_19.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_19.csv",
+      "mediaType": "text/csv",
+      "size": 19566,
+      "checksum": {
+        "hash": "641786fd066360332ff5f038d8ce4cf64eb922456b654dd4963bf181f6af0e6d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_41.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_41.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_41.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_41.csv",
+      "description": "SHA-256 checksum value for group1_waveformTableSubset_41.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5b21ebe0b704f91d953eeee2ce63c9a779448c6f821d048ae94ba6431e723941",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_35.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_35.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_CSVInfo/group1_waveformTableSubset_35.csv",
+      "mediaType": "text/csv",
+      "size": 20167,
+      "checksum": {
+        "hash": "e82bd2e26262eb34990f1f667a51ca058e70b214bd845d01bc233508f09459a5",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_32.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_32.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_32.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463735886,
+      "checksum": {
+        "hash": "78d56a70bf8720f8e52c46588ffbc31f6028ba8c084d7ba6dd7bd0be59136ffd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_38.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_38.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_38.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734446,
+      "checksum": {
+        "hash": "cb5d153356068d478e1239b6ae8616780e0cede83d49e7cf6035ac9f66d9f9d4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_35.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_35.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_35.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_35.mat",
+      "description": "SHA-256 checksum value for group1_subset_35.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "f467565eb0d93c484f73c70dc8bd045ff9c35cf301672c7fca4d986043f3c880",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_46.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_46.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_46.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463736572,
+      "checksum": {
+        "hash": "6dc3bbdfdd230bf73f3bee2c8d58a7926a63159c77c7bb52e8914267453cfd31",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_49.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_49.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_49.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_49.mat",
+      "description": "SHA-256 checksum value for group1_subset_49.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5e1c99faae5304281e9ba1faf6b47b45d1625a33eead3058fe7c94016929711c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_41.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_41.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_41.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_41.mat",
+      "description": "SHA-256 checksum value for group1_subset_41.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "246e385a9a9b8479f88d52d96df2b1b1fe2418438700badeffd1af85123d92a3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_6.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_6.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_6.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729777,
+      "checksum": {
+        "hash": "cdf3df3465787912ca6864663772cdd0c4a1e25c2f833d5c419ee86aa1264903",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_20.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_20.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_20.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_20.mat",
+      "description": "SHA-256 checksum value for group1_subset_20.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "eb709c4499d96ab849c83937be13a6d0017b79f02316ac26f1a35d7d42f6e9b9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_45.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_45.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_45.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463737530,
+      "checksum": {
+        "hash": "6e6d3e86e978b71f15dedfaea05addd4a2f46775ed846cc17b3d280befacf23d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_30.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_30.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_30.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732420,
+      "checksum": {
+        "hash": "24c52721783207415d9f5feb2ed6e097161380f7c5d7421810389daaf95a9206",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_11.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_11.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_11.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_11.mat",
+      "description": "SHA-256 checksum value for group1_subset_11.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "cc2b617998e61dd6127e78cb470d3c6f2bdc5187fddcd2aef4abbf820335cf24",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_34.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_34.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_34.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729664,
+      "checksum": {
+        "hash": "b75ff2a2a1ca4a64a6db00b2351ad238917c413900c9d7d8d6f6c6beeabef1ad",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_13.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_13.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_13.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730297,
+      "checksum": {
+        "hash": "776d3231c4619f5606b5edce61af097b622a280e1ae4d874e297a4c07ce3c77e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_8.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_8.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_8.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_8.mat",
+      "description": "SHA-256 checksum value for group1_subset_8.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "7cdd26f61ff76eb3c96a86bda1e9d933f1556968ae49661c26882d92c5fbd2f9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_1.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_1.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_1.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731809,
+      "checksum": {
+        "hash": "e5e3d1c76892266d484abe1670723922759c0b94d02d750dffdfcf7da330f2d5",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_49.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_49.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_49.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731718,
+      "checksum": {
+        "hash": "f69b57e4a522f35251a578e90027d18feac89f765f73c77410d635a029a9fc91",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_15.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_15.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_15.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_15.mat",
+      "description": "SHA-256 checksum value for group1_subset_15.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9085df645dad03c75fab4ae0dc6c2b1832040a2b2688b935002afd33d1789bcd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_13.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_13.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_13.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_13.mat",
+      "description": "SHA-256 checksum value for group1_subset_13.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "aaeb663f4776e4394568a91fd3c9176a10ee4aca2f117b19c63a52cc7673fd86",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_5.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_5.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_5.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731680,
+      "checksum": {
+        "hash": "4ffc1e5ba2321840e451777150754b93f559fbf728776bc8a67154080b0459a8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_39.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_39.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_39.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730948,
+      "checksum": {
+        "hash": "5cee7d140348e8f5bd29fdb818f9e1fe54c83d86e4fc83b9635db5eb4a5f9639",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_42.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_42.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_42.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_42.mat",
+      "description": "SHA-256 checksum value for group1_subset_42.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "d9983a2109d9d7097c920bbf19ef8286c53017a286380002d08c1c829c4e25d4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_9.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_9.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_9.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_9.mat",
+      "description": "SHA-256 checksum value for group1_subset_9.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "f21d22bee17f4dc9cfb94e0a2159108b42bd29151d7c3ce86965212b5e6da180",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_15.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_15.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_15.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463726694,
+      "checksum": {
+        "hash": "236a1fb0c78da32f4b6c9f8d9b8e10de1ec6b641e6631c79b33d9e5a1159eefb",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_14.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_14.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_14.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_14.mat",
+      "description": "SHA-256 checksum value for group1_subset_14.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "86a1df9cbc47e049b3819cf55474d17f2c4bfdecab3062932484459e8b090304",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_37.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_37.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_37.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_37.mat",
+      "description": "SHA-256 checksum value for group1_subset_37.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "ba1f6d37547303cb64e10c09acb72cbb71ed32ff149b02d878de75fa85ce6807",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_26.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_26.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_26.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463735074,
+      "checksum": {
+        "hash": "39a20dc4712c75ead674a2fb2b6708944a23615bdccb912c40a9b3cc7ff401ea",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_21.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_21.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_21.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_21.mat",
+      "description": "SHA-256 checksum value for group1_subset_21.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "1206339f00f71b4692ffaabeb96899f8902e243dd68863a8dc5bc8b8ea798496",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_27.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_27.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_27.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_27.mat",
+      "description": "SHA-256 checksum value for group1_subset_27.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "c9a89467e4a9b523a37e0f96ae9be93e31a85ca5c6425f1b51480a351bb182c5",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_43.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_43.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_43.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_43.mat",
+      "description": "SHA-256 checksum value for group1_subset_43.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "fd781561d7d6c1b8d36e598ef6f90e7dcc438732e60e77922c73255d8b40b8e2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_21.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_21.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_21.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463733568,
+      "checksum": {
+        "hash": "3959163ad46698357403f4f380fd688d0969274020b838aabfad85ae4700d1d3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_37.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_37.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_37.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463728728,
+      "checksum": {
+        "hash": "03c372330607a361cd15682b2b16c33f8c39234fd20b6ccc1f9bdcdadc099de7",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_4.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_4.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_4.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463733575,
+      "checksum": {
+        "hash": "c1b3068cfa11f24a36044fcc01e678a91cb601d9950753cf4ee02987ca318b01",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_7.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_7.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_7.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_7.mat",
+      "description": "SHA-256 checksum value for group1_subset_7.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "e9a14180ebbb953677a227b48b3a2218ecc11debc274471a237b08d2e7d2d37b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_5.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_5.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_5.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_5.mat",
+      "description": "SHA-256 checksum value for group1_subset_5.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "20da4645c9e38e0d44148c006a0831e51a5ceea249355129a3db29ba64a6bff3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_7.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_7.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_7.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463736565,
+      "checksum": {
+        "hash": "5a0c572ca76edce122c4783167218d5ad3f9aa5b106c6351c83c4a16392ce064",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_18.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_18.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_18.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463737360,
+      "checksum": {
+        "hash": "dd439d7271aa37e7d5e81ccffe401951cb746516a63d343a5b9166cfbd6727fa",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_29.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_29.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_29.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730622,
+      "checksum": {
+        "hash": "b377e888f0a8bfc05c861c6d68c92d4609cfb8bad323eb91dc19040ca250d4ef",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_23.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_23.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_23.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_23.mat",
+      "description": "SHA-256 checksum value for group1_subset_23.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "d737ec870e9ca66d234009eb4fa2333b3fc2f7bbe780d6ea8d8db8baebe6ad2f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_19.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_19.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_19.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463735759,
+      "checksum": {
+        "hash": "6b117dda49b9cd08e4fae457d59082527e0c4b87f9195c1169d89586eb3bef82",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_17.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_17.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_17.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463735537,
+      "checksum": {
+        "hash": "2b61b9cabc45d6278adc4524f8104ad294113e1d08a846397e9e05e95e382249",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_33.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_33.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_33.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463726593,
+      "checksum": {
+        "hash": "687cbc9a1dc32f57550c9431e608e7bae4f717ef86092ca9e3d4c0a0eae0f159",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_11.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_11.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_11.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463735373,
+      "checksum": {
+        "hash": "c0d16e48a88469db30ef9f2f968bf6cb7f669a322a3b4113d573373d2329b8d1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_38.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_38.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_38.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_38.mat",
+      "description": "SHA-256 checksum value for group1_subset_38.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "27e1bed0edfc9783f1f23fd51036fae40c9e0b938c74f72d44eb0951e9c1a4da",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_33.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_33.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_33.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_33.mat",
+      "description": "SHA-256 checksum value for group1_subset_33.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "49cd4621e8f514b4018c84519b6e9968474309330c56549ca60786b8e121ebb9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_36.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_36.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_36.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_36.mat",
+      "description": "SHA-256 checksum value for group1_subset_36.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "13d3f4dd87ace3b0496122d9afee5277fc59aa35e2f7b6edd13a0fb7693cbfb3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_12.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_12.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_12.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_12.mat",
+      "description": "SHA-256 checksum value for group1_subset_12.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "8d607dd909b82e3f95d8e9c6b5f9d4cf3dd2aebe14d6aa5268f94a5a247f7993",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_1.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_1.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_1.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_1.mat",
+      "description": "SHA-256 checksum value for group1_subset_1.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9554d74574ca89a909c691faae49d6c04da8210cebb910d04e4ab1f74e334de3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_17.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_17.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_17.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_17.mat",
+      "description": "SHA-256 checksum value for group1_subset_17.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "2ec1a8c8ed9bfd8cd01a35f5f87b19cbab1ad974010d6df41b3ddcec95da7ccc",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_3.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_3.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_3.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_3.mat",
+      "description": "SHA-256 checksum value for group1_subset_3.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "467bbabc391cd0f1ad7fac240026aacb7b9c0e2432733a7415793c20d0ad594f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_4.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_4.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_4.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_4.mat",
+      "description": "SHA-256 checksum value for group1_subset_4.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "58accadb5a88877b336a1343b95072e8e6d3326970ed5eac643751c116ddf95d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_3.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_3.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_3.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734906,
+      "checksum": {
+        "hash": "02a6f8002474013650bc28e79330fa050e8969e03449f8fb9242763b71568619",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_36.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_36.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_36.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463736946,
+      "checksum": {
+        "hash": "513777bbff54fafc774530434167e73520d698220a572b7c74a51ef11f3e3d56",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_47.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_47.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_47.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_47.mat",
+      "description": "SHA-256 checksum value for group1_subset_47.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "c5ac51799e68032eea7d14bf6fa2b56946fa347b481b437d590fa95ac05b7b1c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_40.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_40.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_40.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_40.mat",
+      "description": "SHA-256 checksum value for group1_subset_40.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "fd2d7f2098e81c8d31dec77adef6b92633ebcb04b6fda22bf34f09dabcefd3cb",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_44.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_44.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_44.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734990,
+      "checksum": {
+        "hash": "bf86f6a5027423fcf231ba3ff93d4da8c51f357982c866d95029a7ead6e0c3a8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_41.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_41.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_41.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463733582,
+      "checksum": {
+        "hash": "b1f1953338512ea5b58c0775248909c87dff51fccb51fc215f0105e0e03b5160",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_40.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_40.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_40.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463736010,
+      "checksum": {
+        "hash": "c7521ce475fb7a348357d6421d91c3fb5a1460537f0fe3cd7b80072b962f44f4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_10.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_10.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_10.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463725603,
+      "checksum": {
+        "hash": "56cab7c8048bcba43b8c8e976c4b1d3c515581c1105393075e94e4fca6e5f9e4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_31.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_31.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_31.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_31.mat",
+      "description": "SHA-256 checksum value for group1_subset_31.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "52b89ec1825af8c3e5d59e4326c3796b2fa623b81025996c8bb46c1dd1abcb24",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_31.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_31.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_31.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463733365,
+      "checksum": {
+        "hash": "fd2b3dab1f416f785caa02221f624f920d0d5299cca56128d4b59766b04d7644",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_12.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_12.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_12.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731525,
+      "checksum": {
+        "hash": "6b6f3f28151a1fedceb1324f1da2aea8b78d2611a56a7be28f7f789502d812aa",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_27.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_27.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_27.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463736375,
+      "checksum": {
+        "hash": "65c7d9eb3283f8cf0064b429b8d757edcb95a67247ac295d8065aa7019fdc602",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_43.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_43.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_43.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729362,
+      "checksum": {
+        "hash": "739455981860a910d51e242f15b700d0987c69e250ba4acf6e9beec9d62cddf2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_26.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_26.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_26.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_26.mat",
+      "description": "SHA-256 checksum value for group1_subset_26.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "3d246e75d1a4ec2b2a7e5824c7a78e914586fed1d62376797d5089caf12fa98d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_50.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_50.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_50.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730010,
+      "checksum": {
+        "hash": "c66bb641db46d7466407f0ae8b2093be7032b623a1510070a099b084e90155d4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_6.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_6.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_6.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_6.mat",
+      "description": "SHA-256 checksum value for group1_subset_6.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "3868b23e1a8086d2bbea577068c258021a15cc81fc095b99b1eb39e5f21f9828",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_22.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_22.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_22.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729855,
+      "checksum": {
+        "hash": "b8c13dc0e3c09f2f4fd6dd09b3f42c86d1b0bcd4e897c010b10b8e9930aa88c1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_25.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_25.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_25.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_25.mat",
+      "description": "SHA-256 checksum value for group1_subset_25.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "082c1f3758c6509358a933d4d4ac019a2e1ce3ed7dfa6d9d2188023f9c30a701",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_25.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_25.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_25.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463726679,
+      "checksum": {
+        "hash": "8fd592645f13ecbf8dde61e0f0d6cc38f24cb1877bb494653ca3aa093037de0d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_22.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_22.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_22.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_22.mat",
+      "description": "SHA-256 checksum value for group1_subset_22.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "227e6bc3b56eb4d5db81b334321386145507ee214d043030dc17fdfeb5795d28",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_24.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_24.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_24.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729331,
+      "checksum": {
+        "hash": "1f5e0b407cee66fa3b8f803e5daa29db251f11d953d379a7ab9fc0e2ff28d2bd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_8.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_8.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_8.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463733432,
+      "checksum": {
+        "hash": "881f61a22f264c9e0b510bd8e4a4e3946e820b85248967dca73f3b14e2ad20f5",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_28.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_28.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_28.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_28.mat",
+      "description": "SHA-256 checksum value for group1_subset_28.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "a094e3a02a0f329b3c87054a0ec73e530c53734e371544b13f6a73a829fe0c52",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_34.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_34.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_34.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_34.mat",
+      "description": "SHA-256 checksum value for group1_subset_34.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "64ddae2436bd20a4f04d6da6dc47c3df18560fb104a15830348c30993f71d423",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_10.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_10.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_10.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_10.mat",
+      "description": "SHA-256 checksum value for group1_subset_10.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "c5c5006961721f836e5064b0b3a32f0704ce9bdf738c5d1ff27bca4be6f6a218",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_32.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_32.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_32.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_32.mat",
+      "description": "SHA-256 checksum value for group1_subset_32.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "c7f14c53ec571ca088d9d452d6fc07798a2afd817596e6ff2b661344c64b0a51",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_16.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_16.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_16.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732639,
+      "checksum": {
+        "hash": "d72fad67913cf96cd6e915f50c48a1df12267fc2b71d8ed2a52cc415178fc116",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_20.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_20.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_20.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731266,
+      "checksum": {
+        "hash": "98f7469c5c9fc953a861deac553d2b2709cf740d06a566714f52008330ea2e3a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_23.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_23.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_23.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732140,
+      "checksum": {
+        "hash": "67ac1eae366ed33274f1b0b33871600e7c304d6203e2c8d01591ed9cd761cb3c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_16.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group1/group1_subset_16.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group1/group1_subset_16.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group1/group1_subset_16.mat",
+      "description": "SHA-256 checksum value for group1_subset_16.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "69b1b022b283b768a0acd0d540844ed9e9f4a80749a04346b0636a6cda9a88f3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/allWaveformsTableCombined.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/allWaveformsTableCombined.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/allWaveformsTableCombined.csv",
+      "mediaType": "text/csv",
+      "size": 3864830,
+      "checksum": {
+        "hash": "3a0a270cc515064316e2fbcc54cc15c5b10b33651c7873536f867bedad89f98f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/allWaveformsTableCombined.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/allWaveformsTableCombined.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/allWaveformsTableCombined.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/allWaveformsTableCombined.csv",
+      "description": "SHA-256 checksum value for allWaveformsTableCombined.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "3b5fc3f68f5884181319d41c91b8da5957b225d61d414997e9f5aa1002f363d8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4",
+      "@type": [
+        "nrdp:Subcollection"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/Subcollection"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4"
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_48.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_48.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_48.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_48.mat",
+      "description": "SHA-256 checksum value for group4_subset_48.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "8e59e5f56e0dee6d4a072ad7f0d961fe6a5a51ed0674d9eb79df7a62372ea47c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_8.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_8.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_8.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_8.mat",
+      "description": "SHA-256 checksum value for group4_subset_8.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "f0b7879dfcfb72fee17ab5320b1323d9cc9dfd33ccf15407ba75cbaf61b08c54",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_46.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_46.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_46.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732739,
+      "checksum": {
+        "hash": "100e03a160ded862bb11a9712f713c23cff0864b01b0e7d9acf752e55d23ced7",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_39.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_39.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_39.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_39.mat",
+      "description": "SHA-256 checksum value for group4_subset_39.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "70eac1e013e3c37e605d4d05040dbb1ed3963f6a553a58335148748c1758315c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_26.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_26.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_26.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_26.mat",
+      "description": "SHA-256 checksum value for group4_subset_26.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "72bbf74b3012128ef96a40332de7d1d7b2e1996fe06df9ce28669d7846e9af23",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_11.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_11.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_11.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_11.mat",
+      "description": "SHA-256 checksum value for group4_subset_11.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "09b4ba3d29e1964c576ce8ff6a28879b8e267b558c32b814f4d00a1d853de746",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_24.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_24.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_24.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_24.mat",
+      "description": "SHA-256 checksum value for group4_subset_24.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "d4eb67f815c4dd048d330d4e6a64bbf77e67beddef28a989581d7a5594cc7775",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_2.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_2.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_2.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732907,
+      "checksum": {
+        "hash": "01d6d6cf108a33e1603e5fabf68a539c7deeb56821c8e854e42517d5e213adb3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_40.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_40.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_40.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_40.mat",
+      "description": "SHA-256 checksum value for group4_subset_40.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b733406b8ae6fa34225597c0c87534596c7adb7cef872ffe4e1cfc8618d2f947",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_33.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_33.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_33.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_33.mat",
+      "description": "SHA-256 checksum value for group4_subset_33.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "deac9ab1a864e6c40c06cd4da94ea91b6b785802071b6b51d82c86d4f32414b9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_18.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_18.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_18.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732444,
+      "checksum": {
+        "hash": "c33b8cdd8e45d6519bf9de6cc4114a7cbbc0f8dccf8de957c1892ea48a940e6e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_16.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_16.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_16.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_16.mat",
+      "description": "SHA-256 checksum value for group4_subset_16.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "f1ba36fc3908ee2f2755643aeea740581b456e903bdbc02b16953d0b95b8f021",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_2.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_2.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_2.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_2.mat",
+      "description": "SHA-256 checksum value for group4_subset_2.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "8b20d5b0a27fcdfb8ee8da25ada5d52f375a804c983ac175ec57433ce31b3303",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_13.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_13.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_13.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734284,
+      "checksum": {
+        "hash": "cf57fbedcdc920c98fd2254062f7f8d600ce31117d3631c26d6e2de8abde0210",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_15.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_15.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_15.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_15.mat",
+      "description": "SHA-256 checksum value for group4_subset_15.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "d3bf7ffced2f30e46c94560763d3d90f78e4a0fab970eef6d125776b3dcfec69",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_26.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_26.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_26.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731238,
+      "checksum": {
+        "hash": "f5d2fd3144749be54fd327dbb7804947a3442c60ff50a8779b1a0622c91cf39b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_11.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_11.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_11.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463733230,
+      "checksum": {
+        "hash": "c41eb019f581366277268d3b652b39e02dbea4da0c993e360e7f3ed2b1abef76",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_21.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_21.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_21.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_21.mat",
+      "description": "SHA-256 checksum value for group4_subset_21.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9a1bba524c27192177a569e0fea839e0c11418a5e013f277e1b3ada96ec4c5d1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_42.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_42.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_42.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729875,
+      "checksum": {
+        "hash": "514bd8801f95b277f62d02064341e85a43ec6aa79aa344f6375db8fbafe493b9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_6.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_6.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_6.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_6.mat",
+      "description": "SHA-256 checksum value for group4_subset_6.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "6620158d6952a1538d574efa9655ad57fd716b2b3bb318c00835c3f4fbfcb9ba",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo",
+      "@type": [
+        "nrdp:Subcollection"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/Subcollection"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo"
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_50.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_50.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_50.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_50.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_50.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b0e948031eb5606c074993415594f4b5ea3d44e44fbd267933c8d212e5cde3a5",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_46.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_46.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_46.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_46.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_46.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "79defe99ccf49b35821a29b7ac1c372456702b7ade8fd73cdc4432d4b6eb9204",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_37.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_37.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_37.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_37.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_37.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "a5a12fbc25fd635235c61794128c589469c542dba3c32aab80268bc05d50ca37",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_24.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_24.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_24.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_24.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_24.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "6409efa3477865d8cbaf1b58d0e04125fd8c3f1dfc71830c8dabbe47e2c3ac14",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_48.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_48.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_48.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_48.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_48.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "dc47edc9a5a2c16ecf32fe7e2761ab640d4aac2db59705390b18ef1cf19b6c5f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_18.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_18.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_18.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_18.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_18.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "f8aa6bf9da5b8953802942b8c36444ead9397a00d011c2554ceb10977b14d981",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_16.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_16.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_16.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_16.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_16.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "d31c63da8df9ef7b492da11dd0579fba5fc1a7a133222dcc584eb79b51f9e797",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_41.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_41.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_41.csv",
+      "mediaType": "text/csv",
+      "size": 20440,
+      "checksum": {
+        "hash": "8af2b924856da399e1c0c172e66ca81c7bdddc647cd4743cfb49efdad34b8647",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_22.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_22.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_22.csv",
+      "mediaType": "text/csv",
+      "size": 19783,
+      "checksum": {
+        "hash": "2a0a436d8c48fc32914fa748004542ab79c04395cd4605a634077cfb5a0bc654",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_14.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_14.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_14.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_14.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_14.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "899187d82905661f2c0e459c1168a80a14878242c35a8127514d7077183780c6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_20.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_20.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_20.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_20.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_20.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b498a7451deba62f40bbad3f7aef5dca192816ba00804d3e3d7cb66c661c9b4c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_31.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_31.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_31.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_31.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_31.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "fdc2e20456760fb368fd9e1ab3093a02a87b2e8de895250ab40ebdd10130161e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_14.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_14.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_14.csv",
+      "mediaType": "text/csv",
+      "size": 19240,
+      "checksum": {
+        "hash": "c2505baa1dbe40026dcd2258d0999f9d1babc8bf35f1ed12ea4024af2988c57c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_48.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_48.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_48.csv",
+      "mediaType": "text/csv",
+      "size": 19286,
+      "checksum": {
+        "hash": "fc91285e43c5c40e644b890945aac39cb0c40ad1db6089e882f718fc432ba2bb",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_33.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_33.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_33.csv",
+      "mediaType": "text/csv",
+      "size": 20189,
+      "checksum": {
+        "hash": "f3bdd9d0e3db6ed41dea7e71d3240e36d8f64c33677b2bc6fbe3572683147eed",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_20.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_20.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_20.csv",
+      "mediaType": "text/csv",
+      "size": 19330,
+      "checksum": {
+        "hash": "b97082b244edcfc173900d1d148d759daeb009d69fce970479579dc0c45939b2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_47.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_47.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_47.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_47.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_47.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b8ab617b07f90a9da67413e264d3eaad4cc13c701f0bc47bacdf91b206073ed4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_10.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_10.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_10.csv",
+      "mediaType": "text/csv",
+      "size": 19159,
+      "checksum": {
+        "hash": "ec54bda1ab50a66ff5b26f4954e70fbcece465fc28f6fc79a5efee544af2a450",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_1.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_1.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_1.csv",
+      "mediaType": "text/csv",
+      "size": 19157,
+      "checksum": {
+        "hash": "d513ae6e6f42f435d4189b8ff39e8400d72f28eef22fbfe58b7a0f438c787650",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_11.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_11.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_11.csv",
+      "mediaType": "text/csv",
+      "size": 19487,
+      "checksum": {
+        "hash": "dae820a42dd6ac20d7824415256d42a3d25f74f517563d0f60497353aaf39a43",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_19.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_19.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_19.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_19.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_19.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b05cdd7c8a640834310bc59df682953289296e319c507f98659f3584ed73df25",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_42.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_42.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_42.csv",
+      "mediaType": "text/csv",
+      "size": 19045,
+      "checksum": {
+        "hash": "7d5e5ac30016ef80d1e91fb596f63cfab82e03437b6212fe8516d8ecc2668a6c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_45.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_45.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_45.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_45.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_45.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "e47bab7a4733cca62bc2a74e8d09691f8485743b55cef84f885d861ffaacc7aa",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_31.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_31.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_31.csv",
+      "mediaType": "text/csv",
+      "size": 19546,
+      "checksum": {
+        "hash": "8440da1bd0cd604e9a4e7ed203bc3767df3dcc470cf62f595efc0c554183fed5",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_11.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_11.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_11.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_11.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_11.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "af7370f37bac0ceaa7c70cb2c4cfeb3afb3e0bd82cd4ff6094e05758f7838189",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_28.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_28.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_28.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_28.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_28.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "338081d927756634964a420fa21630248d17940fa3bd883329cf639e9875f6e9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_23.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_23.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_23.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_23.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_23.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "0e5f616079b9932ecfc41492c4287897d34fec345686a6b0af1a95dd06b27a2e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_12.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_12.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_12.csv",
+      "mediaType": "text/csv",
+      "size": 19119,
+      "checksum": {
+        "hash": "553cbec312abd517194f7ea227234bfafada225a68ed7789f1f9fcb04f5c2049",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_21.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_21.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_21.csv",
+      "mediaType": "text/csv",
+      "size": 19062,
+      "checksum": {
+        "hash": "9cbcf03b6e89a01abacf7e40bf12d7158f6a14f5b799a2f0b8b595a2682217bf",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_32.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_32.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_32.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_32.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_32.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "f45650c45af0c3ad942a7f2047176bdbf481b2be79b1b2fb033cbe57cbe365e4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_26.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_26.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_26.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_26.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_26.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "d9566f182bdac3a9114e6177bfd7fa96275a6b7f49aa4927546435d69a1abc7d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_13.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_13.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_13.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_13.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_13.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "0e1e161e6a2cfae2468d37dfd95f8d9ee8b072a7ef15b3b6d368c57cbb249058",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_44.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_44.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_44.csv",
+      "mediaType": "text/csv",
+      "size": 19210,
+      "checksum": {
+        "hash": "e989c4f1e926177ae4e7e71dd7dfee176337fbfa28d692eb568a12e360eece2f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_39.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_39.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_39.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_39.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_39.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "de687b5e5c1481a1ea20677e212d74f9d972198cffd1e4c8a21ddc41c25c5a67",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_50.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_50.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_50.csv",
+      "mediaType": "text/csv",
+      "size": 19706,
+      "checksum": {
+        "hash": "c78df1ad0a0dff9d5653dadba41623ccde6f57d707193cbfe26117166dbf8e66",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_45.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_45.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_45.csv",
+      "mediaType": "text/csv",
+      "size": 20415,
+      "checksum": {
+        "hash": "46b29cb7d1ed3e499e539da47fc6991c20145cd6bacdaf595139847abfba1ad0",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_43.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_43.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_43.csv",
+      "mediaType": "text/csv",
+      "size": 19652,
+      "checksum": {
+        "hash": "a80b32dc466d3eace1811a57bea990c1a89b4d9099d323b053b99ce6f7c98eac",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_4.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_4.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_4.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_4.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_4.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "2217e967730d51bf32747cbc16d847353a0814ccff7f7e2bfe9c0faa3a75df37",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_25.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_25.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_25.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_25.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_25.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "232a1bed7eb421ed564ecc2fdc44a68be424de3c1c71df6a73f567b75a83d9dc",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_37.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_37.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_37.csv",
+      "mediaType": "text/csv",
+      "size": 20164,
+      "checksum": {
+        "hash": "a8701eeca4a6a85a0af1f986b70d7952d437765f179291e0f4eb884c11977df2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_36.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_36.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_36.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_36.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_36.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "889b46d9602aad4e1a4596d614e1fd09990946f8cd42e64eb1a379405af25ad4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_6.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_6.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_6.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_6.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_6.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5a56d37b8d4ed1613e59bd49c3989d5e3dbb1b3feebfe843d224507a2d064d70",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_2.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_2.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_2.csv",
+      "mediaType": "text/csv",
+      "size": 20661,
+      "checksum": {
+        "hash": "2de93071737d7290b32b38bb9211e2fe0189bb543142a5e81a4e6041eacd8cd7",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_7.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_7.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_7.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_7.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_7.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "8512f3d7e68c918dce5725524247aa0d297ca92e685f6fe2d7b220ec21ba1729",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_8.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_8.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_8.csv",
+      "mediaType": "text/csv",
+      "size": 19641,
+      "checksum": {
+        "hash": "7efc17a2e21389d2081a234b30edb66bf11cf0e22ee339edfda36f622670a33b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_42.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_42.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_42.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_42.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_42.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "7d13253002db25edd9c47624768399884d9cd64fd81d6699ee1263a78c2e6c02",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_27.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_27.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_27.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_27.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_27.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "dcde0a7fedb9b709a968e1e0c44d0ba29fb4458c0cf0831e8194b60e2494dc5e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_3.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_3.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_3.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_3.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_3.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "79aad13b6ab9bd0c925d7991d30b3a018e14dcea739d7dfb803e9500ee11e331",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_18.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_18.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_18.csv",
+      "mediaType": "text/csv",
+      "size": 19810,
+      "checksum": {
+        "hash": "8b66c1ca9e08c5e9b2df76fa891b907ec77c8e669f7a004e5ddb1718fe1b8391",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_5.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_5.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_5.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_5.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_5.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "203038b954d1a229c2823987ca5c78faecb12213209205c733a262590e5cf878",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_32.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_32.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_32.csv",
+      "mediaType": "text/csv",
+      "size": 19495,
+      "checksum": {
+        "hash": "1a1a0380af829c98a423f3c3b7922bc171781ad275161df5720a4c9cdce8fcc0",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_27.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_27.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_27.csv",
+      "mediaType": "text/csv",
+      "size": 19365,
+      "checksum": {
+        "hash": "c2eec254f57519cb364179a1fc297a867456322474b11891018670b4384c29bd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_38.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_38.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_38.csv",
+      "mediaType": "text/csv",
+      "size": 19510,
+      "checksum": {
+        "hash": "d716fb48744a921b8b9bd79f295339831c32c604e20a140a091c0f94b24f4c26",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_35.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_35.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_35.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_35.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_35.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "7585f6e06b43a6718a8641e560b448e8a5963f25f1160893f43354e9dd466f94",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_33.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_33.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_33.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_33.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_33.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "326a563944fcfd878fffbd7cecdacc60026d31f382e0f54c05f37246d90cfe16",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_9.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_9.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_9.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_9.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_9.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "77ee8f896a2e59787d6da47e6e96cbcd252b6ce1e54cfca2927a3059cb175e90",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_13.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_13.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_13.csv",
+      "mediaType": "text/csv",
+      "size": 19770,
+      "checksum": {
+        "hash": "19da38fafc97f8414deec1a67e68d9ef0ca8ea727248b754dfc2d4edc1581ad9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_25.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_25.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_25.csv",
+      "mediaType": "text/csv",
+      "size": 19354,
+      "checksum": {
+        "hash": "6585297bfd688ec88d2dceb13b21d1d9c01624e9cde15f055b562655c4b14fed",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_34.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_34.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_34.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_34.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_34.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "c2fd95924e5131d4ea65ff150cb1d756013c97e507a92dd3c59b89197d48e448",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_34.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_34.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_34.csv",
+      "mediaType": "text/csv",
+      "size": 19306,
+      "checksum": {
+        "hash": "80534305ee96fb9fdad440fec715d7188d98748c7f8cdb087237c48236b49893",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_29.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_29.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_29.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_29.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_29.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "4b9a9cd54276999f03e4901f2ce73c0f8703a66a4f551f38a2c209ba425e08fd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_5.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_5.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_5.csv",
+      "mediaType": "text/csv",
+      "size": 20191,
+      "checksum": {
+        "hash": "c5882d54d50ca86a0ff3c9a337dc60332e839b400f6074f72ed0a7b3caff847a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_44.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_44.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_44.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_44.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_44.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "a9837f4d82b125f7d51751b9ddb1aa0954aeab9faa740a017931a85b6f01ad38",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_38.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_38.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_38.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_38.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_38.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5e040bd291a3f524dde889d3dca14b56e347fc1e0541cdadd3f0cc3c2fa568b0",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_7.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_7.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_7.csv",
+      "mediaType": "text/csv",
+      "size": 19289,
+      "checksum": {
+        "hash": "06e7b81070f4cbb40938ae5a28064ae4a15725fcf4c6b47fc2a2082f78ca9342",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_39.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_39.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_39.csv",
+      "mediaType": "text/csv",
+      "size": 19330,
+      "checksum": {
+        "hash": "87754047b44d8fbe0c5f8b4a2575bb30fa9d534a1320cafbfe5112776314be5d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_43.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_43.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_43.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_43.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_43.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "3a35305d876acf6c027240433151f68bd0d47674aeee84a41b6fca7ae1db00d6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_8.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_8.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_8.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_8.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_8.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "ecd6dcaa61424e9ba6b930554160c0d17a8a63077dc4e645ec72f2bc11361eac",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_35.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_35.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_35.csv",
+      "mediaType": "text/csv",
+      "size": 19614,
+      "checksum": {
+        "hash": "a1fdefa5c7401f4c3129819ac68942ba0e40f0299f006fc8c6bcd1aeebcc9f30",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_29.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_29.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_29.csv",
+      "mediaType": "text/csv",
+      "size": 19450,
+      "checksum": {
+        "hash": "c840e4cfd9d24818fe4a90add0412b0a61b2fffb65c188e51f8f4c4b56e83793",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_12.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_12.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_12.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_12.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_12.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "8150f1c44934f80db622e290b3d7630e51244a2d0ea5369c599be88e766db8cd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_16.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_16.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_16.csv",
+      "mediaType": "text/csv",
+      "size": 19307,
+      "checksum": {
+        "hash": "28c5d0e1d904d12975ca4a9de9d601a0c55f4308f33445a8bd0e59028bbf6b4c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_2.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_2.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_2.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_2.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_2.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "e31c30140f3e74f6dd0fe7b95e10d396d9c4d2b85da06d31f44697af227c7a0a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_4.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_4.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_4.csv",
+      "mediaType": "text/csv",
+      "size": 19160,
+      "checksum": {
+        "hash": "6f12eadb83bfc681e012af3d47742782d4f0028b774a805b04c1b5055be3e6e8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_1.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_1.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_1.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_1.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_1.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "01f2eb6d6fe5668e4766bd162617ea2f048e78de6c458ec0808d71eb5bade2a7",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_17.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_17.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_17.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_17.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_17.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "7b42092db17a4b48a4e93201db019df218efab43c92c2b47a868dec4817d6d66",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_36.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_36.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_36.csv",
+      "mediaType": "text/csv",
+      "size": 19505,
+      "checksum": {
+        "hash": "9e8db29608edb5f9ff2865128741d38b254cd1827582c3c2904058033a368482",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_17.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_17.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_17.csv",
+      "mediaType": "text/csv",
+      "size": 19746,
+      "checksum": {
+        "hash": "62d6b84eafa722542a611ef47fe5fa6882f6d146e8c2c8f710c48afc2b8ef764",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_19.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_19.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_19.csv",
+      "mediaType": "text/csv",
+      "size": 20002,
+      "checksum": {
+        "hash": "e3448f3ccaad92bddf4f6686203957e26b10c72f7c60f78e805d0a1455f6852f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_3.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_3.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_3.csv",
+      "mediaType": "text/csv",
+      "size": 19654,
+      "checksum": {
+        "hash": "5625e1a79e8df5e30fbd92aaebe6099e9a51d376c5bdd0a4eb5facae3ae57487",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_47.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_47.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_47.csv",
+      "mediaType": "text/csv",
+      "size": 19570,
+      "checksum": {
+        "hash": "7d053683fdb904154960625e63bd331779ea5ca774fd321e33fadbb8a4aaf12a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_49.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_49.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_49.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_49.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_49.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "ef680931a9430331999a41e2eb5f4b31b6367cdd1899fbfcbd8dea78bd361f04",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_28.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_28.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_28.csv",
+      "mediaType": "text/csv",
+      "size": 19178,
+      "checksum": {
+        "hash": "69c7409b64a791e0229eaeb1623d3abc3000c8bc5261a5a5db6b6d10a3e5d9e8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_15.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_15.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_15.csv",
+      "mediaType": "text/csv",
+      "size": 19572,
+      "checksum": {
+        "hash": "01d1861ce8205629a81e49185ac8e6197417ee02c170a69b2c0915d0fb5dbed4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_40.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_40.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_40.csv",
+      "mediaType": "text/csv",
+      "size": 19262,
+      "checksum": {
+        "hash": "1b729acc470328597513d5fb850c806e18516baf47160f44bb9db28cfb50a824",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_6.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_6.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_6.csv",
+      "mediaType": "text/csv",
+      "size": 18747,
+      "checksum": {
+        "hash": "0419731d96eabc0f1edeb5517df6f47c1cc201b6fedbaa2c3c6abd32fff7e806",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_23.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_23.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_23.csv",
+      "mediaType": "text/csv",
+      "size": 19682,
+      "checksum": {
+        "hash": "d25f0d70382bbac80898d206440cc4031eeb082bf6f53e3b313489750243cb42",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_24.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_24.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_24.csv",
+      "mediaType": "text/csv",
+      "size": 19834,
+      "checksum": {
+        "hash": "cf643b89625813f6b4a4c659485fa7a023f49d45d7159ddb38de0fefd4d79d11",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_49.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_49.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_49.csv",
+      "mediaType": "text/csv",
+      "size": 19915,
+      "checksum": {
+        "hash": "e47731453ff88e537b15fe8fa9f593147fc7157d56c3185a6a53061b8aff2a70",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_40.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_40.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_40.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_40.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_40.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "7e76a098ea1c9303ba483005ba1fabf468c90cdaa92a8a640d3acf6489ef76a7",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_10.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_10.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_10.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_10.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_10.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "62f4eb6ba97d8b741d4d5b7072ae482e028e48efd3cc04b1e2931f99e03b4567",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_26.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_26.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_26.csv",
+      "mediaType": "text/csv",
+      "size": 18608,
+      "checksum": {
+        "hash": "d923fed2140e8391657184645f5be337b817cc27def65fb4d5d7453bf982e936",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_30.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_30.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_30.csv",
+      "mediaType": "text/csv",
+      "size": 19398,
+      "checksum": {
+        "hash": "8750f6f89e2bf5b82f8a9a0b7438b33c2e3138adeaaefd227400432e103e1ceb",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_41.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_41.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_41.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_41.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_41.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "610dbd56e76785b78de1e715f9170eed34b8ca6304b7d5b0922a588357c9c0e1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_9.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_9.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_9.csv",
+      "mediaType": "text/csv",
+      "size": 19847,
+      "checksum": {
+        "hash": "b802eed8790170c08b9f140f980ddcc511a24094a6ede441f3d7f95e68d5f834",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_46.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_46.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_46.csv",
+      "mediaType": "text/csv",
+      "size": 19202,
+      "checksum": {
+        "hash": "cb6cf6d2c3bfcd6ba1b9c9c990514debc09eaebe7afdcd77bf89b077f88321c6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_30.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_30.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_30.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_30.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_30.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "bd82c6b061eda4f8faff41bd4969248109e0292b517526142651b77986284418",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_15.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_15.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_15.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_15.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_15.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "958c4902fa051522adb771df30972379eff1490bbc359a522b6edcf2e545d3b0",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_21.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_21.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_21.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_21.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_21.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "7a65620e36a96bb281a1664317c69f4d60c64185b1524aa118a0e22aced0f25d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_22.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_22.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_22.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_CSVInfo/group4_waveformTableSubset_22.csv",
+      "description": "SHA-256 checksum value for group4_waveformTableSubset_22.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "da9a20c200b0caead22185e081bf591c8d5a006465cbfd2a8ca1e758a4991e45",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_37.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_37.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_37.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730554,
+      "checksum": {
+        "hash": "4f64701ae01e9bdf1f26994fb5085153205011d1307e4ad9b7b062bfc9863b34",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_19.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_19.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_19.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463728126,
+      "checksum": {
+        "hash": "fcdf1dded8447e03635fb3e2b5dbb7088201f80c48910fa5607bd2d0d5a2072a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_4.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_4.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_4.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463728096,
+      "checksum": {
+        "hash": "8ac91327d17afc9bdfd4a273832392f34df1af8a291474c2f4a1672f85e3fe8e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_18.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_18.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_18.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_18.mat",
+      "description": "SHA-256 checksum value for group4_subset_18.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5d32c87d6caf6a78bafe80322ac69c72ea3ee57a6045b7af243ea34bd24f9820",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_41.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_41.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_41.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_41.mat",
+      "description": "SHA-256 checksum value for group4_subset_41.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "1347829797add68aa14d0f46dcb69ff198d9696fcdf243649e2aa8f252f6b215",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_48.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_48.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_48.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729146,
+      "checksum": {
+        "hash": "6d54c6c5b4ef65bda2bc60fbef8e9cde90cdcda2eb890ecb45e77f126628a118",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_43.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_43.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_43.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_43.mat",
+      "description": "SHA-256 checksum value for group4_subset_43.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "4efdaf6a875d6bf4eec412594a6dd38225c8a7591f50ff5fd9ffca940d9c4aa5",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_20.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_20.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_20.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_20.mat",
+      "description": "SHA-256 checksum value for group4_subset_20.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "e6a1a8238b640b59dadd67a721f356296a6d82313cea1d5ac2413cde70955864",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_7.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_7.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_7.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731571,
+      "checksum": {
+        "hash": "fc9fd92cd4447e76dddf17cfb37667bbea552d1cc6fdd38e98072710efb3715c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_29.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_29.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_29.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729997,
+      "checksum": {
+        "hash": "efffc20e3830a504448d245dc814a1e14b2b221657e6c62ef411ac4c2e5c5dc8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_36.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_36.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_36.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_36.mat",
+      "description": "SHA-256 checksum value for group4_subset_36.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "08841b9a820a9d4864c31df42425cd50d50b788b2ebd84813c96400b070bba7a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_40.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_40.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_40.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463727833,
+      "checksum": {
+        "hash": "5c926a22dcd6fbe47b962b0e83d669181a5b37508c85f8a75646fd2985341b0d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_38.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_38.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_38.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_38.mat",
+      "description": "SHA-256 checksum value for group4_subset_38.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "187709e403e20e5d26f31c3d9d68ffc4fea562d72254e3f392cd447539f97703",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_25.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_25.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_25.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463735429,
+      "checksum": {
+        "hash": "9ff87b76aafed9ff3a124e0e9b54d2adb72991110e5a4bb542acea2a8f456b66",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_37.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_37.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_37.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_37.mat",
+      "description": "SHA-256 checksum value for group4_subset_37.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "d31ee500938a65d579a576d4306bd6d2d24cf881115ce1098c4917ec796b73a9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_10.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_10.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_10.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729807,
+      "checksum": {
+        "hash": "128ac00d8c6c334959baad5219a18ca020426aa9b6b2db1c0a40c419530a9a6d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_17.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_17.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_17.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_17.mat",
+      "description": "SHA-256 checksum value for group4_subset_17.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "fdbba5e39b439a66f3e53f8154ba24ed70de98d19f4fc010cfcc5a91531ba1e5",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_23.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_23.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_23.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731582,
+      "checksum": {
+        "hash": "abe436d1d93f3afd1b05b686cb59879305b85f5a3b2588782c2ac01710236d58",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_27.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_27.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_27.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731220,
+      "checksum": {
+        "hash": "64db647c9aba405609cc1c6ea50c20fbf65045fe1079c2b704eb6e8562febd96",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_45.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_45.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_45.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463741848,
+      "checksum": {
+        "hash": "623e0ac450756ac965a3acdef8e8dfdd37ba87899edcfb300529c7e46e7a61af",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_34.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_34.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_34.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732872,
+      "checksum": {
+        "hash": "f5f1078e7f90a85bf10f24639f00ea7eba1b549a7bbcc509445a8b0be43cb389",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_1.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_1.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_1.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_1.mat",
+      "description": "SHA-256 checksum value for group4_subset_1.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "568e8939dd6b0a4fd98c9a3ec29fb4a5e5ad7e40613517d347c2a4fbdbc030b6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_3.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_3.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_3.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_3.mat",
+      "description": "SHA-256 checksum value for group4_subset_3.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "4462a01adac69ae3ab74491d582028cbfe02f4613b91d7fb225f1eca1f3e36ec",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_44.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_44.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_44.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_44.mat",
+      "description": "SHA-256 checksum value for group4_subset_44.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b6f22732481bc360cd9e6d2be2dba1aa051dd857847199fcb8f9105b82072c22",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_38.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_38.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_38.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729245,
+      "checksum": {
+        "hash": "502d2fa8410179bad6e87a898a07ec64b983dd8b5d331d4a7e971899f5f5f3b5",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_7.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_7.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_7.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_7.mat",
+      "description": "SHA-256 checksum value for group4_subset_7.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "e2e99d45d34c0c3518767dbc6616fd674c57631ce80e76cf83db3ae196ef8db0",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_5.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_5.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_5.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734866,
+      "checksum": {
+        "hash": "628b2168e72d3865b0f34260d1c4d02dbe1421b81c74221666b5494315e16d7f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_14.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_14.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_14.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_14.mat",
+      "description": "SHA-256 checksum value for group4_subset_14.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "e88aabd8312fcf87ca9869cf82909de36dff764563830c0660f7d126c6c960d9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_30.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_30.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_30.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463735044,
+      "checksum": {
+        "hash": "5139eaa435a58dad2a35310c9ae47f50f6e3bdad040fd64fcae44adf99799af3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_20.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_20.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_20.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730182,
+      "checksum": {
+        "hash": "cbf1d89855636f7ad4d8a1e34769ecb55fff3b318815911eeedb49a6a77b6ad4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_47.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_47.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_47.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732243,
+      "checksum": {
+        "hash": "1b09e895587a22e32b3926051b99bec32f4cb0fd93be7506898ac658c9a57ea1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_8.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_8.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_8.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730225,
+      "checksum": {
+        "hash": "8fbfe2ef13b4ea41ad97554de1b94955c251684dab69ca4822bb4b51c428e9a9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_27.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_27.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_27.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_27.mat",
+      "description": "SHA-256 checksum value for group4_subset_27.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "669df58ee1122650ee05d2ae1746a54702626d00b99bf6433d2ddc4ca1ba19d4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_49.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_49.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_49.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_49.mat",
+      "description": "SHA-256 checksum value for group4_subset_49.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "a05f3ad3816b598acafdf896bb1d2f1344a8b09f8528d2ca3d24c5c82e93a0b2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_4.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_4.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_4.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_4.mat",
+      "description": "SHA-256 checksum value for group4_subset_4.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "0061f3072ef898668537aaeb87e0feb2c0616419564da2ae6b41f10a024c9479",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_17.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_17.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_17.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730536,
+      "checksum": {
+        "hash": "b10c26b843eb07c1c1052bf58721a86a267ac4658f1fb7dea1d496f3856677dc",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_15.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_15.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_15.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463735081,
+      "checksum": {
+        "hash": "d2fafcb5ad17c5f74db6feebea2d195a810f2468da986c4f9c0dd11a2944363e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_13.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_13.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_13.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_13.mat",
+      "description": "SHA-256 checksum value for group4_subset_13.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "2fed50e3e004cfcc4a7ff578e7cd1ac29cd5c9d5a8f301e130464ebad022fd99",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_31.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_31.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_31.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_31.mat",
+      "description": "SHA-256 checksum value for group4_subset_31.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "6782a909d54abdd9def3811aa6e5e6bcafc6af3c3555bae581f8f8da34d531e6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_50.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_50.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_50.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730931,
+      "checksum": {
+        "hash": "42a49285231568eddc137a46792ebc412440b63f5e1196710277e2d1d8218d23",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_35.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_35.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_35.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_35.mat",
+      "description": "SHA-256 checksum value for group4_subset_35.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "668c7ccd33eebd5b472cbd8db129740fdcf289f5e11db5f2686fe1228422ef18",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_29.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_29.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_29.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_29.mat",
+      "description": "SHA-256 checksum value for group4_subset_29.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "d89603051640e62b9f633cdb1ff831c072f1c43fdcc23d04098b2b597d9c49b4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_45.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_45.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_45.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_45.mat",
+      "description": "SHA-256 checksum value for group4_subset_45.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "7f2973502b43e467ba5a65d8ec3389435270e4bfa74f733013f41a33da71d31d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_25.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_25.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_25.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_25.mat",
+      "description": "SHA-256 checksum value for group4_subset_25.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9981b4b2eb274c90e97ee9bb2705f5d19e5e7e8fce7350fffed499a573ce6175",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_32.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_32.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_32.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734650,
+      "checksum": {
+        "hash": "37acfb54fafe90c8c89ed38a5a000ac436bcaff85550fcf9f4f8a0d27e89ba2b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_9.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_9.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_9.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_9.mat",
+      "description": "SHA-256 checksum value for group4_subset_9.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "7e6bd3ba5361ce6e06ca5c5b142b97b0ca9b8878eca595f4b0965dba812de5bf",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_16.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_16.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_16.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730183,
+      "checksum": {
+        "hash": "e0993399d971610884fdbba790a705ed79a48f7e059fe575264acfc36174ff3c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_5.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_5.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_5.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_5.mat",
+      "description": "SHA-256 checksum value for group4_subset_5.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "83aae16c3586e575ce74aafcb6d160b599a6a701d6437f9945497d5af869e819",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_44.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_44.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_44.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729802,
+      "checksum": {
+        "hash": "8dda270a9ebd7111e85a170b864029db6619b0208791b0b525bf2a1bebad1fd7",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_6.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_6.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_6.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730012,
+      "checksum": {
+        "hash": "4dbd1d330e3e82edac44f548963e63b6b2fa75b2583223de08f38fa35ce89aba",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_19.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_19.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_19.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_19.mat",
+      "description": "SHA-256 checksum value for group4_subset_19.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9d96f12779aef57f658f74d3b4a08cb9c5e1b77cb01988d21cafb43a655e7745",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_30.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_30.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_30.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_30.mat",
+      "description": "SHA-256 checksum value for group4_subset_30.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "1848cdb84e7851a8d0a9680f5a5ebf3dd91ba0accf937c3afa8f1b84943bef6e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_33.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_33.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_33.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734896,
+      "checksum": {
+        "hash": "0431e5d9258b0dc39d401d81309eccbb25c2c637d58ca6c28eb3acb54a1a8cd8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_39.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_39.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_39.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734899,
+      "checksum": {
+        "hash": "6645862722cfc1f1227b20500da07f5e9be780f87ad2c10dddd277e170124a64",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_22.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_22.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_22.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729708,
+      "checksum": {
+        "hash": "1eec2cd609d3a3b29b79548b85c28c54aeb5e587fa473a9517f34d2080c08817",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_49.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_49.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_49.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730821,
+      "checksum": {
+        "hash": "687dbb48d5bebfea78267b7f2b730c42f64ce4793afd8ce827c59204876011b8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_9.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_9.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_9.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463733087,
+      "checksum": {
+        "hash": "80c9d4db1e3ad18d3b01fb0d682b31427408f661ff35b5092fbdfc38b0876c66",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_12.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_12.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_12.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734038,
+      "checksum": {
+        "hash": "a9c2064763c99375f54d3d21822f82d70e11200afef97ee91e601c3f886550e2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_47.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_47.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_47.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_47.mat",
+      "description": "SHA-256 checksum value for group4_subset_47.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "c88c8d98d2b4431c30b06030ca2facf7cc0604b097f7caec5badba9156408fb6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_36.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_36.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_36.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463736606,
+      "checksum": {
+        "hash": "025032051a2d71bfad726e91053042d8ecef0d6ca082dc1f86e81a80e5a32970",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_34.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_34.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_34.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_34.mat",
+      "description": "SHA-256 checksum value for group4_subset_34.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "fbc3375cd2a730ddef0e54ca8729862b6b19784d77f35c41dc7596cbe46a61b7",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_1.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_1.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_1.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463728241,
+      "checksum": {
+        "hash": "32f3090eecced47b84ff4904a85a1d7333e0501449b787a6bbf1c2a3a9c33e0e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_21.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_21.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_21.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463738545,
+      "checksum": {
+        "hash": "deff5cf098c8837fcb8f296697f33df322ab4b8b3207a471c1ec05e185bb5ac2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_28.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_28.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_28.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_28.mat",
+      "description": "SHA-256 checksum value for group4_subset_28.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "3ce73049200204fb5e21889e7043fef695842a3e1d0e3190bd5bb50cb50ad7dc",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_41.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_41.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_41.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734441,
+      "checksum": {
+        "hash": "5002cdf7b6c83a8d0f8c8cb5c721bc7685d8578fff820d07dd03aac5b64c5f85",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_43.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_43.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_43.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731902,
+      "checksum": {
+        "hash": "35f4e17ef1a3e88178a0f8ff6d1cd43fc074e30af44da4d7d4f5ee06fefe959f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_28.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_28.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_28.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731009,
+      "checksum": {
+        "hash": "2d7d493a9dff3a190130e0ec24ef340be2ab32257288962085190c77a5952923",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_50.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_50.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_50.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_50.mat",
+      "description": "SHA-256 checksum value for group4_subset_50.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "8e0f6476af0ca690c5fc8f1915fd1b60a50ced4a0ea6088d24771dbedadacab2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_14.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_14.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_14.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463728275,
+      "checksum": {
+        "hash": "f763f73805fd4cdb789909d0d7b3595eac45366f8bce44e85ddfe838d2cda619",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_24.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_24.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_24.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730268,
+      "checksum": {
+        "hash": "05e2b33f9aac15f29b9025b942d885eeafb8cb4d4e77ba5fbd15c1f3d3b9c7e1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_46.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_46.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_46.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_46.mat",
+      "description": "SHA-256 checksum value for group4_subset_46.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "caa048b88e569a18f62f9d76198641d2d48d4cca6757744ae2f4a2e2852898e1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_12.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_12.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_12.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_12.mat",
+      "description": "SHA-256 checksum value for group4_subset_12.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9a7bc8277e38d524286f21d5fdda15c60058724f988294e423600beaf5884457",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_10.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_10.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_10.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_10.mat",
+      "description": "SHA-256 checksum value for group4_subset_10.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "4bfe5c43e1ed3f9469e1eedfa32ae067d4f2fdf60694b1af8ae8d9e7af05dee6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_35.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_35.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_35.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730811,
+      "checksum": {
+        "hash": "645d876cd9208ad16ba73106540b4c2559d75de18ea2f097b321cf26374e18fa",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_32.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_32.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_32.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_32.mat",
+      "description": "SHA-256 checksum value for group4_subset_32.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "ef71e474b15ff8fced56e77f6ba5a32a26b7daade28ea3464fc1802140fb2b1e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_23.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_23.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_23.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_23.mat",
+      "description": "SHA-256 checksum value for group4_subset_23.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "992170f7b72352f0bb7219a20e86df338954e82bb463c440e8df14e0d25c6680",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_31.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_31.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_31.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729715,
+      "checksum": {
+        "hash": "2997267a5ddf1c9bc9794cd25982b32689c6257b1e48b5c7fd6547b35ab29bd3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_42.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_42.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_42.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_42.mat",
+      "description": "SHA-256 checksum value for group4_subset_42.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "582c0f9d1055f4a97d4a62681ecbca1af0dd2e49e7fc03b44e6677fa4c7759be",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_3.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_3.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_3.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731175,
+      "checksum": {
+        "hash": "d308bdec1d3088dce2cfc2026c129178f286002aa65485cfbcc085cd2097444f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_22.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group4/group4_subset_22.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group4/group4_subset_22.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group4/group4_subset_22.mat",
+      "description": "SHA-256 checksum value for group4_subset_22.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "12de2b76a9072202a9ad435c9b6c7c5105a6af6d69040ae614e2a1859ae4f855",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/readWaveformsCodeExamples",
+      "@type": [
+        "nrdp:Subcollection"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/Subcollection"
+      ],
+      "filepath": "SimulatedRadarWaveforms/readWaveformsCodeExamples"
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/readWaveformsCodeExamples/readFileExample.m",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/readWaveformsCodeExamples/readFileExample.m",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/readWaveformsCodeExamples/readFileExample.m",
+      "mediaType": "text/x-matlab",
+      "size": 1083,
+      "checksum": {
+        "hash": "59ef21d09e8c229d7358995977f34ebe5c705fb91c6c75f7e1febee03017461d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/readWaveformsCodeExamples/readFileExample.m.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/readWaveformsCodeExamples/readFileExample.m.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/readWaveformsCodeExamples/readFileExample.m.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/readWaveformsCodeExamples/readFileExample.m",
+      "description": "SHA-256 checksum value for readFileExample.m",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b3e47aacdef02b9aa76a87875c52aec5ca0575a0d7e1590867ea04f528241a53",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/readWaveformsCodeExamples/readFileExample.py",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/readWaveformsCodeExamples/readFileExample.py",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/readWaveformsCodeExamples/readFileExample.py",
+      "mediaType": "text/x-python",
+      "size": 1241,
+      "checksum": {
+        "hash": "664cf32d73e55771c4aa761718004bc798a814bed1cf7d320568015e3d798466",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/readWaveformsCodeExamples/readFileExample.py.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/readWaveformsCodeExamples/readFileExample.py.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/readWaveformsCodeExamples/readFileExample.py.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/readWaveformsCodeExamples/readFileExample.py",
+      "description": "SHA-256 checksum value for readFileExample.py",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "6cd6825c481bcf0c85496ab44772926b61d506952f5fe135a9b5868df5033c71",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/readWaveformsCodeExamples/previewWaveformsFromFolder.ipynb",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/readWaveformsCodeExamples/previewWaveformsFromFolder.ipynb",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/readWaveformsCodeExamples/previewWaveformsFromFolder.ipynb",
+      "mediaType": "application/octet-stream",
+      "size": 3293572,
+      "checksum": {
+        "hash": "0fc4572865f5e338641a7240a9e3b366eb8f929930df9d594a6cc285ca5ac659",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/readWaveformsCodeExamples/previewWaveformsFromFolder.ipynb.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/readWaveformsCodeExamples/previewWaveformsFromFolder.ipynb.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/readWaveformsCodeExamples/previewWaveformsFromFolder.ipynb.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/readWaveformsCodeExamples/previewWaveformsFromFolder.ipynb",
+      "description": "SHA-256 checksum value for previewWaveformsFromFolder.ipynb",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "8e5b1fd0f727e3c3b5237e2ebdaa7f95757af308dfcd314efeb3ff5c8bcc0d48",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3",
+      "@type": [
+        "nrdp:Subcollection"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/Subcollection"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3"
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_39.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_39.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_39.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463733367,
+      "checksum": {
+        "hash": "48daa74e2208e360aa586e795d79ec1143e5a320c64d69be1963862e120d1e3f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_37.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_37.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_37.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732495,
+      "checksum": {
+        "hash": "ea92ad69cbc8df20e530f824f8e1fa2f8551da3a8ed7a73e5e432e1a665dbfd2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_10.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_10.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_10.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_10.mat",
+      "description": "SHA-256 checksum value for group3_subset_10.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "350d3995a0460b6045301d9808c19eaa5f58b5dca0da6a1cf83a9651c4a7a7de",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_29.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_29.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_29.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_29.mat",
+      "description": "SHA-256 checksum value for group3_subset_29.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "3a5946127fd804ac0d383dc171544b7f48edd7388615533fea8b0892d4bfbb4d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_24.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_24.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_24.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463733741,
+      "checksum": {
+        "hash": "9fd1332a618bd1630c02c31ca92c33f5e7adcfe735434b0de696599b6a8cf74e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_48.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_48.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_48.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463728127,
+      "checksum": {
+        "hash": "f4cea6271f335b25eae1c362ac990fc52419e63edf503b401d007e8ccf0d78d1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_30.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_30.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_30.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_30.mat",
+      "description": "SHA-256 checksum value for group3_subset_30.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "c9ab4530ae4f3bfa0e90bcbcbfce52945b2b9f9f7546c199bb88384da706e7d1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_34.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_34.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_34.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_34.mat",
+      "description": "SHA-256 checksum value for group3_subset_34.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "0d4ec3ebcd8326ef4249c6f477fce936b03016224f8bb37a428359aa124421c3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_12.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_12.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_12.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_12.mat",
+      "description": "SHA-256 checksum value for group3_subset_12.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "a36c08fb9c07ebf34ec76ec5eb07f2ce93bfba25c27f978aaaf17e1b1faf29ec",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_50.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_50.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_50.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_50.mat",
+      "description": "SHA-256 checksum value for group3_subset_50.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9fe1995c1d554286f3de67494d85ca88722a6f1b97ac2df04fd8dbdf0a9e9c71",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_49.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_49.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_49.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463726905,
+      "checksum": {
+        "hash": "2124fe09ca89a7dfe7cce19864beb0068e481f9249fc02bca5cf0d0ba1d3b853",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_18.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_18.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_18.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_18.mat",
+      "description": "SHA-256 checksum value for group3_subset_18.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "0269da85db3ca8664c5fb4d1ea3e96bf0f65a27387233da19fe1ca1276dd8324",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_30.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_30.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_30.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463736685,
+      "checksum": {
+        "hash": "1158413c36e2b287a50998d73be5e0c562b9c08ff5cb70f7bad2ff04210f98c3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_9.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_9.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_9.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_9.mat",
+      "description": "SHA-256 checksum value for group3_subset_9.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "4425c1408a16ffdb89920023f22b57deff25de43fc954ae446191175112476ba",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_21.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_21.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_21.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_21.mat",
+      "description": "SHA-256 checksum value for group3_subset_21.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "7624b7b828f6aa8405afa88bf9e12865635d4439ef6cb62390e8f4ef83100c17",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_14.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_14.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_14.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_14.mat",
+      "description": "SHA-256 checksum value for group3_subset_14.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "290ee29653892518722bf785598c5ed05a0dcc5bb011bc09267a3ac4e0c1dc22",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_25.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_25.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_25.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_25.mat",
+      "description": "SHA-256 checksum value for group3_subset_25.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b2ad379a5ee9629a82552480a3ea1721d56e42e68a3508942a785a5b70e06e6c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_41.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_41.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_41.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_41.mat",
+      "description": "SHA-256 checksum value for group3_subset_41.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "175ff8a48c59aa2882fdc30d20c83102edbcc8d72f280ca530cde863ea830acd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_31.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_31.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_31.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_31.mat",
+      "description": "SHA-256 checksum value for group3_subset_31.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "cc8217244f7cb163221306fac122ec600e71c8249afed72e4b6575efcca3fd74",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_36.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_36.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_36.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734898,
+      "checksum": {
+        "hash": "e55643feb34a95d08d2ac029f4ed17e356e732c1a469f58ec18f3a0d86137692",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_1.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_1.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_1.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734007,
+      "checksum": {
+        "hash": "fea3862556a4ff743092cd431019d01db51d24b9f19435d81905f52ace9067db",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_47.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_47.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_47.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_47.mat",
+      "description": "SHA-256 checksum value for group3_subset_47.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9bf4854db86374f98c2db931f273396711dd29840af3dd734f99ef500b4db4b4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_17.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_17.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_17.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463740377,
+      "checksum": {
+        "hash": "005681539893f8006176331d9ec98bea340caea3e499ae8e75d178c4e3752639",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_16.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_16.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_16.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_16.mat",
+      "description": "SHA-256 checksum value for group3_subset_16.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "37578d6b2880a5c2dff588f724e5e4f99807f7d09951d91d108337d987e6cde7",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_32.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_32.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_32.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731813,
+      "checksum": {
+        "hash": "af25e6651eb8362cdb8af1ce204913fbd5ae69ceff61a1df3004b77c3cb2bc9c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_27.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_27.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_27.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732669,
+      "checksum": {
+        "hash": "b317e285bb435e2c13a04795de6b5d5db569d295d9aabf72ac79080389644a36",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_26.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_26.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_26.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_26.mat",
+      "description": "SHA-256 checksum value for group3_subset_26.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5adbe994a9249f41da71341e50a2547f47f1afe33f0e4f0584c7800462bebb69",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_44.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_44.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_44.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_44.mat",
+      "description": "SHA-256 checksum value for group3_subset_44.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "37bba7653f5e473a65724aca4983bc3b22137a16a679332ff4323de0f387b374",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_2.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_2.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_2.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463727700,
+      "checksum": {
+        "hash": "bd6e420a9d46138e4cb148e037105977def2dec7d26b50f025bc9f49f6453aa6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_8.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_8.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_8.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_8.mat",
+      "description": "SHA-256 checksum value for group3_subset_8.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5f21c622adbfc134a5983d49309b6473abbf9d57fc97f092e6523f492f1fa17b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_22.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_22.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_22.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463723915,
+      "checksum": {
+        "hash": "a25a44dc8122e6d660e1d0b3ca4041d4e9b4f7a7b876cc104076c574a0405839",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_20.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_20.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_20.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463727415,
+      "checksum": {
+        "hash": "9ae92699b41dff2c19cfb726313787f7f606831e5e6a506383221a45c2837219",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_22.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_22.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_22.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_22.mat",
+      "description": "SHA-256 checksum value for group3_subset_22.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "04f56c56f728db4c364637438387e661f594097099e2809372dfcbbcbe87c315",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo",
+      "@type": [
+        "nrdp:Subcollection"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/Subcollection"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo"
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_9.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_9.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_9.csv",
+      "mediaType": "text/csv",
+      "size": 18404,
+      "checksum": {
+        "hash": "27fa56df039daf8d46ec3389a2f3d7eb358326b934b92a98b0714c7d5569b29a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_42.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_42.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_42.csv",
+      "mediaType": "text/csv",
+      "size": 19878,
+      "checksum": {
+        "hash": "0f86b461c92880cd2a7f1a17f94aeade6ba71c5a4373e04b877429fc8b9e09d9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_6.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_6.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_6.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_6.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_6.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "442556495e33dcb0735995e905922dfc3f8a818cd9eb429d15e661759649fd58",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_15.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_15.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_15.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_15.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_15.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "d2eaa85ed5a4d63cca6b9f7e1b0b0961387dc955ef137e80067cf26680d9b13e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_1.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_1.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_1.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_1.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_1.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "621d3ef67980cffa371028f1a4150baea9b3f2efcfe8b6d73083f4c2afb57634",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_34.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_34.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_34.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_34.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_34.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "eccd72e9c722f48b1c6f3e642372c2708a23695a1ba637ecb94e8ecd3965652f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_10.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_10.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_10.csv",
+      "mediaType": "text/csv",
+      "size": 19330,
+      "checksum": {
+        "hash": "d06cfbed280a0a6b442b6e8269e5769a7a35ea764d8cad9ed7d362eefd2d9083",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_41.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_41.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_41.csv",
+      "mediaType": "text/csv",
+      "size": 19645,
+      "checksum": {
+        "hash": "ae8f5b5c76d97fad69c5b081a7d678abf711f31c1c44c37a155cb8e032b91d1b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_15.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_15.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_15.csv",
+      "mediaType": "text/csv",
+      "size": 19713,
+      "checksum": {
+        "hash": "349728eebc1e93492a899d6975596b0e690a38987f6bde76a0ef1132a0bc78fe",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_27.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_27.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_27.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_27.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_27.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "a6eae7d7113ea5136bf9a6d8f900dee81d447df6a767460c0269129b6489e8fb",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_24.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_24.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_24.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_24.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_24.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "cae51858682eb56c0cfe68e7fa44d16ca6e5356681b933217fb2fab7be58e8d8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_43.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_43.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_43.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_43.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_43.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "8684290769268ee18b1e8e97ef4484e1730d698a6b9336fdf545d19da8e2e25b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_5.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_5.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_5.csv",
+      "mediaType": "text/csv",
+      "size": 20212,
+      "checksum": {
+        "hash": "c9e6731a580d58a847810dcc101df8570fb26f9ebf312a12f1db6a1e626b0a96",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_17.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_17.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_17.csv",
+      "mediaType": "text/csv",
+      "size": 19659,
+      "checksum": {
+        "hash": "8e4c7038dcda6101d107d1df420beeba2970a8606ec6eae1d114e10e6889fa03",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_28.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_28.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_28.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_28.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_28.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "97213ddf7a923d044974f4b740fd789d54952ce3fed734117a5b8cbc1193bb8d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_38.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_38.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_38.csv",
+      "mediaType": "text/csv",
+      "size": 19234,
+      "checksum": {
+        "hash": "642f7b3e0ce0689e783f9cf75216d832b7a1ba103f77255cf04ec1281a152053",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_45.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_45.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_45.csv",
+      "mediaType": "text/csv",
+      "size": 19898,
+      "checksum": {
+        "hash": "b2b1448b10e761e670e3282d2d3bca708862f39ea7ee14b6da4df64e7e98068e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_11.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_11.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_11.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_11.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_11.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "552927aa58129fb2b4fbf03970c38ddbeff213ddb1b3915ea9c03b1697350567",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_27.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_27.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_27.csv",
+      "mediaType": "text/csv",
+      "size": 19575,
+      "checksum": {
+        "hash": "7ca62d5c785418066ecbd21a64c2037efa734a64d6d739336be90bbc9dbc15ac",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_8.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_8.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_8.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_8.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_8.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "a314883221178d0abbdcfbe105e77e5cd67c811a1164c5ec0fa888a8be58800d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_2.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_2.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_2.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_2.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_2.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "f00dd79566156cf69b9bfe3d1185193e94951f70eede675e4a7fa6fb353e3ef2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_18.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_18.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_18.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_18.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_18.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "72536e27dece189777d0030f12bcd03963703538459992b53f2f86740097532e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_16.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_16.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_16.csv",
+      "mediaType": "text/csv",
+      "size": 19455,
+      "checksum": {
+        "hash": "b34227f25f0b8f7715ec454d79b3f64a9c1d0ada17ae1e6b0621aaf37a7beefa",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_48.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_48.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_48.csv",
+      "mediaType": "text/csv",
+      "size": 19177,
+      "checksum": {
+        "hash": "91da571d09449eea9f001dd06218d70ce7787be508843e51fcbb0cb9ab619b3a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_12.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_12.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_12.csv",
+      "mediaType": "text/csv",
+      "size": 19105,
+      "checksum": {
+        "hash": "ea17cc1a0d476c4bbfa21c68c1ec394801a3c17dfc486e4179fd47e399504958",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_14.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_14.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_14.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_14.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_14.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5c151772ad8ddcbcbcc5d55d90f4f904581c14f6e24aed303bbbc97a597eb4a8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_22.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_22.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_22.csv",
+      "mediaType": "text/csv",
+      "size": 19294,
+      "checksum": {
+        "hash": "8c912f92964b61cd3d607c502f219db29437feec48ed064b8c19f09642f58b57",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_33.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_33.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_33.csv",
+      "mediaType": "text/csv",
+      "size": 19968,
+      "checksum": {
+        "hash": "634265b725b8542b91b0fffd44e0d643271ff7d116668b4bc77cf3eeece92581",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_40.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_40.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_40.csv",
+      "mediaType": "text/csv",
+      "size": 18714,
+      "checksum": {
+        "hash": "a47ccd0e095a8605eadeef1d82c04f75197ebdb4294003eb48456a2df93b4419",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_48.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_48.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_48.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_48.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_48.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "dd84aa609308b9dd143c28098304d15ad064c30f58e0fe24ad16072455c7fd79",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_7.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_7.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_7.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_7.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_7.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "f271a39f22bfaa0819e3eedc99b889a918db6afaf3da644b6320ddebf189df0b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_35.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_35.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_35.csv",
+      "mediaType": "text/csv",
+      "size": 19621,
+      "checksum": {
+        "hash": "de631ecaad0abc9f4f3b71daa4018499bc94ff5c20b4eb6c2d99f47a16df03d7",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_9.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_9.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_9.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_9.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_9.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "8e450c8ce8a4ee6c32ab6575409f3140aa056d8617bf50723e11c794882ad6e0",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_17.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_17.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_17.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_17.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_17.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "f0f0976c17f3f3aec11342ee2ed7f61e6123c1aa9cf917fe4de272570880fc63",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_20.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_20.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_20.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_20.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_20.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5517268be9a85b96db92eb7ed01c65f9ff4a402864f4e5f130b8c59e16f81658",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_32.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_32.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_32.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_32.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_32.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "dc34197571ed7424561e39d9dad0eb3bf31f7eff24ce2e5fab2998f8ea6f3eaa",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_30.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_30.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_30.csv",
+      "mediaType": "text/csv",
+      "size": 19360,
+      "checksum": {
+        "hash": "00915675a2afdfe353afce8df141eba9ecfac2fb491661d978c40365e4e1dd09",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_30.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_30.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_30.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_30.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_30.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "f4f6fb34fb0c87bc2ecf04e611d32fa4b6820d35b53910b7ee9f3f386b521848",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_35.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_35.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_35.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_35.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_35.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "3d24aa49edc5135ae4deefa2f5855a466fb15ae3da0d115899d2d2bd41e792ee",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_49.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_49.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_49.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_49.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_49.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "fe746f1bf8c7bef3e7038941dd7042ef73caa9397d81fa58e65fc80cf502daa8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_37.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_37.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_37.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_37.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_37.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "a7fa3945384e68822ba3a9dfcbbe0b527ec35f83527fcfdc25368192557d4830",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_39.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_39.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_39.csv",
+      "mediaType": "text/csv",
+      "size": 19302,
+      "checksum": {
+        "hash": "65f6f729905c5e93f3c9ae694824ca7b9e720ddc086aea9e9b7e09d3655d326b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_12.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_12.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_12.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_12.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_12.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "375526b9f0372f9d309e87c7fa9cc71f1fe00b47f8bc0ef33f17f3fe8cf03e38",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_29.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_29.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_29.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_29.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_29.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "c43d0c4795f270cf43602915512db286762ec187498050986f25411ded92ecc5",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_47.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_47.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_47.csv",
+      "mediaType": "text/csv",
+      "size": 19549,
+      "checksum": {
+        "hash": "7965bbf8e6cb15f66bdf72bbcd4c61f66ae44c14354cf44d1ccc3bbc82f5d682",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_33.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_33.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_33.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_33.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_33.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "a92ca0b3498fb4d0889f7c3c9632018b1d4cdc4e28dddb33163946472cae0cd8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_50.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_50.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_50.csv",
+      "mediaType": "text/csv",
+      "size": 19868,
+      "checksum": {
+        "hash": "9e2d34f933236ef67061148365f9b5a8210d614c212f7d828190fa659961f1bd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_23.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_23.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_23.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_23.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_23.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "ae21f97945885f8fa9bf002048e3395f01cc49bfc579659aaf55ac7ebed611ae",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_38.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_38.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_38.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_38.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_38.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5c7e63163e9cb5e66d59abb08a67d80396b1fcdcc72321070c84723d33d00626",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_46.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_46.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_46.csv",
+      "mediaType": "text/csv",
+      "size": 20006,
+      "checksum": {
+        "hash": "87fc153d40217521c4a89e31e1ce142d2fd199b291e2eba33e2efd1bc290cc6b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_37.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_37.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_37.csv",
+      "mediaType": "text/csv",
+      "size": 19675,
+      "checksum": {
+        "hash": "386408f62ffaebe719c2dc585b07e184d7004da79ae3ba99e768a36682f3527e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_20.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_20.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_20.csv",
+      "mediaType": "text/csv",
+      "size": 19652,
+      "checksum": {
+        "hash": "49dd04a3dc374b71b5b8564efa8ba4924494df6ba7e79a5a7767de15808ce266",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_26.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_26.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_26.csv",
+      "mediaType": "text/csv",
+      "size": 20371,
+      "checksum": {
+        "hash": "3fa722a49c9265555f03651579942292ac690e38e54214641d2c0b3dc4d7736a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_34.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_34.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_34.csv",
+      "mediaType": "text/csv",
+      "size": 19097,
+      "checksum": {
+        "hash": "c198abfc5a8772f00b75d9f25d4fe9c4f9111335b5a9e0001e9c1b68c06db9c9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_10.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_10.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_10.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_10.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_10.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "36ce10b42b8044a66b34347a2f91cc53b8094db904b162ee72431fc20ec9a8c6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_2.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_2.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_2.csv",
+      "mediaType": "text/csv",
+      "size": 19768,
+      "checksum": {
+        "hash": "90be8e53e94b2ff051b39982bbbd35f5041179d843cebb8c0e4eea49ca0a59d4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_29.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_29.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_29.csv",
+      "mediaType": "text/csv",
+      "size": 19508,
+      "checksum": {
+        "hash": "d1c65c75390dbc1c1bcc7a4f5d8f8cd1aa32c604afd4628fabd95fd57d371352",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_6.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_6.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_6.csv",
+      "mediaType": "text/csv",
+      "size": 19252,
+      "checksum": {
+        "hash": "a7db117a923ae0a0d64726579338ebb68eb828709bd25dff1c75469fea51a780",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_8.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_8.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_8.csv",
+      "mediaType": "text/csv",
+      "size": 19037,
+      "checksum": {
+        "hash": "5bcd768d30f989c45bcb61568f84051c94afee3ca3ece98f9cbe1ab26c3062ad",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_24.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_24.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_24.csv",
+      "mediaType": "text/csv",
+      "size": 19546,
+      "checksum": {
+        "hash": "9945b55f13d9bc0c071c8e429e6b75d160e898fc63dd7eba64ec3ec192f947f6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_45.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_45.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_45.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_45.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_45.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "c4f3e6ff2b77e675d037369e0a62ad67c27c0f6129e2cd56864d211313d51262",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_25.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_25.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_25.csv",
+      "mediaType": "text/csv",
+      "size": 19666,
+      "checksum": {
+        "hash": "8f32c0cbab01e1e300deb8cdd83fb5ebf3ca6db7e40be748c1399b0ec5eb4d48",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_40.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_40.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_40.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_40.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_40.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5d154c28fd577d7709d4c3ee29c97bc28050222aa3ed235c2a5be667a6d7dc20",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_18.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_18.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_18.csv",
+      "mediaType": "text/csv",
+      "size": 19318,
+      "checksum": {
+        "hash": "ae43d43adcdcbd480d34cbdb3a54af64da96ec181fdba2a3d7b4fa29a1a33def",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_25.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_25.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_25.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_25.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_25.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "30c4977fbb3c423ea0c80d52541481a8fe997655b437cf80bcc96d43ba3ac893",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_49.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_49.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_49.csv",
+      "mediaType": "text/csv",
+      "size": 19948,
+      "checksum": {
+        "hash": "08a0f7a80a49178cabffb201414fc5a01ddbe5ce4a8538ddd2303262be1ff4a3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_4.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_4.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_4.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_4.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_4.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "2c4c1859d60b8fc4aa421509e797504b5211e7bb4b9ebea6dd9bb40cb7792460",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_19.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_19.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_19.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_19.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_19.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "d993d2ee6060e64c7fdcfe753f6feff0f6fa713fc05a15f5fa30cae04c8d1023",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_13.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_13.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_13.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_13.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_13.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "1c46b2530dc41a66a1a3de2c1bf35930ea2b49645974f07eff038d26cb630ebe",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_44.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_44.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_44.csv",
+      "mediaType": "text/csv",
+      "size": 18951,
+      "checksum": {
+        "hash": "a84fd2a84989f75125d9d5b19624e54aea65354ad05634076e28dafa8f8bad13",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_50.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_50.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_50.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_50.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_50.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b4a5b8b07a6117a7c78f74b1746ab75cc1bf76efbea042bd0e31ad828cc6dad1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_19.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_19.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_19.csv",
+      "mediaType": "text/csv",
+      "size": 19551,
+      "checksum": {
+        "hash": "592271908f9c7d12b1a9799a9fa11fdca74c975c658de913b769622c73e66d48",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_47.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_47.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_47.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_47.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_47.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "cad6e956617acee0cf087559c3b3d5376848832299ad55cc44ac86b243f14a32",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_41.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_41.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_41.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_41.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_41.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "91736327bf0b47ea3504e4b5ae6e0ee212a9cc5864b3c254fd91724d25344c14",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_36.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_36.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_36.csv",
+      "mediaType": "text/csv",
+      "size": 19887,
+      "checksum": {
+        "hash": "9875a15d1b72d3f45b9780f1fe664e05cf48962342b71f5ce958d678e3c124f4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_28.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_28.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_28.csv",
+      "mediaType": "text/csv",
+      "size": 19514,
+      "checksum": {
+        "hash": "6b1fd44ceda327ef4263264c74a1707674c6706101a5b89572ecc6de7538d3dc",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_7.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_7.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_7.csv",
+      "mediaType": "text/csv",
+      "size": 19534,
+      "checksum": {
+        "hash": "bbca3138953346bbe34d1588c9c369a3f947d2824d909b7fa68f4c86eee031fd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_5.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_5.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_5.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_5.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_5.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "2d835118fcc6f92647e2160278b587846e7d23c18af7b06817a7d0c05e684d48",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_3.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_3.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_3.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_3.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_3.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "846a13b52cbf3962bb4dd28e3eb64aacf9f3d1562cba5a3689112a486ee16502",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_43.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_43.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_43.csv",
+      "mediaType": "text/csv",
+      "size": 19341,
+      "checksum": {
+        "hash": "aa30803ddc0979fbd29eca5d64a592a09625144d8dd3b79cc284994f1d30a698",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_31.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_31.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_31.csv",
+      "mediaType": "text/csv",
+      "size": 19679,
+      "checksum": {
+        "hash": "68a922becdf8e60a64003a25cea84c8098028bc571d2768418f22f8afe86f12d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_14.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_14.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_14.csv",
+      "mediaType": "text/csv",
+      "size": 19318,
+      "checksum": {
+        "hash": "be91390d122cbc3559090762c59c62d9b75bebb05e851ab68a21b7246d0e597e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_11.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_11.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_11.csv",
+      "mediaType": "text/csv",
+      "size": 19887,
+      "checksum": {
+        "hash": "041f760fdfc0f24c8127184002dc918695f30901237508173efa50875866db4e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_44.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_44.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_44.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_44.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_44.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "7c7f4a43b325bf75f6951b32a999f00a40514393b0614411cf5780d3fbd3d6a0",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_22.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_22.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_22.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_22.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_22.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "02fdc9dae260ebae7f86b0b74601c692b9539706bfde1c706283697277a63096",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_3.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_3.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_3.csv",
+      "mediaType": "text/csv",
+      "size": 19204,
+      "checksum": {
+        "hash": "3cbe7a73cac864beedbbcb032a9c2fbeb718fddd8d42577b7c042eb98cb74709",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_21.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_21.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_21.csv",
+      "mediaType": "text/csv",
+      "size": 19177,
+      "checksum": {
+        "hash": "82704bb78c3a053cccdaaebfaf929bebd5666922a966c29ee3d1487948e97d9e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_23.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_23.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_23.csv",
+      "mediaType": "text/csv",
+      "size": 19886,
+      "checksum": {
+        "hash": "d570ac4fe00247a595e3157ba423da73293b7d6b931a3546acbbc77bb68e6d10",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_1.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_1.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_1.csv",
+      "mediaType": "text/csv",
+      "size": 19913,
+      "checksum": {
+        "hash": "c0b1b9fb7d6e5c0e93fe0cf79cb282c1fa7c2ea4a58a28225889d34534fff458",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_26.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_26.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_26.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_26.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_26.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5a7a8e3196686b4d581261312d988d0634061e48b48065e83aa4a267c5c967cd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_42.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_42.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_42.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_42.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_42.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "4689f3db6ef3a37c0e0a5aab97fb5e45a7bfbd6be20bb626722f75d5d8c71b55",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_21.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_21.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_21.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_21.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_21.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "08225cbdd5c541e8c085ff02be7b84101fe8b0369863e845801394f5bfe37a42",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_13.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_13.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_13.csv",
+      "mediaType": "text/csv",
+      "size": 20014,
+      "checksum": {
+        "hash": "f35dbf796264477160e5fb384308df498b99008756e3ce21ba7361d0fa86e927",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_4.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_4.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_4.csv",
+      "mediaType": "text/csv",
+      "size": 19863,
+      "checksum": {
+        "hash": "4857e54386e39b8583ffe7fec740925b4d32fcf6ecb6b9786d4a7e8099a2a56f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_39.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_39.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_39.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_39.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_39.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b90da29f3df3d60a2f2dad2c942b93860282752e3f25ced65f8b92cee3cce72a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_16.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_16.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_16.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_16.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_16.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "e3303e7ec01dcd5b05ad01fbcc1018162a749cab0f7064bf669695009742d2ca",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_32.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_32.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_32.csv",
+      "mediaType": "text/csv",
+      "size": 19608,
+      "checksum": {
+        "hash": "064a57b98436b034a984fe0007368a3b16cc9c99f4c6e097442b54e7ddd12ddf",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_31.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_31.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_31.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_31.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_31.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b7c4c4f5ee3e76f6daa8608f131f9751445f8eda4215aca4a116ab3a5804b8ab",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_36.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_36.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_36.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_36.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_36.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "e3400d3c2ae210e0b7b8ebd76a392582d1690f648ed79e0d1b0b2d70a2beffd5",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_46.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_46.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_46.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_CSVInfo/group3_waveformTableSubset_46.csv",
+      "description": "SHA-256 checksum value for group3_waveformTableSubset_46.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "826fa677e779826f96ca4c8124622e98c6e5cd1e22f6117e19dc19e9e250c7af",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_35.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_35.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_35.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730271,
+      "checksum": {
+        "hash": "054adc7ac0252e2307100bcabb823c993cb26b3e4cf0a657fc2558e0668c265a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_40.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_40.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_40.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_40.mat",
+      "description": "SHA-256 checksum value for group3_subset_40.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "781e35d5d8cfbf7ce59c1f1ac75743f0906a3d5540d92a138d7b6268cb9fdd00",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_41.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_41.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_41.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730588,
+      "checksum": {
+        "hash": "d9939dc92e475f986f2759984f347f1525ca5aa54fb38ae24651636ff2a15459",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_14.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_14.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_14.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730309,
+      "checksum": {
+        "hash": "0ad7ab23e414134261d24ab5604540b994655abb894617555060914e9c175f1d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_13.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_13.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_13.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731410,
+      "checksum": {
+        "hash": "4539346c70890e1464b8fa396a7a5eda7fcfb87354c228c2a71dff43e937aa9a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_45.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_45.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_45.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_45.mat",
+      "description": "SHA-256 checksum value for group3_subset_45.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "e6ab01f4a9b9e454b48ad6985e10420c7f8ec78b2adad288c3c6e87d83823063",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_28.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_28.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_28.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730768,
+      "checksum": {
+        "hash": "331a30f886ab555eb208ad610c3a0dea4b946495ba4e57eaa4025b1b2c62563c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_12.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_12.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_12.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731675,
+      "checksum": {
+        "hash": "9469cc39cc7dd8bf0c75387d7b49ead2fb918aed4b17b8fe34e07c68d90706d1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_6.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_6.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_6.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729596,
+      "checksum": {
+        "hash": "e7bb06b9b336ded7b23b7552dd0162919faafbd2f748528d8bf1d5050c4d3560",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_23.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_23.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_23.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463733852,
+      "checksum": {
+        "hash": "4feae6b3790ba83a9909a191dc35991550fe07bd68225d18f0a0ae9c3d2404ff",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_35.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_35.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_35.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_35.mat",
+      "description": "SHA-256 checksum value for group3_subset_35.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "bb2e4b5a41f9625c19e5b44caaec0973f0024b04ed1f568fdd7baacf9debe4a3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_7.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_7.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_7.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_7.mat",
+      "description": "SHA-256 checksum value for group3_subset_7.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "261dbe02eecb427288d0b69e043f4950c0d41667afaac53fd8121d2afec2db28",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_28.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_28.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_28.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_28.mat",
+      "description": "SHA-256 checksum value for group3_subset_28.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "ff4a106a6676764b79da25b808dc221fdebddf1b8a19dc0c3629d46049788f07",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_24.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_24.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_24.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_24.mat",
+      "description": "SHA-256 checksum value for group3_subset_24.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "3a1e0cee61a5318d4696c6e45d0b327bdb4cbd7bf44cdd804729552bbfa72fca",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_44.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_44.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_44.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463727127,
+      "checksum": {
+        "hash": "158c0ff74e7d2d8c8e7376ad83d626e879426793cfb616f38fa15606bb195418",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_16.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_16.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_16.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732473,
+      "checksum": {
+        "hash": "7ae0ef5c8069094aaf8b41f8f2e434aa178f05e2a7a2b0a0dcd4ac2da43fa64f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_36.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_36.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_36.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_36.mat",
+      "description": "SHA-256 checksum value for group3_subset_36.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "d89afb8db56aee5279f6b3b918bcbb9831b1b37f989bb7f41677951101babe7b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_26.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_26.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_26.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463736259,
+      "checksum": {
+        "hash": "888a8368119a53c73271f4af6ef060e2ec666778cab763d8cb6d523810076c24",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_33.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_33.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_33.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730505,
+      "checksum": {
+        "hash": "a3d82a1a487a2bc9f610c47a99f25e598f2ccc53e2fe04b8832e5046ab1e2a1b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_27.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_27.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_27.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_27.mat",
+      "description": "SHA-256 checksum value for group3_subset_27.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "02902219746e6ea683f0b1eef12a930d006efec5154fffbcd663bec18aba060c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_23.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_23.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_23.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_23.mat",
+      "description": "SHA-256 checksum value for group3_subset_23.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "aa9806693150c5fb8b52538df0c631417c24516b40fa8d513bd6264c5fe5b799",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_10.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_10.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_10.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732431,
+      "checksum": {
+        "hash": "e2bc141779e3b88abbb2044b1f8b00871d549800698827834b5de1cc526b7717",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_2.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_2.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_2.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_2.mat",
+      "description": "SHA-256 checksum value for group3_subset_2.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "2e10e42d98007ed280d1abe9723f32e4fd8173c90aeecbe3e22cf1faff2099a8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_43.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_43.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_43.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732143,
+      "checksum": {
+        "hash": "06efc6b3820074df08ca11a41149f4220e0397b3c5d69056821499c1cdc601de",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_25.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_25.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_25.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730129,
+      "checksum": {
+        "hash": "33fa14074f3e06dccbabddcc45f6fe62311c885ab207e25f8ca382c40b4f182d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_40.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_40.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_40.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463728465,
+      "checksum": {
+        "hash": "e0df3e2e5c79749ff62a9a532e326b9ce9f4515591d149993bd33dd54c41b873",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_38.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_38.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_38.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_38.mat",
+      "description": "SHA-256 checksum value for group3_subset_38.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "e2b3bf5577f592b0527bde1bf1c5df717fdd29dfc85cb112dbf6068a9188d873",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_5.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_5.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_5.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463738154,
+      "checksum": {
+        "hash": "bc61870d8de8ed6ab632c8e10fb588d29b80288b8d39b5b73afe9e602696bacc",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_4.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_4.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_4.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463725904,
+      "checksum": {
+        "hash": "b962c9375259e039a2bbf4afab188524e50106effb4d407ea69cebe7cf9be1a5",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_32.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_32.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_32.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_32.mat",
+      "description": "SHA-256 checksum value for group3_subset_32.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "82359dd10923cd10bbba2a19a1f6cc2172b7f4ba9437df6c642da3b011db33e2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_21.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_21.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_21.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730721,
+      "checksum": {
+        "hash": "84bc61b91e9b951a0905400b1c510fb54e23e37948d6205cdb6f46061d55361b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_8.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_8.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_8.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463728051,
+      "checksum": {
+        "hash": "025710d891ff254ca9c2e722ef529ccdfa666dc43fe2f85bd188f6c5d0af3b40",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_47.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_47.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_47.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730903,
+      "checksum": {
+        "hash": "bf9eb400f78dbd297b86c5c0bab9f950cdd78dcbc31979fbf58c7c2f6b91a27f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_50.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_50.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_50.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734506,
+      "checksum": {
+        "hash": "0ef28e274066c80b7c4564759f4cec79ffd456d440798a46029b7d9b19cca235",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_19.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_19.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_19.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463735170,
+      "checksum": {
+        "hash": "cb53061a2f30d75fb80a04ea1e4590d54d09ff62e56363866d3b022b13cd7f8e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_46.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_46.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_46.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_46.mat",
+      "description": "SHA-256 checksum value for group3_subset_46.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "527d932b674943c213fecdbed468745dfaf010d83c97e589e822a62d30bd27c4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_9.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_9.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_9.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463728103,
+      "checksum": {
+        "hash": "6cea06c76a9b68edabf88a969b4cddb73b6ba8e206ed970daf1ac60d839cb349",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_5.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_5.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_5.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_5.mat",
+      "description": "SHA-256 checksum value for group3_subset_5.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5b38531ca64608853b58acab04deeb88bc4f8325231c0ab974b09f97b6935351",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_38.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_38.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_38.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730061,
+      "checksum": {
+        "hash": "754c273beaf7ef4449136625626ab3f2071886a7a9221c877123036771d6a8eb",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_18.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_18.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_18.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463733588,
+      "checksum": {
+        "hash": "9f2dcec86ee37f4808c1c2ea39e7a884475b7ada0230bb41a18ff642bf85570d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_17.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_17.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_17.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_17.mat",
+      "description": "SHA-256 checksum value for group3_subset_17.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b377bc30785b3593f646f2c93d0c178c3d64159e97a9eaae25788610460440b4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_49.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_49.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_49.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_49.mat",
+      "description": "SHA-256 checksum value for group3_subset_49.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "aa1735f35d1b14fe508e38742bd7613b1974c9d6fc516514e901a9cb723611c5",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_33.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_33.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_33.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_33.mat",
+      "description": "SHA-256 checksum value for group3_subset_33.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "4fab37a785f49e1e27256dfb99a17e4552099f60a4aba6817554aba2981610f7",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_29.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_29.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_29.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463742349,
+      "checksum": {
+        "hash": "85e3219ed1ba60462ed752a99533a3c7b1933e522b1e8feb6d5cd819a1348ed9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_7.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_7.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_7.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731852,
+      "checksum": {
+        "hash": "9f12487cda592f654b0de1668a28465db1f0a6ca5bad7dc68c110238af366b47",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_45.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_45.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_45.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732148,
+      "checksum": {
+        "hash": "7f0d746be57c29f4b8824a2407ebb6f702060b5c148f0f509f5fb21028b58b0e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_46.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_46.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_46.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729920,
+      "checksum": {
+        "hash": "71a225d1c7257dcd9f26ef9b67454ffa45f4a51b5076d7f26ef0f7dc168dd455",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_15.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_15.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_15.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463726441,
+      "checksum": {
+        "hash": "f1307b5856c301087d1292a8aa7c0e000a225447dc4bc0e8ed118a498248a1b6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_34.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_34.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_34.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463728938,
+      "checksum": {
+        "hash": "ef990df9b03e14bbc27eada12ac43b02811ea814339d04e283939f2eb0a41c30",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_19.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_19.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_19.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_19.mat",
+      "description": "SHA-256 checksum value for group3_subset_19.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "c2e06627cea5623efdfe156997feca81643205e549875a0843defdc720b7912b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_3.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_3.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_3.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_3.mat",
+      "description": "SHA-256 checksum value for group3_subset_3.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "674fa798181b866a8d5d2985490a4c727d1c82ee7f608abd37dbda3dcf93ba77",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_15.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_15.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_15.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_15.mat",
+      "description": "SHA-256 checksum value for group3_subset_15.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9b33ed3cfd2dca333ee816e35680193294ca0043e6c4e312e6ca7d7c4e95e7b9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_11.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_11.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_11.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734647,
+      "checksum": {
+        "hash": "55e9d2d8b2fab96f09eb7c8ed74aa5e9190149f75fdeb70bf77ae261ec28a49f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_42.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_42.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_42.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_42.mat",
+      "description": "SHA-256 checksum value for group3_subset_42.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "03bd84a67f93119606b0e2ca19b15386bfd7952f1fa5e55d1177f758455ed68e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_11.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_11.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_11.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_11.mat",
+      "description": "SHA-256 checksum value for group3_subset_11.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "be9b20ae463272b27c855d221b45e7b42d34045ba5e89206bf5e154f94b1943a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_1.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_1.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_1.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_1.mat",
+      "description": "SHA-256 checksum value for group3_subset_1.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "fee93f1acc048e2f7fc32a168f2b5bacd8ba1b6e31e2d91dfebccc1da72c1ca3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_43.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_43.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_43.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_43.mat",
+      "description": "SHA-256 checksum value for group3_subset_43.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "ef001cb26d9d6428aa72c657f527bd008fbcebd9931180089fe80eea515a52c4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_48.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_48.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_48.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_48.mat",
+      "description": "SHA-256 checksum value for group3_subset_48.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "a6291bf257715f25aa057e78e76119a5d168a4d244a12329a7ceef54337971f7",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_20.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_20.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_20.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_20.mat",
+      "description": "SHA-256 checksum value for group3_subset_20.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "0c3a45a1540d08977f31c098645cf79cfb8585eeb5ca01c2d72adf0e0736580c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_6.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_6.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_6.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_6.mat",
+      "description": "SHA-256 checksum value for group3_subset_6.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9bc7688ac3067ce93b2edd0687ba5ad1f4e46c4023192cd12651c98c2f9f7d70",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_31.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_31.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_31.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732423,
+      "checksum": {
+        "hash": "5ba6d53bf07496cd7924c4462873833ae6dc97a995960c21e5e1da585f1a8ef9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_37.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_37.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_37.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_37.mat",
+      "description": "SHA-256 checksum value for group3_subset_37.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "a134945a59a4d357f85ac9fe808364c8d0fa93d6de91989c04a98d65799bd2f8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_4.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_4.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_4.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_4.mat",
+      "description": "SHA-256 checksum value for group3_subset_4.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "fcccc131737e648e6dfc21b5234808a100bd6ef4dc555ad86618e0b119b8531f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_3.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_3.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_3.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463728100,
+      "checksum": {
+        "hash": "771be05019b992195d90e294780109498f4878f8bef4be9f7a7017ed53735ddf",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_13.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_13.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_13.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_13.mat",
+      "description": "SHA-256 checksum value for group3_subset_13.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5551e09edd17c7f32afa6dee37955fc56d16bb81b0fd38b38e1031a05eda99a8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_42.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_42.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_42.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732708,
+      "checksum": {
+        "hash": "23b176e7e6cb3e4a8841099cb869cd540dc68bb5b3c82f73146d7a69df1335f8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_39.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group3/group3_subset_39.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group3/group3_subset_39.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group3/group3_subset_39.mat",
+      "description": "SHA-256 checksum value for group3_subset_39.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "a2441ad96e0b799eb041f1e22644ef22bbc9319f8afd63eb858185c22e8b280c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/License.txt",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/License.txt",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/License.txt",
+      "mediaType": "text/plain",
+      "size": 2282,
+      "checksum": {
+        "hash": "5406c07ef3b62e155e4c58a10d49c6155e19e9984fcef2ad56a59cffdaf32a6d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2",
+      "@type": [
+        "nrdp:Subcollection"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/Subcollection"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2"
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_7.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_7.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_7.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_7.mat",
+      "description": "SHA-256 checksum value for group2_subset_7.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b163adce8342fa659c7371f79f4c1a62ba95911f905ed8ebf8cf26ad741fd1aa",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_19.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_19.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_19.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729288,
+      "checksum": {
+        "hash": "eeacb72fbe1c93b0d9a13c749e42f5c947a573049e3114dbebd9cc3ce9b4da4a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_14.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_14.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_14.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_14.mat",
+      "description": "SHA-256 checksum value for group2_subset_14.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b082d252405571a042fae67ead861cee852908388e8c95444a5f356c20efaa29",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_46.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_46.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_46.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731013,
+      "checksum": {
+        "hash": "1f3c64e41ac7b9cc269a8f86867f7fca5748775a65b6bee5749897d03e136853",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_46.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_46.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_46.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_46.mat",
+      "description": "SHA-256 checksum value for group2_subset_46.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "56ca3f7cc529d2de96d69b315b8da5772f9c7a2f2a3b321d3de9ea8b4116f4a2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_50.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_50.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_50.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732357,
+      "checksum": {
+        "hash": "0a17c87315b54a8d10b5e482838d2b74007ac0e1963778b72f3533fb7e0014a8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_41.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_41.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_41.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_41.mat",
+      "description": "SHA-256 checksum value for group2_subset_41.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "0fa8ec1a6cc64f1826567ee4bf12028961b31fea879fc39e0f0c3322a16be85d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_2.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_2.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_2.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730882,
+      "checksum": {
+        "hash": "4ccfce1a51a6aebe6a99c1c12437ef658f3c3955850feb26f3f263687337dada",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_36.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_36.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_36.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_36.mat",
+      "description": "SHA-256 checksum value for group2_subset_36.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9b1d8aa4ed31dd88bcc915492465584c97b05175194f9a9c9573500da4983936",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_10.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_10.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_10.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_10.mat",
+      "description": "SHA-256 checksum value for group2_subset_10.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b3588633929fda661e7ed8630f54436714099c828255eab2231e2552ecaf6c3d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_29.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_29.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_29.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732732,
+      "checksum": {
+        "hash": "57e384f9a1435314894747ece15f6c421ebd02f9a6d6dffda15b5e14f4a75f20",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_29.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_29.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_29.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_29.mat",
+      "description": "SHA-256 checksum value for group2_subset_29.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "705cc2ca9be4ca1b18ea8c61bb79e801ac09da2df9391b6e3aea10585204bcc6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_11.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_11.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_11.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734451,
+      "checksum": {
+        "hash": "a07e37848beb7daae4b3721f02262f2e71ac6c5b54aadbb7f8884ca0cde56031",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_41.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_41.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_41.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463735940,
+      "checksum": {
+        "hash": "5a47da4d5d8d73966a74370efbac5d74fe726736485b2ced9b11feea38152460",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_35.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_35.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_35.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734257,
+      "checksum": {
+        "hash": "3ce061bf7774af796f41040f4bd31a9e53b326e6bf001cc622bf9dc90171ca56",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_3.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_3.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_3.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730273,
+      "checksum": {
+        "hash": "7585e75b6ab6f4801c3f6af27dc22fbc6978892c5d57aa24f78b73adcd273f79",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_27.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_27.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_27.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_27.mat",
+      "description": "SHA-256 checksum value for group2_subset_27.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "c933a72e22bcd61fb4b3b32d264bda7a4db5634ce869ee19341d12278a8ea6a3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_18.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_18.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_18.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_18.mat",
+      "description": "SHA-256 checksum value for group2_subset_18.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "77b95f9824c1caf158133bc61724b5a767251925333bcfce1409cd0f765c404f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_36.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_36.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_36.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463727319,
+      "checksum": {
+        "hash": "625cbf0b51885cea8ed7eee1687b4c985e9875025d1dc121b5533f977c898154",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_13.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_13.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_13.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_13.mat",
+      "description": "SHA-256 checksum value for group2_subset_13.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "45c094639ccc14c0dbf9687bece7813d9e66784b4ab9e1b2eccb562abcdf6ea3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_16.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_16.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_16.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_16.mat",
+      "description": "SHA-256 checksum value for group2_subset_16.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "ee140a066aa7296eb1e55090c6a83c968773743594ea09182833a2c807891dc3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_21.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_21.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_21.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732671,
+      "checksum": {
+        "hash": "cc0c7d9d3f183acf9315875a3cbf58f8e8799b026f430ca5ff21fbc1a5e931b1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_22.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_22.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_22.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_22.mat",
+      "description": "SHA-256 checksum value for group2_subset_22.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "aaff6c48a714ed0fb3628d0e971d4569db394ad5c3d761f331090279d00ef038",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_38.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_38.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_38.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734121,
+      "checksum": {
+        "hash": "6f5b69cbff530903b60a93724b52277e247cbb348216764f660d785cac4b5517",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_25.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_25.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_25.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_25.mat",
+      "description": "SHA-256 checksum value for group2_subset_25.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b3471f7851fc467032bf3ad32f3c004bcf484d5b29e1466c71b6ae79e751f7d9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_37.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_37.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_37.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_37.mat",
+      "description": "SHA-256 checksum value for group2_subset_37.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "f24395f293708543c6da86435c0cd00b4d8592806affcb7d1fb2a6417269e8c4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_13.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_13.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_13.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463725066,
+      "checksum": {
+        "hash": "9418439c7c001e0d5ef11cbf215260e40199c50b83b756dc0edcb3cee5da005e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_4.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_4.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_4.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_4.mat",
+      "description": "SHA-256 checksum value for group2_subset_4.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9f5472ae53e29ccd6a93a1b586dfa9b96c6d8cbd549769d7fe2decd9d040ac6d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo",
+      "@type": [
+        "nrdp:Subcollection"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/Subcollection"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo"
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_33.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_33.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_33.csv",
+      "mediaType": "text/csv",
+      "size": 19250,
+      "checksum": {
+        "hash": "6c5da6db3901d77709bbc30b9e75773185aab5eff373ee43bdf3e1f916980c99",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_6.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_6.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_6.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_6.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_6.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "97d1bbc257283a6e04909c5ada18d0267fd6e11969a0ec6638d56b5b6a81f1f1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_30.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_30.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_30.csv",
+      "mediaType": "text/csv",
+      "size": 19496,
+      "checksum": {
+        "hash": "2433719f90d693b6326db129860a977e1ad7b94b7dfe81ec1af396ae4587c674",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_33.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_33.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_33.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_33.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_33.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "4793a619b16826a6648bcf10f4e8445f39c2d1a82889d844a846278b379608bd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_42.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_42.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_42.csv",
+      "mediaType": "text/csv",
+      "size": 19879,
+      "checksum": {
+        "hash": "5a573a3c7e7e4ec7438d5ffc666fcf3283957dfc880c6b77938b1266a8ab2c07",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_22.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_22.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_22.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_22.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_22.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "14d642742e4aab56d3538fe554f1c07d0b9923aea5f00aa0b228f9d3b20730d3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_47.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_47.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_47.csv",
+      "mediaType": "text/csv",
+      "size": 19027,
+      "checksum": {
+        "hash": "53cf4581c612c9349d559447cb6e80a57d1f948f898fe8b5c703f4cc97d78cef",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_23.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_23.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_23.csv",
+      "mediaType": "text/csv",
+      "size": 19027,
+      "checksum": {
+        "hash": "3328243588261562bcac310d5e01c16a2b17185615e3afd8a4ebceb50615fabe",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_30.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_30.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_30.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_30.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_30.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "4a427e66967f2c3f7427704938464b73b632d205a737a30381ab293bf755ed84",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_7.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_7.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_7.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_7.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_7.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "4629fb5119887d2c5f9411e11a7934d47d9b57f8fd8d87030611f57fd58a8bf8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_46.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_46.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_46.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_46.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_46.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9b4c4d50bd547185339e8ab6748157ef286ebfa9e19e5020eb84d49e6a866a34",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_36.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_36.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_36.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_36.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_36.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "39ca17ae1d112ab9118e7beee3e380bedca8b388f076ef4349935fd4c98d4812",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_20.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_20.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_20.csv",
+      "mediaType": "text/csv",
+      "size": 19355,
+      "checksum": {
+        "hash": "b4fd27523c4db7d285ef58a0ac3711f83960e483c88d3777b6ec6883d731154f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_27.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_27.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_27.csv",
+      "mediaType": "text/csv",
+      "size": 19535,
+      "checksum": {
+        "hash": "4b2e2ebac20d49ac7fd94e64a9a50fec9bb80c8abe73a621f4d45c1d5436a984",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_20.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_20.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_20.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_20.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_20.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "f323ef0667751576a5997baa12907f58dc1f2115b93daf4962ee55df166e8882",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_10.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_10.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_10.csv",
+      "mediaType": "text/csv",
+      "size": 19460,
+      "checksum": {
+        "hash": "78bf15c84d653d4741f97b8d103e59c57ebeba3830e3fd089ffdbf401f886438",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_26.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_26.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_26.csv",
+      "mediaType": "text/csv",
+      "size": 19773,
+      "checksum": {
+        "hash": "18562a8ee6d96798f6ae346bdbca19b1419403b32a84a9699b1e6d23fd02adbb",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_14.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_14.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_14.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_14.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_14.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "2bb62afd6e1c076702c61de86ad3665189bbb1cbf19d53d93c0d9a97ee5964d5",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_13.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_13.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_13.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_13.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_13.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "51c3e13ea71b52f7dda05dbcfbd903f413b8ac5fd1700ba36b9f3c4dae501da1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_13.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_13.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_13.csv",
+      "mediaType": "text/csv",
+      "size": 18888,
+      "checksum": {
+        "hash": "a9b4e2fe4cfe6c61623c9df7c99c5a5ab31ede366df25b8988ff79f94ad4f503",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_16.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_16.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_16.csv",
+      "mediaType": "text/csv",
+      "size": 19436,
+      "checksum": {
+        "hash": "4e9ae9acb9b435acca5a4c743c9c58b96bb978caab1c17be42692e28c80990a9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_43.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_43.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_43.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_43.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_43.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "75b3f5e6a716593295f0f904f3d8f36633a5dc1dccc33b1f3fd27801df4f388c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_18.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_18.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_18.csv",
+      "mediaType": "text/csv",
+      "size": 19148,
+      "checksum": {
+        "hash": "2e8e3ddf0369630e7f16ff44bfaae0b437eebc75f2f1b33201fa48a3e6e15f3f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_11.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_11.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_11.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_11.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_11.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "83dd17c032f9f1fe5a3dd2b82b1e8e6101758f48b55d68cb42f90a3dbbb76786",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_12.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_12.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_12.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_12.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_12.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "7dd452085e97d6bb8cf1bb3a12075251cae3425adf37a7f0dedee3745ffc3a10",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_8.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_8.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_8.csv",
+      "mediaType": "text/csv",
+      "size": 19865,
+      "checksum": {
+        "hash": "fc5f90ce185ff31ec0663ebc43c0ba4d7e01b7c79a4d37a7cd76a63ff2507fd4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_5.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_5.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_5.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_5.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_5.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "1c03a09a59a8e945e5a549e14da335b3d92b5b5566f2e6746e391a65b7eec60b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_9.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_9.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_9.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_9.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_9.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "f03222eb8a0a25515dd949aff94ec214c0c4eff175c6d3d2d7da24e9d4eab797",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_31.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_31.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_31.csv",
+      "mediaType": "text/csv",
+      "size": 19371,
+      "checksum": {
+        "hash": "306b87341b4ec68b1af4f9f198f768a57d3e1f7edc2d94dcecb8f4c295e24e4a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_2.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_2.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_2.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_2.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_2.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "fff0062da4e238401efca99581748a2e375235123218f4f811d58cdd24c3970c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_34.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_34.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_34.csv",
+      "mediaType": "text/csv",
+      "size": 19832,
+      "checksum": {
+        "hash": "45d86f506c8140867ee7f6bdd351da18f99c0ee960d2870f4771cb2c2972e2f7",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_32.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_32.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_32.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_32.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_32.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "ef8f808c545de1d3542c1371c5ba45a513053223f951e59c3704b79b599d674a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_41.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_41.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_41.csv",
+      "mediaType": "text/csv",
+      "size": 19694,
+      "checksum": {
+        "hash": "ad0ce676ca492d315aa5c5a4185d11a1d800db59fdad9df89cdfb6b3b3901add",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_27.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_27.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_27.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_27.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_27.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "8f26d6f301cdc683510dd07120dd54830dfbf5cdb70027e5383ee354a7271150",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_50.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_50.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_50.csv",
+      "mediaType": "text/csv",
+      "size": 19423,
+      "checksum": {
+        "hash": "f6547420ff3297ec3a247c46d5c09f76576c680fba6d1d49e2acf62cdf94a1d9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_25.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_25.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_25.csv",
+      "mediaType": "text/csv",
+      "size": 19245,
+      "checksum": {
+        "hash": "6e0ec3ffd4fce99b5a74fc64783beb1b83dcad977d2d79c3de55d4b632c86b74",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_45.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_45.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_45.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_45.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_45.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "583a6e4bbe6c43cd4f136b9d2ce901d1191ebbd40aa2d328cafb22869a50862e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_3.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_3.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_3.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_3.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_3.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "0a3b40976c7ed37069b2c0566fa06c2bac23e5a9db7246398021973fa02df62d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_48.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_48.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_48.csv",
+      "mediaType": "text/csv",
+      "size": 19305,
+      "checksum": {
+        "hash": "5a3d61fd7c2070da159e51a84a1a74a05de3a84ca7de7336b4af8dd6d6fe791a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_19.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_19.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_19.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_19.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_19.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "1a73c6de2c492b35bdaba0fedae2750872310454380bf32d9c48139bb596debd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_49.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_49.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_49.csv",
+      "mediaType": "text/csv",
+      "size": 20438,
+      "checksum": {
+        "hash": "92be0e434820ed462a7505eed8e91299682f31b5ca4dc9b38edcefaf169514d5",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_49.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_49.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_49.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_49.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_49.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "ca9c6f47f42370b7de3f1646366be13d7f32f584feb09a75e17fbc229d37991a",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_40.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_40.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_40.csv",
+      "mediaType": "text/csv",
+      "size": 19718,
+      "checksum": {
+        "hash": "7e370fb21a656b62a769d2ad2d010d86669a7e9d497bb5c9e5662ab5a4b7541d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_48.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_48.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_48.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_48.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_48.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "c2527e2874b6fa0cb86e03cd45b0694a6bc8380d7eabeefb32c4c08244c874c8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_28.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_28.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_28.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_28.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_28.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "d8d74c370458818b6146c7e9ba67585f484be38b13590f82d88279da95c2f793",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_2.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_2.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_2.csv",
+      "mediaType": "text/csv",
+      "size": 19685,
+      "checksum": {
+        "hash": "3245c1619833a8691f1db73447e2818779d92c214dded3af4ecba71c5d12ffdf",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_21.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_21.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_21.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_21.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_21.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "fc3029d5daf45e60f326ccd28f79d8e379145960860312ae53d46a31f68db7c9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_37.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_37.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_37.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_37.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_37.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "183f5800ec775a157915cbaf1d65d7a88d76c18c9aee34b4298f3965cf7281ad",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_7.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_7.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_7.csv",
+      "mediaType": "text/csv",
+      "size": 19243,
+      "checksum": {
+        "hash": "62f9ee0c3e382efc6659c5a60832ba6ba5204812988cf46c4c9d4dac830de3df",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_23.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_23.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_23.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_23.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_23.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "1b87451f273fb04363d3e24bdf7beae403ab7df79b1d32d88135c40935afe376",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_22.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_22.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_22.csv",
+      "mediaType": "text/csv",
+      "size": 19517,
+      "checksum": {
+        "hash": "9ab216516dcfc58d0f149b1fef43b210f9010f752a2ba24cbefab978261b2d0b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_10.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_10.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_10.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_10.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_10.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "758146a56b0107909e493e80f0630ce63dd3578e5c9bf8937518d099806acff2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_1.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_1.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_1.csv",
+      "mediaType": "text/csv",
+      "size": 19912,
+      "checksum": {
+        "hash": "48b1055c78370ba613ccef40c8328600adcb7e382780ad4b97d2e4e3c1ce7959",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_29.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_29.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_29.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_29.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_29.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "d092040cb76fc014648fe97435688870bdcf6e915da9f661184289d15fd377dc",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_4.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_4.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_4.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_4.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_4.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9b89e00f5ec2267886b02f85d0c1d1f737d47bad6993e41d54bcbabf2557b5a6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_46.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_46.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_46.csv",
+      "mediaType": "text/csv",
+      "size": 19139,
+      "checksum": {
+        "hash": "bb601e7aefa175814a0a6d7c2c6306615f2f5b760bf2fc07d41e74e1414cc78b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_16.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_16.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_16.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_16.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_16.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "a58c24137e989c317040b7c6172a1d4dee03a6203e18748d0f635d8502ff3bf2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_25.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_25.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_25.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_25.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_25.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "8255dbab330fff0977b8e78ca29c1c00a22d3f11ce016562445244a16056b83e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_17.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_17.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_17.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_17.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_17.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5264843e725c7f3c7cd30ea420b1436f132776ffbfe149e0aca5ba305852f3db",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_31.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_31.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_31.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_31.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_31.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b8cdb169af1fa444898ee4e34895ce79affe59952d6fc0c3d9a87d605a05a049",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_32.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_32.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_32.csv",
+      "mediaType": "text/csv",
+      "size": 19729,
+      "checksum": {
+        "hash": "447fec326af845836818121dfd756ad3467b4c7a4699cb305ee1bbc499ee612e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_42.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_42.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_42.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_42.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_42.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "6f66779d9ed1f3fab09974d3b340f211e7ea762bf993b025bcca01cab6232beb",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_36.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_36.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_36.csv",
+      "mediaType": "text/csv",
+      "size": 19265,
+      "checksum": {
+        "hash": "3001f31095c57844c9561f989ea70c3f3672f5863334caf492743d8fcd9773e2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_44.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_44.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_44.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_44.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_44.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "e036f8641230e81ddc21a08bd3eb237ba0b46cbf41c3f837a66e2a6bbc6c9797",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_28.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_28.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_28.csv",
+      "mediaType": "text/csv",
+      "size": 19841,
+      "checksum": {
+        "hash": "e5b305a12c267e701dc1ed221df6deed3d6e081f5e91c9bbfc95f10d4ba4c142",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_24.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_24.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_24.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_24.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_24.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "df0ed987feed96eb83ed0c6065d8850b919ec52050821a23173c420bc1aa3b24",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_18.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_18.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_18.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_18.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_18.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "3ebbe9203acf6128ebf4cf4df6a019620bc5f8f70bf9b397e9deaaf46bfa07de",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_38.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_38.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_38.csv",
+      "mediaType": "text/csv",
+      "size": 20093,
+      "checksum": {
+        "hash": "d44fb673b4dc22208bef85e333decdf08b798f20ab040d91d98425900c34ee6c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_39.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_39.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_39.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_39.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_39.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "0321a1af8b1b2f6e3ae6c2fbe1ab513d1704d96d9b29486436316b8b7aadbc13",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_34.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_34.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_34.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_34.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_34.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "cfc64762bcbbad13ff78ef3ced94b3fce436e37fe66c38bacd1eddd6702de0bc",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_3.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_3.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_3.csv",
+      "mediaType": "text/csv",
+      "size": 19663,
+      "checksum": {
+        "hash": "fd38da2ce12275e37d09b305bc19f61f5a1cab386226e2169b5c945715a161e6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_29.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_29.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_29.csv",
+      "mediaType": "text/csv",
+      "size": 19670,
+      "checksum": {
+        "hash": "aa52ae5f678c543f5c1edf808f5c37ad25d35aabe07695ab62e513952d454de8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_35.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_35.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_35.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_35.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_35.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "ffe8ceab4965e69bb48df0d86d529debfc97157dc2b75ba1166691e4e905824b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_14.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_14.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_14.csv",
+      "mediaType": "text/csv",
+      "size": 18947,
+      "checksum": {
+        "hash": "8c57107d31f96b38d1fa09208b4112f92b21e912e69b6bb48a161e0f0ed868d3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_39.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_39.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_39.csv",
+      "mediaType": "text/csv",
+      "size": 19476,
+      "checksum": {
+        "hash": "7748ed9737077ece4bd307cabfecfacc315cfead98c6afc4dae5404f4ea0cfe7",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_44.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_44.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_44.csv",
+      "mediaType": "text/csv",
+      "size": 19523,
+      "checksum": {
+        "hash": "366531919f1a225fb7365f90e78152195ad54b8eb5963a8d83e2828fbff52b6f",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_5.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_5.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_5.csv",
+      "mediaType": "text/csv",
+      "size": 20312,
+      "checksum": {
+        "hash": "eb30d8eb94d7135f2262e3d74e1dccea9f821fe1581bd2742c1d57391d3aa53c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_6.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_6.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_6.csv",
+      "mediaType": "text/csv",
+      "size": 19121,
+      "checksum": {
+        "hash": "65f2f3957e8aa5514c1c1c195620a90f6d021502fef1c8eff08dd687b1860213",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_8.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_8.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_8.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_8.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_8.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "2275580ea87a1d536cf7a446747bec4a6ad4cee5e192a34a75f7e429d206cebd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_50.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_50.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_50.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_50.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_50.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "65cd21548af6c460968f0d95b4a0bc60443032ca1c15a56c451eaf8f85e2ecd0",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_40.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_40.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_40.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_40.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_40.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "123ba83409301d80070a30fe31118352cb6001921171790581a9c58c3ded5474",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_41.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_41.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_41.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_41.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_41.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "0228fad556e8c535bad46264f477dbde5b8a7fb19d9735798c835b0bef6fa0df",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_1.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_1.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_1.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_1.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_1.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "4a3bdbddd075570bdf04c8fac0bcf5d08cc942b214c537ba22f49cb7eb36ea9c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_45.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_45.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_45.csv",
+      "mediaType": "text/csv",
+      "size": 20156,
+      "checksum": {
+        "hash": "beca74fbff3e25fc9d5434f198050e4c74577f6ac4c31924284ff59796869585",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_26.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_26.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_26.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_26.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_26.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "f734906ef9148d5f3e9cc39dca48c26533df4a26e6df274788446f7d91add023",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_38.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_38.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_38.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_38.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_38.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "5de3c437557be86f4606cc145cb6624fe2be2fd3117c109adc505e2c2e9490c0",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_37.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_37.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_37.csv",
+      "mediaType": "text/csv",
+      "size": 19547,
+      "checksum": {
+        "hash": "7b358c879cc954b35156d8dfebe1ae3d37b7780e336dcd46150a61572f500467",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_24.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_24.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_24.csv",
+      "mediaType": "text/csv",
+      "size": 19685,
+      "checksum": {
+        "hash": "71b5057f80991266fbb31eba6f42dfdf22c372f812d5878c8124348799b45209",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_9.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_9.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_9.csv",
+      "mediaType": "text/csv",
+      "size": 19244,
+      "checksum": {
+        "hash": "27e8c49b361e6f9260d609ee7bc7d81369269557817da1559ae953c3cbd89574",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_21.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_21.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_21.csv",
+      "mediaType": "text/csv",
+      "size": 19561,
+      "checksum": {
+        "hash": "9e692958ed34290b4eb0fb3a9849583325440870ec0dc3920f04a60bbf958e5b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_19.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_19.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_19.csv",
+      "mediaType": "text/csv",
+      "size": 18884,
+      "checksum": {
+        "hash": "13922f4e270c17fae831f7e985e5708c2331f83297654262d6e34207d253160b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_47.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_47.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_47.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_47.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_47.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "8955290689a848478fe2610332deaab067cc40b8a398475d34111414750a1b20",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_15.csv.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_15.csv.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_15.csv.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_15.csv",
+      "description": "SHA-256 checksum value for group2_waveformTableSubset_15.csv",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "a04fe52e668acb9b93c8f8f9eeca2a197f3c6946a1b40e1264e0ace072a90c4d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_4.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_4.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_4.csv",
+      "mediaType": "text/csv",
+      "size": 19440,
+      "checksum": {
+        "hash": "38c016b12c9cce30b8ac8e49210931bc175cdfb8421469b5573f696d3040d020",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_12.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_12.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_12.csv",
+      "mediaType": "text/csv",
+      "size": 19988,
+      "checksum": {
+        "hash": "06633798602e7fc95f2e7ce6b7e190a3263d5815ecb5f06fe6155cd8914c4988",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_11.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_11.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_11.csv",
+      "mediaType": "text/csv",
+      "size": 19402,
+      "checksum": {
+        "hash": "b53fa6eaab905d065187aa50d0f6c02b7e275d742abb718d063eccaa540451f2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_15.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_15.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_15.csv",
+      "mediaType": "text/csv",
+      "size": 19195,
+      "checksum": {
+        "hash": "a99c02352df9976efb7d184f00ad9639aa649d00a029b79f57356b53232cebb9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_43.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_43.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_43.csv",
+      "mediaType": "text/csv",
+      "size": 19270,
+      "checksum": {
+        "hash": "9f2a2560c49e659871fd026a0a4b5517df3a1b46fc43b0e6ffa09f32bbb6f883",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_17.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_17.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_17.csv",
+      "mediaType": "text/csv",
+      "size": 20415,
+      "checksum": {
+        "hash": "ca027b40aad0a33087a9ce5acae993af8e9bda60abdb5edbe1a2d03866e8eddd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_35.csv",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_35.csv",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_CSVInfo/group2_waveformTableSubset_35.csv",
+      "mediaType": "text/csv",
+      "size": 20022,
+      "checksum": {
+        "hash": "b2c91cf025284462543643badd54a60e932176ccbb514cb93af582cc932c6c63",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_44.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_44.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_44.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730343,
+      "checksum": {
+        "hash": "cc0b6e693b26baaa8c54e21c7fa1a09bd0153be51197069edabe74f32f878819",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_1.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_1.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_1.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731632,
+      "checksum": {
+        "hash": "0cd735080e05420927670769baf370aa6c6e6683c4ac35c6c6dbae9a2c046629",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_34.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_34.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_34.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_34.mat",
+      "description": "SHA-256 checksum value for group2_subset_34.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "6d7578412c04637219dd5318faf730853c3c818551541ef864687e370c621dbd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_12.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_12.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_12.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463735550,
+      "checksum": {
+        "hash": "33ef0f2380cef03c6f322b8af0f43f157efd78bcd4c50627de05c65a09c3dbcb",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_44.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_44.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_44.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_44.mat",
+      "description": "SHA-256 checksum value for group2_subset_44.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "1a0b6a71c857237e1809b2fab7d2c464f098d8c3fd8920c33f4cbf887a326ad3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_50.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_50.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_50.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_50.mat",
+      "description": "SHA-256 checksum value for group2_subset_50.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "e17538ffac3394e7d36603c727930c91e0fb09f5528f4fb3a3f6358af2dd479c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_49.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_49.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_49.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_49.mat",
+      "description": "SHA-256 checksum value for group2_subset_49.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "7f1867481acdb1be0957ddf97f60e99c79e900970c999569755f4622f6ff88a1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_47.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_47.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_47.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730382,
+      "checksum": {
+        "hash": "e7fda8154ed81fac4dea9562fc039d593603ef9f83d648719fe97e708885da56",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_23.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_23.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_23.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729270,
+      "checksum": {
+        "hash": "a4c5dbc8dba5049b8fafdf9ffbc7fa46321244f961f0904a7ca8775660a6c819",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_26.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_26.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_26.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_26.mat",
+      "description": "SHA-256 checksum value for group2_subset_26.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "101786233a6e3a63eb82633b964902cd4bb058e0df5d6c96472ff3d18ac7db34",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_9.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_9.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_9.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_9.mat",
+      "description": "SHA-256 checksum value for group2_subset_9.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "d587476516c2dfe634f70ae9ffd2b2677dc58f89aedb6a7907571ddfd5e36917",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_20.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_20.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_20.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463727781,
+      "checksum": {
+        "hash": "089e4bfdc68da285c2b8961591cb79d34b98bd93b81c64e5b30b5117c06259dc",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_45.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_45.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_45.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463733083,
+      "checksum": {
+        "hash": "39814dd4cab1f117bcbeec4b6a088fc215e24905ab809df0bdd78de626296510",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_23.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_23.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_23.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_23.mat",
+      "description": "SHA-256 checksum value for group2_subset_23.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "7990a7d0ecd7f276bcc517da930ad2669888f3e7eda62af24cb1ac968a0c66b6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_1.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_1.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_1.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_1.mat",
+      "description": "SHA-256 checksum value for group2_subset_1.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "d2e136a33177e8a9b42c3596b687669e66c16ed3c232436bf9fe2a75cca0ce47",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_17.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_17.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_17.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_17.mat",
+      "description": "SHA-256 checksum value for group2_subset_17.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "66cc45556b6aeb8b2f47e76ef2c27046ba4ef89dea78a314326becf82f661c6d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_4.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_4.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_4.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731350,
+      "checksum": {
+        "hash": "d4435ad358cb7e444db41165ca993ff02a485ab357a651248e2dae44c7aecda1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_33.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_33.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_33.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_33.mat",
+      "description": "SHA-256 checksum value for group2_subset_33.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "c468d4437c2a07dc1c5b9f8dcca0f1bb2e9fd9889d6e18c4e9939c4408466fe9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_48.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_48.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_48.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463733433,
+      "checksum": {
+        "hash": "399b46ac311fd4946f5ffdbf419c41ea1b2aa889880906b76036c42e168355f0",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_34.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_34.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_34.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731666,
+      "checksum": {
+        "hash": "4f8ac064e2f14e0cd083fb99230cf51779cef4d6a3c241fb15fcddd9f43a5467",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_27.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_27.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_27.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729229,
+      "checksum": {
+        "hash": "4de2bc26418be10659d8fc5ed890dacdb5a2809875ef95c40b6f0800519c0142",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_5.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_5.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_5.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732301,
+      "checksum": {
+        "hash": "cd5f520a345ba363fd5d1096bf5447390ce529105a0ea515dcc26ade29913aa4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_11.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_11.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_11.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_11.mat",
+      "description": "SHA-256 checksum value for group2_subset_11.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "2d89ec4ffdf0e2fd65371d39a3b3def9207f4d822950198c085f6e4765c29091",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_38.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_38.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_38.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_38.mat",
+      "description": "SHA-256 checksum value for group2_subset_38.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "1af9240922d62994d2270636cb861ceab117c0f57dff5a18afcc964c596c05ed",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_39.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_39.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_39.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463728446,
+      "checksum": {
+        "hash": "2a19fcb63f9b9c9c22c543a5e2c61fa3e80f955e2837e7fb4eb9be8b58dd6cb3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_8.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_8.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_8.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463736981,
+      "checksum": {
+        "hash": "6870288349137f6338af1f9f88613280bf268bb244757846e6385d570241d544",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_8.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_8.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_8.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_8.mat",
+      "description": "SHA-256 checksum value for group2_subset_8.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "ff43f12d80aa647052dc3abe6c5dd7b107744eb251458292778dd8a5e4ed5f1b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_9.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_9.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_9.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463739800,
+      "checksum": {
+        "hash": "e342261fd5b60f9b5e447dcdda4e4a77aa16eb9df3027422bacb2cfc7751a302",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_32.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_32.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_32.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463735868,
+      "checksum": {
+        "hash": "163656481b2e647a15bf64267320c9a64b6c71751aff41e584644ee7b99ab9a9",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_31.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_31.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_31.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_31.mat",
+      "description": "SHA-256 checksum value for group2_subset_31.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "1bf6c4e70c0a20e35b3cdede4b9c95793cdcc0d0a6b838cc84aa7e80a0a3ac39",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_37.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_37.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_37.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463726252,
+      "checksum": {
+        "hash": "ba752bde9b2de6a0ba0882b4bbc96bace8ef4855bdea1eec197a4f75596c3373",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_20.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_20.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_20.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_20.mat",
+      "description": "SHA-256 checksum value for group2_subset_20.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "3e788d0ab711884051453b4cc28e6167f94576b50c56f73601da00a858a25de6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_32.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_32.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_32.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_32.mat",
+      "description": "SHA-256 checksum value for group2_subset_32.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "18b4d5f483fd45dfb1697826490c4d283dbdbc421e26b6bff8b0aec69430a69d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_33.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_33.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_33.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463728457,
+      "checksum": {
+        "hash": "22d70fab33f335ef045d4982774f9422edf639830e2f3de52539de5e08b81c23",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_24.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_24.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_24.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_24.mat",
+      "description": "SHA-256 checksum value for group2_subset_24.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "4cc9828f5bcc89401e21bf8e2b9f4081ee824341fa09e24fa960103834954f39",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_43.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_43.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_43.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_43.mat",
+      "description": "SHA-256 checksum value for group2_subset_43.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "17ee0fc406759a428409b05f04276904e152085b6d43be6be0d35ebd801e9206",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_49.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_49.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_49.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732447,
+      "checksum": {
+        "hash": "5483c8603f84715da66b719451bfbaae323dab6e67ca9d00f9051b227d9b94eb",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_19.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_19.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_19.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_19.mat",
+      "description": "SHA-256 checksum value for group2_subset_19.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "397d3a7eb130bff7796f5794165ffa7ffc752047d5415966fa215d328abfa053",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_35.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_35.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_35.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_35.mat",
+      "description": "SHA-256 checksum value for group2_subset_35.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "f691fc35c915669c3104bf5599b7577447758f2b8c3ea0c467744b809af6ea98",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_15.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_15.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_15.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463727127,
+      "checksum": {
+        "hash": "98f3e0170f2a5cf0125f6c9317f19d270295f8478dce61cf1257ac8207e2926c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_17.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_17.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_17.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463733696,
+      "checksum": {
+        "hash": "74e9d40e4735305d5172b38829b5f209e31cd5e284c62d86ac78cc9f3741ddfc",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_48.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_48.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_48.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_48.mat",
+      "description": "SHA-256 checksum value for group2_subset_48.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "0fa494a4a154242eb9a01ef9c8ed10b5352c6f7d495b8726876c5130f8897ef2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_2.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_2.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_2.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_2.mat",
+      "description": "SHA-256 checksum value for group2_subset_2.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9ca81e8dc753dbc01d5d14183fa435e5aee36eb50420e662b9565367146361ea",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_45.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_45.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_45.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_45.mat",
+      "description": "SHA-256 checksum value for group2_subset_45.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "93bdacdb9790272b73a430c61d9d69f49ec861d00a742d69aa4e278ebd6bcce8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_30.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_30.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_30.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732484,
+      "checksum": {
+        "hash": "f899912e5c7ffa80e77a7abe665bd851ab89d102a52ec606d59ef263132df2e8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_42.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_42.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_42.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463728203,
+      "checksum": {
+        "hash": "9949f4d547185652803494af8dfcaed11c5570839b378fd80fa71e6af0590fd4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_12.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_12.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_12.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_12.mat",
+      "description": "SHA-256 checksum value for group2_subset_12.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "9ecdceffde4894ea2d5641a0d4c0f88d73283a8e4a77880b5c8e5553a35e227b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_42.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_42.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_42.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_42.mat",
+      "description": "SHA-256 checksum value for group2_subset_42.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "26d99687a5ff52440420a1504190d6ca80ebfa3c64cc127667af4c7e74a8b4b3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_30.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_30.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_30.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_30.mat",
+      "description": "SHA-256 checksum value for group2_subset_30.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "735b5c985c9b8c904be224864b18d9d4cdb124f08439a32b4c87654800894695",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_7.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_7.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_7.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463735807,
+      "checksum": {
+        "hash": "e50dab9e8616eafc4a933f34ecd963409346638f3291f9bc051e592db93080a4",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_25.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_25.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_25.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463733089,
+      "checksum": {
+        "hash": "cd767a9d8fdb69d9b766c616885a59fdaa2d483432641fc261e05be57d9161dd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_6.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_6.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_6.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_6.mat",
+      "description": "SHA-256 checksum value for group2_subset_6.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "6695478fbfb42b34bdb7096cf35ecc441078effa40bef3c6b79592d88ffdedfa",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_16.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_16.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_16.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463728545,
+      "checksum": {
+        "hash": "5efe2a0a0b7bf038a3b6563121a12a2efb0ca8fefc863f0792058724b817b329",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_28.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_28.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_28.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_28.mat",
+      "description": "SHA-256 checksum value for group2_subset_28.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "8b867c618c2f0f63c5faf45c6c3aebb59a797a67cce8549442b39e5c69b73262",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_22.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_22.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_22.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463733323,
+      "checksum": {
+        "hash": "c28a1789f10a2df34c84e32740e148c565fa002f7c1b4ba0c53590512ba0e8d8",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_47.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_47.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_47.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_47.mat",
+      "description": "SHA-256 checksum value for group2_subset_47.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "db32d227f7764d65dbd4a2084a9136cb3c6e7f9d67bb9969184e02aee5a8b27b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_40.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_40.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_40.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_40.mat",
+      "description": "SHA-256 checksum value for group2_subset_40.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "c62e663c435dbcbaed4c713083fe7b513dbcb40d5597019893d2d9bc073eca7b",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_43.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_43.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_43.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732415,
+      "checksum": {
+        "hash": "2bf83d98033f47cec3d3f27f873037a6963a74c4321b750a9698e70f41550d6c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_3.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_3.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_3.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_3.mat",
+      "description": "SHA-256 checksum value for group2_subset_3.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "ea36359dcec77b0057b43f6f1633c3edc1e6f4ce9dc4c2f594048505161dd606",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_18.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_18.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_18.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463736002,
+      "checksum": {
+        "hash": "839aa704b52d55dbe1b64c2c12b08b3003200c0f877c64366c86bc5256a456da",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_26.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_26.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_26.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734547,
+      "checksum": {
+        "hash": "5c7bcf2f83d0ca4af5a1b9b8290cce5693d896d2a82fc4c9347c677b1ae4944d",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_10.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_10.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_10.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731144,
+      "checksum": {
+        "hash": "80b028f8b2769f51a30027422178b19a611b5474ed9764205525e684618c0fb6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_15.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_15.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_15.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_15.mat",
+      "description": "SHA-256 checksum value for group2_subset_15.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "550b41bb54eddbe54e8dfa12660a325e063cc878e28d058b350770ae6a7d28dd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_28.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_28.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_28.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463730506,
+      "checksum": {
+        "hash": "b23085e2f13c76c5952c05f1529cb8b7e36a015369ff368fb8340772ccc84e0e",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_5.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_5.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_5.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_5.mat",
+      "description": "SHA-256 checksum value for group2_subset_5.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "fa8ab419c99c3a1cb651f1e8a8ff248d91a40500e7fde2af4faf85b3421e5fa1",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_24.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_24.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_24.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463732047,
+      "checksum": {
+        "hash": "319425ff205c5a2bf3283f707cbab6bcb1b85428c70254688beee5a83b5436ce",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_21.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_21.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_21.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_21.mat",
+      "description": "SHA-256 checksum value for group2_subset_21.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "7cc2bf6fa3cfe6156453fd34023711a88d1fac3ccff93bab1e67c71166f98ff0",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_14.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_14.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_14.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729345,
+      "checksum": {
+        "hash": "f5d09dabab624b3669552c0167f98c00cabd7dc9ecf15c220a765961e5744ff2",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_6.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_6.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_6.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463734781,
+      "checksum": {
+        "hash": "d564beb4f4ffcb28dbeb53b7c350cb8a01de8bd66b91ab4f4d563d98d8bf5e82",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_40.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_40.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_40.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463731676,
+      "checksum": {
+        "hash": "f0a3de43d8d6a18e412bfa602195e0c86d4c53046b6c46ac936efc248a3a616c",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_31.mat",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_31.mat",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_31.mat",
+      "mediaType": "application/x-matlab-data",
+      "size": 2463729231,
+      "checksum": {
+        "hash": "7265df9ad28df97c584c32d4c417929ffc9537bd3adc090a0eeef5f8a193bcbd",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_39.mat.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/Group2/group2_subset_39.mat.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/Group2/group2_subset_39.mat.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/Group2/group2_subset_39.mat",
+      "description": "SHA-256 checksum value for group2_subset_39.mat",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "392521af955a5dae11664e9dd4a83b78dd147b740c44ca6a1f13dcfc97c2e2ce",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/ReadMe.txt",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "SimulatedRadarWaveforms/ReadMe.txt",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/ReadMe.txt",
+      "mediaType": "text/plain",
+      "size": 1399,
+      "checksum": {
+        "hash": "4d74221383b28921be007ac02120b21f79c1b40efa8ea2b0e3c907c0e560e6fe",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    },
+    {
+      "@id": "cmps/SimulatedRadarWaveforms/License.txt.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "SimulatedRadarWaveforms/License.txt.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/SimulatedRadarWaveforms/License.txt.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/SimulatedRadarWaveforms/License.txt",
+      "description": "SHA-256 checksum value for License.txt",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "6c79e26ae5e58acbb19feec12f3381c0990a6a9de504eab57e01ae80d8b124d3",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/Data%20Dictionary%20of%203.5%20GHz%20Radar%20Waveforms.pdf.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "Data Dictionary of 3.5 GHz Radar Waveforms.pdf.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/Data%20Dictionary%20of%203.5%20GHz%20Radar%20Waveforms.pdf.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/Data Dictionary of 3.5 GHz Radar Waveforms.pdf",
+      "description": "SHA-256 checksum value for Data Dictionary of 3.5 GHz Radar Waveforms.pdf",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "b23ce8d359e5879e32d3273afc26ebaf09bc00584f23d30655a47863d5b49894",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/downloadDataset.py.sha256",
+      "@type": [
+        "nrdp:ChecksumFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "filepath": "downloadDataset.py.sha256",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/downloadDataset.py.sha256",
+      "algorithm": {
+        "tag": "sha256",
+        "@type": "Thing"
+      },
+      "describes": "cmps/downloadDataset.py",
+      "description": "SHA-256 checksum value for downloadDataset.py",
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/ChecksumFile"
+      ],
+      "mediaType": "text/plain",
+      "size": 64,
+      "checksum": {
+        "hash": "fa5a0f94ecf7c45ed857f3120b320e1d96ee665d08c166120832380cd8a59584",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      },
+      "valid": true
+    },
+    {
+      "@id": "cmps/Data%20Dictionary%20of%203.5%20GHz%20Radar%20Waveforms.pdf",
+      "@type": [
+        "nrdp:DataFile",
+        "nrdp:DownloadableFile",
+        "dcat:Distribution"
+      ],
+      "_extensionSchemas": [
+        "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+      ],
+      "filepath": "Data Dictionary of 3.5 GHz Radar Waveforms.pdf",
+      "downloadURL": "https://data.nist.gov/od/ds/ark:/88434/mds2-2116/Data%20Dictionary%20of%203.5%20GHz%20Radar%20Waveforms.pdf",
+      "mediaType": "application/pdf",
+      "size": 3723368,
+      "checksum": {
+        "hash": "4c8c4c4587d79f743e8831765aaae50c427c472ddfc9f4eb1c8fe9f7195672f6",
+        "algorithm": {
+          "tag": "sha256",
+          "@type": "Thing"
+        }
+      }
+    }
+  ],
+  "publisher": {
+    "name": "National Institute of Standards and Technology",
+    "@type": "org:Organization"
+  },
+  "language": [
+    "en"
+  ],
+  "bureauCode": [
+    "006:55"
+  ],
+  "programCode": [
+    "006:045"
+  ],
+  "doi": "doi:10.18434/M32116",
+  "issued": "2019-11-21",
+  "references": [],
+  "version": "1.1.0",
+  "authors": [
+    {
+      "@type": "foaf:Person",
+      "givenName": "Raied",
+      "familyName": "Caromi",
+      "fn": "Raied Caromi",
+      "affiliation": [
+        {
+          "@id": "grid.94225.38",
+          "@type": "schema:affiliation",
+          "title": "National Institute of Standards and Technology"
+        }
+      ]
+    },
+    {
+      "@type": "foaf:Person",
+      "givenName": "Michael",
+      "familyName": "Souryal",
+      "fn": "Michael Souryal",
+      "affiliation": [
+        {
+          "@id": "grid.94225.38",
+          "@type": "schema:affiliation",
+          "title": "National Institute of Standards and Technology"
+        }
+      ]
+    },
+    {
+      "@type": "foaf:Person",
+      "givenName": "Timothy",
+      "middleName": "A.",
+      "familyName": "Hall",
+      "fn": "Timothy A. Hall",
+      "affiliation": [
+        {
+          "@id": "grid.94225.38",
+          "@type": "schema:affiliation",
+          "title": "National Institute of Standards and Technology"
+        }
+      ]
+    }
+  ],
+  "releaseHistory": {
+    "@id": "ark:/88434/mds2-2116/pdr:v",
+    "@type": [
+      "nrdr:ReleaseHistory"
+    ],
+    "hasRelease": [
+      {
+        "version": "1.0.0",
+        "issued": "2019-08-27 00:00:00",
+        "@id": "ark:/88434/mds2-2116/pdr:v/1.0.0",
+        "location": "https://data.nist.gov/od/id/ark:/88434/mds2-2116/pdr:v/1.0.0",
+        "description": "initial release"
+      },
+      {
+        "version": "1.1.0",
+        "issued": "2019-08-27 00:00:00",
+        "@id": "ark:/88434/mds2-2116/pdr:v/1.1.0",
+        "location": "https://data.nist.gov/od/id/ark:/88434/mds2-2116/pdr:v/1.1.0",
+        "description": "data update"
+      }
+    ]
+  }
+}

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -11,10 +11,12 @@
  */
 import { LPSConfig } from '../app/config/config';
 
+const largedata: any  = require('../assets/sample-data/mds2-2116.json');
+
 export const context = {
     production: false,
     useMetadataService: false,
-    useCustomizationService: true
+    useCustomizationService: false
 };
 
 export const config: LPSConfig = {
@@ -50,6 +52,7 @@ export const config: LPSConfig = {
 }
 
 export const testdata: {} = {
+    test0: largedata,
     test1: {
         "@context": [
             "https://www.nist.gov/od/dm/nerdm-pub-context.jsonld",


### PR DESCRIPTION
This check in solves the problems mentioned in Jira ticket: http://mml.nist.gov:8080/browse/ODD-1086.

Problem #1 seems only happens in edit mode while the two icons are disabled. To test this, set environment.ts to test mode then use this url: http://localhost:4200/lps/test3?editEnabled=true.

Problem #2 happens in both edit and public mode. Edit mode can be tested the same way as problem #1. Public mode can be tested using this url: http://localhost:4200/lps/ECBCC1C1301D2ED9E04306570681B10735.

Problem #3 also happens in both edit and public mode. 
  To test it in public mode, set environment to non-editing and use url: http://localhost:4200/lps/mds2-2116.
  To test it in edit mode, use http://localhost:4200/lps/test0?editEnabled=true. I added test0 to environment.ts for this purpose.

