### PR TITLE
Bug fix: properly link to data via ghost record

### DIFF
--- a/python/nistoar/pdr/preserv/bagger/midas3.py
+++ b/python/nistoar/pdr/preserv/bagger/midas3.py
@@ -180,7 +180,7 @@ class MIDASSIP(object):
             if replid and (replid.startswith('doi:') or replid.startswith("http")):
                 replid = None
         if replid:
-            recnum = _midadid_to_dirname(midasid)
+            recnum = _midadid_to_dirname(replid)
             for pdir in [reviewdir, uploaddir]:
                 extradir = os.path.join(pdir, recnum)
                 if os.path.isdir(extradir):

--- a/python/nistoar/pdr/preserv/bagger/midas3.py
+++ b/python/nistoar/pdr/preserv/bagger/midas3.py
@@ -154,6 +154,8 @@ class MIDASSIP(object):
             nerd = nerdrec
         else:
             nerd = read_json(nerdrec)
+
+        # figure out where the files will be based on the EDI-ID
         midasid = nerd.get('ediid')
         if not midasid:
             msg = "Missing required ediid property from NERDm record"
@@ -167,8 +169,26 @@ class MIDASSIP(object):
         if not os.path.isdir(upldir):
             upldir = None
 
-        return cls(midasid, revdir, upldir, nerdrec=nerd)
+        out = cls(nerd.get('ediid'), revdir, upldir, nerdrec=nerd)
 
+        # if this SIP is replacing a previous one, look for data in the old local
+        replid = None
+        if nerd.get("replaces") and len(nerd['replaces']) > 0:
+            replid = nerd['replaces'][-1].get('ediid')
+            if not replid:
+                nerd['replaces'][-1].get('@id')
+            if replid and (replid.startswith('doi:') or replid.startswith("http")):
+                replid = None
+        if replid:
+            recnum = _midadid_to_dirname(midasid)
+            for pdir in [reviewdir, uploaddir]:
+                extradir = os.path.join(pdir, recnum)
+                if os.path.isdir(extradir):
+                    out._indirs.append(extradir)
+
+        return out
+
+    
     def __init__(self, midasid, reviewdir, uploaddir=None, podrec=None, nerdrec=None):
         """
         :param midasid      str:  the identifier provided by MIDAS, used as the 

--- a/python/nistoar/pdr/publish/midas3/service.py
+++ b/python/nistoar/pdr/publish/midas3/service.py
@@ -408,7 +408,7 @@ class MIDAS3PublishingService(PublishSystem):
         try: 
             # prevent updates to new worker's bag
             replworker.halt_pod_processing("EDI-swapping")
-            oldworker.ensure_res_metadata()
+            oldworker.bagger.ensure_res_metadata()
 
             # lock the old worker
             oldworker.bagger.ensure_filelock()

--- a/python/nistoar/pdr/publish/midas3/service.py
+++ b/python/nistoar/pdr/publish/midas3/service.py
@@ -408,6 +408,7 @@ class MIDAS3PublishingService(PublishSystem):
         try: 
             # prevent updates to new worker's bag
             replworker.halt_pod_processing("EDI-swapping")
+            oldworker.ensure_res_metadata()
 
             # lock the old worker
             oldworker.bagger.ensure_filelock()

--- a/python/nistoar/pdr/publish/midas3/service.py
+++ b/python/nistoar/pdr/publish/midas3/service.py
@@ -421,14 +421,16 @@ class MIDAS3PublishingService(PublishSystem):
             with replworker.bagger.lock:
                 replworker.bagger.ensure_res_metadata()
                 version = replworker.bagger.sip.nerd.get("version", "1.0.0")
+                replacesinfo = replworker.bagger.sip.nerd.get("replaces", [])
+                replacesinfo.append(OrderedDict([
+                    ("@id", replworker.bagger.sip.nerd.get("doi", replworker.bagger.sip.nerd.get("@id"))),
+                    ("ediid", oldworker.bagger.sip.nerd.get("ediid")),
+                    ("issued", replworker.bagger.sip.nerd.get("issued",
+                                                              replworker.bagger.sip.nerd.get("modified")))
+                ]))
                 tweak = {
                     "ediid": replworker.bagger.midasid,
-                    "replaces": OrderedDict([
-                        ("@id", replworker.bagger.sip.nerd.get("doi", replworker.bagger.sip.nerd.get("@id"))),
-                        ("ediid", oldworker.bagger.sip.nerd.get("ediid")),
-                        ("issued", replworker.bagger.sip.nerd.get("issued",
-                                                                  replworker.bagger.sip.nerd.get("modified")))
-                    ])
+                    "replaces": replacesinfo
                 }
                 replworker.bagger.bagbldr.update_metadata_for("", tweak,
                                                               message="setting new EDI-ID for major update")

--- a/python/nistoar/pdr/publish/midas3/service.py
+++ b/python/nistoar/pdr/publish/midas3/service.py
@@ -420,7 +420,16 @@ class MIDAS3PublishingService(PublishSystem):
             with replworker.bagger.lock:
                 replworker.bagger.ensure_res_metadata()
                 version = replworker.bagger.sip.nerd.get("version", "1.0.0")
-                replworker.bagger.bagbldr.update_metadata_for("", {"ediid": replworker.bagger.midasid}, 
+                tweak = {
+                    "ediid": replworker.bagger.midasid,
+                    "replaces": OrderedDict([
+                        ("@id", replworker.bagger.sip.nerd.get("doi", replworker.bagger.sip.nerd.get("@id"))),
+                        ("ediid", oldworker.bagger.sip.nerd.get("ediid")),
+                        ("issued", replworker.bagger.sip.nerd.get("issued",
+                                                                  replworker.bagger.sip.nerd.get("modified")))
+                    ])
+                }
+                replworker.bagger.bagbldr.update_metadata_for("", tweak,
                                                               message="setting new EDI-ID for major update")
                 if not re.search(r'\+ \([\w\s]+\)', version):
                     replworker.bagger.bagbldr.update_annotations_for("", {"version": version+"+ (in edit)"},

--- a/python/tests/nistoar/pdr/preserv/bagger/test_midas3.py
+++ b/python/tests/nistoar/pdr/preserv/bagger/test_midas3.py
@@ -165,9 +165,20 @@ class TestMIDASSIPMixed(test.TestCase):
         self.assertTrue(isinstance(self.sip.nerd, Mapping))
         self.assertEqual(self.sip.midasid, self.midasid)
         self.assertEqual(self.sip._pod_rec(), {'distribution': []})
+        indirs = [os.path.join(self.revdir,"1491"), os.path.join(self.upldir,"1491")]
+        self.assertEqual(self.sip._indirs, indirs)
         nerd = self.sip._nerdm_rec()
         self.assertEqual(nerd['accessLevel'], "public")
         self.assertEqual(nerd['ediid'], self.midasid)
+
+        nerd['replaces'] = [{
+            "@id": "doi:10.88888/mds2-1491",
+            "ediid": "ark:/88434/mds2-1491",
+        }]
+        self.sip = midas.MIDASSIP.fromNERD(nerd, self.revdir, self.upldir)
+        self.assertEqual(self.sip._indirs, indirs + indirs)
+        
+                         
         
 
 class TestMIDASMetadataBaggerMixed(test.TestCase):

--- a/python/tests/nistoar/pdr/publish/midas3/test_service_update.py
+++ b/python/tests/nistoar/pdr/publish/midas3/test_service_update.py
@@ -227,8 +227,9 @@ class TestMIDAS3PublishingServiceOnUpdate(test.TestCase):
         self.assertEqual(data.get('ediid'), self.updmidasid)
         self.assertEqual(data.get('version'), "1.0.0+ (in edit)")
         self.assertIn('replaces', data)
-        self.assertIn('ediid', data['replaces'])
-        self.assertEqual(data['replaces'].get("ediid"), oldwrkr.bagger.sip.nerd.get("ediid"))
+        self.assertGreater(len(data['replaces']), 0)
+        self.assertIn('ediid', data['replaces'][-1])
+        self.assertEqual(data['replaces'][-1].get("ediid"), oldwrkr.bagger.sip.nerd.get("ediid"))
 
         
     def test_update_ds_with_pod_onupdate(self):

--- a/python/tests/nistoar/pdr/publish/midas3/test_service_update.py
+++ b/python/tests/nistoar/pdr/publish/midas3/test_service_update.py
@@ -226,6 +226,9 @@ class TestMIDAS3PublishingServiceOnUpdate(test.TestCase):
         data = newwrkr.bagger.sip.nerd
         self.assertEqual(data.get('ediid'), self.updmidasid)
         self.assertEqual(data.get('version'), "1.0.0+ (in edit)")
+        self.assertIn('replaces', data)
+        self.assertIn('ediid', data['replaces'])
+        self.assertEqual(data['replaces'].get("ediid"), oldwrkr.bagger.sip.nerd.get("ediid"))
 
         
     def test_update_ds_with_pod_onupdate(self):


### PR DESCRIPTION
Currently, when someone updates a previously published record in MIDAS with new or updated files, the changes are sent to review under a new temporary record number--the so-called ghost record.  Meanwhile, the PDR can provide the draft landing page under that new number provided the submitted POD record contains a proper "replaces" property.  That landing page must link simultaneously to the new files and the previously published files that are not being updated.  Currently, there is a bug in the linking to the new files; the landing page service will only look for the files in directories associated with the new number when they actually are still stored under the new one.  This PR fixes this problem by adding the old record data directories to the list that the PDR checks for new/updated files.

Note that this bug was manifesting itself because of a separate bug in MIDAS: it was not always setting the "replaces" property.  