### PR TITLE
LPS: set rel="noopener" to links with target="_blank"

### DIFF
--- a/angular/src/app/datacart/treetable/treetable.component.html
+++ b/angular/src/app/datacart/treetable/treetable.component.html
@@ -63,7 +63,7 @@
                     </td>
                     <td [ngStyle]="bodyStyle(sizeWidth)">
                         <div *ngIf="rowData.cartItem;else space_holder" style="display:inline;color: green;" >
-                            <a *ngIf="rowData.cartItem.downloadStatus != 'downloading'" href='{{rowData.cartItem.downloadURL}}' target='_blank' download="download" data-toggle="tooltip" 
+                            <a *ngIf="rowData.cartItem.downloadStatus != 'downloading'" href='{{rowData.cartItem.downloadURL}}' target='_blank' rel="noopener"  download="download" data-toggle="tooltip" 
                                 title="Download this file" aria-label="Download this file">
                                 <i class="faa faa-download"
                                     aria-hidden="true" (click)="setFileDownloaded(rowData)"></i>

--- a/angular/src/app/frame/footbar.component.html
+++ b/angular/src/app/frame/footbar.component.html
@@ -5,7 +5,7 @@
             <div class="item-list">
                 <ul>
                     <li *ngFor="let socialMedia of socialMediaList">
-                        <a [href]="socialMedia.url" target="_blank" class="social-btn social-btn--large extlink ext"><i [class]="socialMedia.icon"><span
+                        <a [href]="socialMedia.url" target="_blank" rel="noopener noreferrer" class="social-btn social-btn--large extlink ext"><i [class]="socialMedia.icon"><span
                             class="element-invisible">{{socialMedia.name}}</span></i><span class="ext"><span class="element-invisible"> (link
                             is external)</span></span></a>
                     </li>

--- a/angular/src/app/frame/footbar.component.html
+++ b/angular/src/app/frame/footbar.component.html
@@ -16,7 +16,7 @@
         <!-- Footer logo -->
         <div class="footer__logo">
             <a href="https://nist.gov/" target="_blank" title="National Institute of Standards and Technology"
-                class="footer__logo-link" rel="home">
+                class="footer__logo-link" rel="home noopener">
                 <img src="./assets/images/logo_rev.png" alt="National Institute of Standards and Technology"
                 title="National Institute of Standards and Technology">
             </a>
@@ -27,7 +27,7 @@
         class="block menu--footer-menu first even block--menu block--menu-menu-footer-menu" role="navigation">
             <ul class="menu">
                 <li *ngFor="let link of footerLinks01; let i = index" [ngClass]="getLinkClass(i, footerLinks01)">
-                    <a [href]="link.url" target="_blank" class="menu__link">{{link.title}} </a>
+                    <a [href]="link.url" target="_blank" rel="noopener" class="menu__link">{{link.title}} </a>
                 </li>
             </ul>
         </div>
@@ -37,7 +37,7 @@
         class="block menu--footer-menu last even block--menu block--menu-menu-footer-menu-3" role="navigation">
             <ul class="menu">
                 <li *ngFor="let link of footerLinks02; let i = index" [ngClass]="getLinkClass(i, footerLinks02)">
-                    <a [href]="link.url" target="_blank" class="menu__link">{{link.title}} </a>
+                    <a [href]="link.url" target="_blank" rel="noopener" class="menu__link">{{link.title}} </a>
                 </li>
             </ul>
         </div>

--- a/angular/src/app/landing/data-files/data-files.component.html
+++ b/angular/src/app/landing/data-files/data-files.component.html
@@ -113,7 +113,7 @@
                                 <div *ngIf="rowData.comp.downloadURL;else space_holder">
                                     <a *ngIf="rowData.downloadStatus != 'downloading'"
                                         href='{{rowData.comp.downloadURL}}' target='_blank' download="download"
-                                        data-toggle="tooltip" title="Direct download"
+                                        data-toggle="tooltip" title="Direct download" rel="noopener"
                                         (click)="setFileDownloaded(rowData)">
                                         <i class="faa faa-download" [ngStyle]="{'color':getDownloadBtnColor(rowData)}"
                                             aria-hidden="true"></i>

--- a/angular/src/app/landing/resultlist/resultlist.component.html
+++ b/angular/src/app/landing/resultlist/resultlist.component.html
@@ -42,7 +42,7 @@
         <div *ngIf="resultItem.active && i >= (currentPage.value-1)*itemsPerPage && i <= currentPage.value*itemsPerPage-1"
             style="border-bottom: 1px solid rgb(202, 202, 202);margin-bottom: 1em; ">
             <a *ngIf="resultItem.landingPage" style="float: right; margin-top: -0.5em;"
-                href="{{resultItem.landingPage}}" target="_blank">
+                href="{{resultItem.landingPage}}" target="_blank" rel="noopener">
                 <button pButton label="Home Page" type="button" class="p-button-sm visit-home-page-forensics"
                     icon="faa faa-external-link" iconPos="left" style="padding: 3px 10px;"></button>
             </a>

--- a/angular/src/app/landing/sections/resourcedata.component.html
+++ b/angular/src/app/landing/sections/resourcedata.component.html
@@ -27,7 +27,7 @@
     <!-- Display Homepage button if 'landingPage field exist and does not contain '/od/id' -->
     <div *ngIf="record['landingPage'] && record['landingPage'].indexOf('/od/id') === -1 ">
         For more information, please visit the
-        <a target="_blank" href="{{ record['landingPage'] }}"
+        <a target="_blank" href="{{ record['landingPage'] }}" rel="noopener"
             (click)="gaService.gaTrackEvent('homepage', $event, 'Resource title: ' + record.title, record['landingPage'])">home
             page</a>.
     </div>
@@ -65,7 +65,7 @@
                 </div>
                 <ng-template #RestrictedAccessPage>
                     <div style="padding:10px 20px;">
-                        <a href={{apage.accessURL}} target="_blank">
+                        <a href={{apage.accessURL}} target="_blank" rel="noopener">
                             <button style="margin-top: -6px;" type="button" class="btn btn-primary py-0"
                                 data-toggle="tooltip" data-placement="top" title="{{apage['title']}}"
                                 (click)="googleAnalytics(apage['accessURL'], $event, 'Download Data')"><i

--- a/angular/src/app/landing/sections/resourceidentity.component.html
+++ b/angular/src/app/landing/sections/resourceidentity.component.html
@@ -49,7 +49,7 @@
     <div class="col-4 col-md-4 col-lg-4 col-sm-12">
         <span *ngIf="showHomePageLink" style="float: right;">
             <span *ngIf="inBrowser; else visitHomeOnServer">
-                <a href={{record.landingPage}} target="_blank">
+                <a href={{record.landingPage}} target="_blank" rel="noopener">
                     <button type="button" pButton type="submit" [disabled]="!inViewMode"
                         class="home_button p-button p-component ui-button-text-empty"
                         [ngStyle]="{'background-color': visitHomePageBtnStyle()}"


### PR DESCRIPTION
This PR is in response to a security scan of  the datacart page serving RPA requests.  The scan recommends adding `rel="noopener noreferrer"` to any `<a href="...">` that also has `target="_blank"`.  This would apply to any link generated in the PDR angular application.  

There are two disadvantages to making this recommended change:
  *  when the link points to a downloadable file, an access page, or a home page, the use of `noreferrer` prevents target sites from learning that the PDR is driving users to that site, including when that site is the PDR itself.  Note that in most cases, when this type of link does not point to a PDR URL, it points to another `nist.gov` server; thus, "noreferrer" mainly hurts ourselves. 
  *  when the link points to a PDR angular URL, use of `noopener` prevents angular from leveraging the linkage to the referring app.  

Thus, in response, this PR applies the following changes to templates with links with `target="_blank"`:
  *  if the link points explicitly/definitively to a PDR URL, no change is made.  
  *  if the link points to a downloadable file, an access page, or a home page, `rel="noopener"` is added to the link tag.
  *  if the link points definitively to an external site (e.g. a social media site), `rel="noopener noreferrer"` is added to the link tag. 

I have tested this under oar-docker and confirmed that the new attribute appears and that the links still work.  