### PR TITLE
Fix/odd 1110 rpd

### DIFF
--- a/angular/src/app/landing/data-files/data-files.component.css
+++ b/angular/src/app/landing/data-files/data-files.component.css
@@ -1,5 +1,5 @@
 .restrict-public {
-    background-color: rgb(238, 238, 238); padding: 20px;
+    padding-left: 20px;
 }
 
 .ui-treetable .ui-state-highlight {

--- a/angular/src/app/landing/data-files/data-files.component.html
+++ b/angular/src/app/landing/data-files/data-files.component.html
@@ -1,7 +1,6 @@
 <!-- This bloack is for the data access session of landing page -->
 <!-- <div id="filelisting"> -->
-<div id="filelisting" *ngIf="displayMode != 'restrict_preview'"
-    [ngClass]="displayMode == 'restrict' ? 'restrict-public' : ''">
+<div id="filelisting" *ngIf="displayMode != 'restrict_preview'" style="margin-bottom: 20px;">
 
     <!-- Display 'Download all' and 'Add all to cart' buttons and other info -->
     <div *ngIf="files.length  > 0">

--- a/angular/src/app/landing/data-files/data-files.component.html
+++ b/angular/src/app/landing/data-files/data-files.component.html
@@ -2,8 +2,6 @@
 <!-- <div id="filelisting"> -->
 <div id="filelisting" *ngIf="displayMode != 'restrict_preview'"
     [ngClass]="displayMode == 'restrict' ? 'restrict-public' : ''">
-    <div *ngIf="displayMode == 'restrict'">Note: This dataset is designated as restricted public data; this file list
-        will not be shown in the public version of this page.</div>
 
     <!-- Display 'Download all' and 'Add all to cart' buttons and other info -->
     <div *ngIf="files.length  > 0">

--- a/angular/src/app/landing/data-files/data-files.component.html
+++ b/angular/src/app/landing/data-files/data-files.component.html
@@ -110,8 +110,9 @@
                         </td>
                         <td [ngStyle]="statusStyle()">
                             <div style="display: flex;">
-                                <div *ngIf="rowData.comp.downloadURL;else space_holder">
+                                <div *ngIf="displayMode != 'restrict' || rowData.comp.downloadURL;else space_holder">
                                     <a *ngIf="rowData.downloadStatus != 'downloading'"
+                                        style="margin-left: 10px;"
                                         href='{{rowData.comp.downloadURL}}' target='_blank' download="download"
                                         data-toggle="tooltip" title="Direct download"
                                         (click)="setFileDownloaded(rowData)">
@@ -126,18 +127,29 @@
                                 <ng-template #space_holder>
                                     <div style="padding-right: 0.4em;">&nbsp;&nbsp;</div>
                                 </ng-template>
-                                <div style="padding-left:10px;" *ngIf="rowData.isInCart;else not_in_cart"
+
+                                <!-- Display shopping cart icon for oublic data. Otherwise display lock icon -->
+                                <div class="indent-content"
+                                *ngIf="displayMode != 'restrict' || rowData.comp.downloadURL; else RestrictedAccessPage">
+                                    <div style="padding-left:10px;" *ngIf="rowData.isInCart;else not_in_cart"
                                     (click)="removeFromGlobalCart(rowData)">
-                                    <i class="faa faa-cart-plus green-cart" aria-hidden="true" data-toggle="tooltip"
-                                        title="Remove from cart"></i>
-                                </div>
-                                <div *ngIf="rowData.isInCart" style="margin-left: 0.5em;font-size: 0.5em">Added
-                                </div>
-                                <ng-template #not_in_cart>
-                                    <div style="padding-left:10px;" (click)="addToGlobalCart(rowData)">
-                                        <i class="faa faa-cart-plus blue-cart" aria-hidden="true" data-toggle="tooltip"
-                                            title="Add to cart"></i>
+                                        <i class="faa faa-cart-plus green-cart" aria-hidden="true" data-toggle="tooltip"
+                                            title="Remove from cart"></i>
                                     </div>
+                                    <div *ngIf="rowData.isInCart" style="margin-left: 0.5em;font-size: 0.5em">
+                                        Added
+                                    </div>
+                                    <ng-template #not_in_cart>
+                                        <div style="padding-left:10px;" (click)="addToGlobalCart(rowData)">
+                                            <i class="faa faa-cart-plus blue-cart" aria-hidden="true" data-toggle="tooltip"
+                                                title="Add to cart"></i>
+                                        </div>
+                                    </ng-template>
+                                </div>
+                                <ng-template #RestrictedAccessPage>
+                                    <a *ngIf="!rowData.comp.downloadURL && rapWithAccessUrl" href={{accessURL}} target="_blank">
+                                        <i class="faa faa-lock blue-cart" (click)="googleAnalytics(rowData.comp['accessURL'], $event, 'Request access')" aria-hidden="true" data-toggle="tooltip" title="Request access"></i>
+                                    </a>
                                 </ng-template>
                             </div>
                         </td>

--- a/angular/src/app/landing/data-files/data-files.component.ts
+++ b/angular/src/app/landing/data-files/data-files.component.ts
@@ -151,6 +151,8 @@ export class DataFilesComponent implements OnInit, OnChanges {
     prevMouseY: number = 0;
     prevTreeTableHeight: number = 0;
     searchText: string = "";
+    rapWithAccessUrl: boolean = false; // Indicate if there is a restricted access page with access url
+    accessURL: string = "";
 
     // The key of treenode whose details is currently displayed
     currentKey: string = '';
@@ -168,7 +170,7 @@ export class DataFilesComponent implements OnInit, OnChanges {
             { field: 'name', header: 'Name', width: '60%' },
             { field: 'mediaType', header: 'File Type', width: 'auto' },
             { field: 'size', header: 'Size', width: 'auto' },
-            { field: 'download', header: 'Status', width: 'auto' }];
+            { field: 'download', header: "Status", width: 'auto' }];
 
         if (typeof (window) !== 'undefined') {
             window.onresize = (e) => {
@@ -219,8 +221,9 @@ export class DataFilesComponent implements OnInit, OnChanges {
      * Restrict and preview mode: hide the whole block -- restrict_preview
      */
     get displayMode() {
-        if(!this.editEnabled || this.record['accessLevel'] === 'public') {
-            return "normal";
+        // if(!this.editEnabled || this.record['accessLevel'] === 'public') {
+        if(this.record['accessLevel'] === 'public') {
+                return "normal";
         }else if(this.record['accessLevel'] === 'restricted public' && this.editMode != this.EDIT_MODES.PREVIEW_MODE) {
             return "restrict";
         }else {
@@ -262,14 +265,37 @@ export class DataFilesComponent implements OnInit, OnChanges {
     // --- end of mouse drag functions
 
     useMetadata() {
-        this.ediid = this.record['ediid']
-        this.buildTree();
+        this.ediid = this.record['ediid'];
 
+        if(this.record['accessLevel'] === 'restricted public') {
+            this.checkAccessPageType();
+            this.cols[3]['header'] = "Access";
+        }
+
+        this.buildTree();
+        console.log("files", this.files);
         // If total file count > virtual scrolling threshold, set virtual scrolling to true. 
         this.virtualScroll = this.fileCount > FileCountForVirtualScroll? true : false;
 
         // If number of top level elements > 5, set table height to MaxTreeTableHeight, otherwise set it to actual rows * 25 pixels
         this.treeTableHeight = this.files.length > 5 ? MaxTreeTableHeight : this.files.length * 25;
+    }
+
+    isRestrictedData(node: any) {
+        return node['comp']['@type'].includes('nrdp:RestrictedAccessPage');
+    }
+
+    checkAccessPageType() {
+        let comps = this.record["components"];
+        if(comps && comps.length > 0) {
+            for (let comp of comps) {
+                if(comp['@type'].includes('nrdp:RestrictedAccessPage') && comp["accessURL"] && comp["accessURL"].trim() != "") {
+                    this.rapWithAccessUrl = true;
+                    this.accessURL = comp["accessURL"];
+                    break;
+                }
+            }
+        }
     }
 
     /**
@@ -907,4 +933,14 @@ export class DataFilesComponent implements OnInit, OnChanges {
         let mType: string = MediaTypeMapping[ext];
         return mType == undefined ? "" : mType;
     }
+
+    /**
+     * Google Analytics track event
+     * @param url - URL that user visit
+     * @param event - action event
+     * @param title - action title
+     */
+    googleAnalytics(url: string, event, title) {
+        this.gaService.gaTrackEvent('homepage', event, title, url);
+    }    
 }

--- a/angular/src/app/landing/sections/resourcedata.component.html
+++ b/angular/src/app/landing/sections/resourcedata.component.html
@@ -69,16 +69,19 @@
                             <button style="margin-top: -6px;" type="button" class="btn btn-primary py-0"
                                 data-toggle="tooltip" data-placement="top" title="{{apage['title']}}"
                                 (click)="googleAnalytics(apage['accessURL'], $event, 'Download Data')"><i
-                                    class="faa faa-external-link button_icon"></i>Download Data</button>
+                                    class="faa faa-external-link button_icon"></i>Request Data Access</button>
                         </a>
 
                         <div *ngIf="apage['description']">
-                            <div style="cursor: pointer;color: #1471AE;" (click)="apage[showDesc] = !apage[showDesc]"><i
-                                    class="faa faa-caret-right" *ngIf="!apage[showDesc]"></i><i
-                                    class="faa faa-caret-down" *ngIf="apage[showDesc]"></i> About downloading restricted
+                            <div style="cursor: pointer;color: #1471AE;" (click)="apage['showDesc'] = !apage['showDesc']"><i
+                                    class="faa faa-caret-right" *ngIf="!apage['showDesc']"></i><i
+                                    class="faa faa-caret-down" *ngIf="apage['showDesc']"></i> About downloading restricted
                                 public data
                             </div>
-                            <div class="description" *ngIf="apage[showDesc]" [@enterAnimation]>{{apage['description']}}
+
+                            <div *ngIf="apage['description']" class="description" >
+                                <div [@detailExpand]="apage['showDesc'] ? 'expanded' : 'collapsed'" style="overflow: hidden;">{{apage['description']}}
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/angular/src/environments/environment.ts
+++ b/angular/src/environments/environment.ts
@@ -14,7 +14,7 @@ import { LPSConfig } from '../app/config/config';
 export const context = {
     production: false,
     useMetadataService: false,
-    useCustomizationService: true
+    useCustomizationService: false
 };
 
 export const config: LPSConfig = {
@@ -28,9 +28,9 @@ export const config: LPSConfig = {
     },
     APIs: {
         customization: "https://data.nist.gov/customization",
-        // customization: "https://testdata.nist.gov/customization",
+        // customization: "https://data.nist.gov/customization",
         // distService: "https://data.nist.gov/od/ds/",
-        distService: "https://testdata.nist.gov/od/ds/",
+        distService: "https://data.nist.gov/od/ds/",
         mdService: "https://data.nist.gov/od/id/",
         mdSearch:  "https://data.nist.gov/rmm/",
         metrics:   "https://data.nist.gov/rmm/usagemetrics",
@@ -40,7 +40,7 @@ export const config: LPSConfig = {
     status: "Dev Version",
     appVersion: "v1.3.X",
     production: context.production,
-    editEnabled: true,
+    editEnabled: false,
     gacode: "not-set",
     screenSizeBreakPoint: 1060,
     bundleSizeAlert: 500000000,
@@ -386,9 +386,8 @@ export const testdata: {} = {
         "license": "https://www.nist.gov/open/license",
         "components": [
             {
-                "accessURL": "https://www.nist.gov/itl/iad/image-group/special-database-32-multiple-encounter-dataset-meds",
-                "description": "This page presents a registration form that must be completed to download the restricted data. Multiple Encounter Dataset (MEDS-I) is a test corpus organized from an extract of submissions of deceased persons with prior multiple encounters. MEDS is provided to assist the FBI and partner organizations refine tools, techniques, and procedures for face recognition as it supports Next Generation Identification (NGI), forensic comparison, training, and analysis, and face image conformance and inter-agency exchange standards. The MITRE Corporation (MITRE) prepared MEDS in the FBI Data Analysis Support Laboratory (DASL) with support from the FBI Biometric Center of Excellence.",
-                "title": "Gateway for Registered Data Access",
+                "description": "Zip file with JPEG formatted face image files.",
+                "title": "Multiple Encounter Dataset (MEDS)",
                 "format": {
                     "description": "JPEG formatted images"
                 },
@@ -396,12 +395,40 @@ export const testdata: {} = {
                 "downloadURL": "http://nigos.nist.gov:8080/nist/sd/32/NIST_SD32_MEDS-I_face.zip",
                 "filepath": "NIST_SD32_MEDS-I_face.zip",
                 "@type": [
-                    "nrdp:RestrictedAccessPage",
-                    "nrdp:AccessPage"
+                    "nrdp:Hidden",
+                    "nrdp:AccessPage",
+                    "dcat:Distribution"
                 ],
                 "@id": "cmps/NIST_SD32_MEDS-I_face.zip",
                 "_extensionSchemas": [
                     "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/AccessPage"
+                ]
+            },
+            {
+                "accessURL": "https://data.nist.gov/od/rp?@id=ark:/88434/mds2-2419",
+                "description": "This page provides a registration form that must be completed before downloading the data.",
+                "title": "Gateway for Registered Data Access",
+                "@type": [
+                  "nrdp:RestrictedAccessPage",
+                  "nrdp:AccessPage",
+                  "dcat:Distribution"
+                ],
+                "@id": "#pdr?@id=ark:/88434/mds2-2419",
+                "_extensionSchemas": [
+                  "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/AccessPage"
+                ]
+            },
+            {
+                "accessURL": "https://doi.org/10.18434/mds0000fbk",
+                "description": "DOI Access to landing page",
+                "title": "DOI Access to \"Multiple Encounter Dataset (MEDS-I)\"",
+                "@type": [
+                    "nrdp:AccessPage",
+                    "dcat:Distribution"
+                ],
+                "@id": "#doi:10.18434/mds0000fbk",
+                "_extensionSchemas": [
+                    "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/"
                 ]
             },
             {
@@ -416,13 +443,35 @@ export const testdata: {} = {
                 "filepath": "NIST_SD32_MEDS-I_html.zip",
                 "@type": [
                     "nrdp:DataFile",
-                    "dcat:Distribution",
-                    "nrdp:AccessPage"
+                    "dcat:Distribution"
                 ],
                 "@id": "cmps/NIST_SD32_MEDS-I_html.zip",
                 "_extensionSchemas": [
                     "https://www.nist.gov/od/dm/nerdm-schema/pub/v0.1#/definitions/DataFile"
                 ]
+            },
+            {
+                "@id": "cmps/nfiq2_conformance_expected_output.csv",
+                "@type": [
+                  "nrdp:DataFile",
+                  "nrdp:DownloadableFile",
+                  "dcat:Distribution"
+                ],
+                "_extensionSchemas": [
+                  "https://data.nist.gov/od/dm/nerdm-schema/pub/v0.7#/definitions/DataFile"
+                ],
+                "filepath": "nfiq2_conformance_expected_output.csv",
+                "mediaType": "text/csv",
+                "description": "Expected output from NFIQ 2 when run against the conformance dataset.",
+                "title": "NFIQ 2 Conformance Expected Output",
+                "size": 74061,
+                "checksum": {
+                  "hash": "863b33fd8b5a725616d21d5f482205ea7d0e625162f883b6aadfb20ad6cea34e",
+                  "algorithm": {
+                    "tag": "sha256",
+                    "@type": "Thing"
+                  }
+                }
             },
             {
                 "accessURL": "https://doi.org/10.18434/mds0000fbk",


### PR DESCRIPTION
…ict public data

http://mml.nist.gov:8080/browse/ODD-1110

To test locally, use http://localhost:4200/lps/test3. This restrict data record contains two data files. One has download url and the other has not.

The last column of the data table should be named" "Access". The row that does not have the download url should display a lock and link to the accessURL of the page.

The expand function of "About downloading restricted public data" was fixed.