### PR TITLE
Handle metrics that has no filepath

### DIFF
--- a/angular/src/app/app.component.ts
+++ b/angular/src/app/app.component.ts
@@ -41,7 +41,7 @@ export class AppComponent {
             this.gaCode = this.cfg.get("gaCode", "") as string;
             this.ga4Code = this.cfg.get("ga4Code", "") as string;
             let homeurl = this.cfg.get("locations.portalBase", "data.nist.gov") as string;
-            console.log('homeurl', homeurl);
+
             const url = new URL(homeurl);
             this.hostName = url.hostname;
 

--- a/angular/src/app/landing/data-files/data-files.component.ts
+++ b/angular/src/app/landing/data-files/data-files.component.ts
@@ -282,7 +282,14 @@ export class DataFilesComponent implements OnInit, OnChanges {
     }
 
     isRestrictedData(node: any) {
-        return node['comp']['@type'].includes('nrdp:RestrictedAccessPage');
+        if(node){
+            if(node['comp'])
+                return node['comp']['@type'].includes('nrdp:RestrictedAccessPage');
+            else
+                return false;
+        }else{
+            return false;
+        }
     }
 
     checkAccessPageType() {
@@ -631,7 +638,8 @@ export class DataFilesComponent implements OnInit, OnChanges {
      * @returns boolean
      */
     isLeaf(fileNode: any) {
-        return (fileNode.comp['@type'].indexOf('nrdp:DataFile') > -1);
+        if(!fileNode.comp) return false;
+        else return (fileNode.comp['@type'].indexOf('nrdp:DataFile') > -1);
     }
 
     /**

--- a/angular/src/app/landing/data-files/data-files.component.ts
+++ b/angular/src/app/landing/data-files/data-files.component.ts
@@ -273,7 +273,7 @@ export class DataFilesComponent implements OnInit, OnChanges {
         }
 
         this.buildTree();
-        console.log("files", this.files);
+
         // If total file count > virtual scrolling threshold, set virtual scrolling to true. 
         this.virtualScroll = this.fileCount > FileCountForVirtualScroll? true : false;
 

--- a/angular/src/app/landing/landingpage.component.ts
+++ b/angular/src/app/landing/landingpage.component.ts
@@ -311,7 +311,10 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
                         let filepath = this.md.components[i].filepath;
                         if(filepath) filepath = filepath.trim();
 
-                        this.metricsData.hasCurrentMetrics = this.fileLevelMetrics.FilesMetrics.find(x => x.filepath.substr(x.filepath.indexOf(ediid)+ediid.length+1).trim() == filepath) != undefined;
+                        this.metricsData.hasCurrentMetrics = this.fileLevelMetrics.FilesMetrics.find(x => {
+                            x.filepath? x.filepath.substr(x.filepath.indexOf(ediid)+ediid.length+1).trim() == filepath : false
+                        }) != undefined;
+                        
                         if(this.metricsData.hasCurrentMetrics) break;
                     }
                 }else{

--- a/angular/src/app/landing/landingpage.component.ts
+++ b/angular/src/app/landing/landingpage.component.ts
@@ -302,19 +302,13 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
             // when download is completed
             if(event.type == HttpEventType.Response){
                 let response = await event.body.text();
-
+                
                 this.fileLevelMetrics = JSON.parse(response);
-
                 if(this.fileLevelMetrics.FilesMetrics != undefined && this.fileLevelMetrics.FilesMetrics.length > 0 && this.md.components){
                     // check if there is any current metrics data
                     for(let i = 1; i < this.md.components.length; i++){
-                        let filepath = this.md.components[i].filepath;
-                        if(filepath) filepath = filepath.trim();
+                        this.metricsData.hasCurrentMetrics = this.metricsService.findFileLevelMatch(this.fileLevelMetrics.FilesMetrics, this.md.ediid, this.md['@id'],this.md.components[i].filepath);
 
-                        this.metricsData.hasCurrentMetrics = this.fileLevelMetrics.FilesMetrics.find(x => {
-                            x.filepath? x.filepath.substr(x.filepath.indexOf(ediid)+ediid.length+1).trim() == filepath : false
-                        }) != undefined;
-                        
                         if(this.metricsData.hasCurrentMetrics) break;
                     }
                 }else{

--- a/angular/src/app/landing/landingpage.component.ts
+++ b/angular/src/app/landing/landingpage.component.ts
@@ -250,9 +250,6 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
         
                     if (this.editRequested) {
                         showError = false;
-                        // console.log("Returning from authentication redirection (editmode="+
-                        //             this.editRequested+")");
-                        
                         // Need to pass reqID (resID) because the resID in editControlComponent
                         // has not been set yet and the startEditing function relies on it.
                         this.edstatsvc.startEditing(this.reqId);
@@ -304,12 +301,12 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
                 let hasFile = false;
 
                 if(this.md.components && this.md.components.length > 0){
-                    this.md.components.forEach(element => {
-                        if(element.filepath){
+                    for(let com of this.md.components) {
+                        if(com.filepath){
                             hasFile = true;
-                            return;
+                            break;
                         }
-                    });
+                    }
                 }
 
                 if(hasFile){

--- a/angular/src/app/landing/landingpage.component.ts
+++ b/angular/src/app/landing/landingpage.component.ts
@@ -52,6 +52,7 @@ import { Themes, ThemesPrefs } from '../shared/globals/globals';
     encapsulation: ViewEncapsulation.None
 })
 export class LandingPageComponent implements OnInit, AfterViewInit {
+    pdrid: string;
     layoutCompact: boolean = true;
     layoutMode: string = 'horizontal';
     profileMode: string = 'inline';
@@ -223,6 +224,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
                 metadataError = "not-found";
             }
             else{
+                this.pdrid = this.md["@id"];
                 this.theme = ThemesPrefs.getTheme((new NERDResource(this.md)).theme());
 
                 if(this.inBrowser){
@@ -310,12 +312,16 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
                 }
 
                 if(hasFile){
-                    //Now check if there is any metrics data
-                    this.metricsData.totalDatasetDownload = this.recordLevelMetrics.DataSetMetrics[0] != undefined? this.recordLevelMetrics.DataSetMetrics[0].record_download : 0;
-    
-                    this.metricsData.totalDownloadSize = this.recordLevelMetrics.DataSetMetrics[0] != undefined? this.recordLevelMetrics.DataSetMetrics[0]["total_size_download"] : 0;
-        
-                    this.metricsData.totalUsers = this.recordLevelMetrics.DataSetMetrics[0] != undefined? this.recordLevelMetrics.DataSetMetrics[0].number_users : 0;
+                    for(let metrics of this.recordLevelMetrics.DataSetMetrics) {
+                        if((!this.pdrid || metrics["pdrid"].toLowerCase() == 'nan' || metrics["pdrid"].trim() == this.pdrid) && metrics["last_time_logged"]){
+                            //Now check if there is any metrics data
+                            this.metricsData.totalDatasetDownload = metrics != undefined? metrics.record_download : 0;
+                            
+                            this.metricsData.totalDownloadSize = metrics != undefined? metrics["total_size_download"] : 0;
+
+                            this.metricsData.totalUsers = metrics != undefined? metrics.number_users : 0;
+                        }
+                    }
             
                     this.metricsData.totalUsers = this.metricsData.totalUsers == undefined? 0 : this.metricsData.totalUsers;  
 

--- a/angular/src/app/metrics/horizontal-barchart/horizontal-barchart.component.ts
+++ b/angular/src/app/metrics/horizontal-barchart/horizontal-barchart.component.ts
@@ -294,16 +294,6 @@ export class HorizontalBarchartComponent implements OnInit {
                     .attr('opacity', 0.6)
                     .style('fill', '#00e68a')
             
-                // draw a yellow dash line at the end of the active bar
-                // line style is defined in line#limit
-                chart.append('line')
-                    .attr('id', 'limit')
-                    .attr('x1', xScale(actual[1]))
-                    .attr('y1', 0)
-                    .attr('x2', xScale(actual[1]))
-                    .attr('y2', height)
-                    .attr('stroke', 'red')
-            
                 d3.selectAll('.label')
                   .filter(function(d) { return d[0] == actual[0]; })
                   .attr('opacity', 1)

--- a/angular/src/app/metrics/metrics.component.html
+++ b/angular/src/app/metrics/metrics.component.html
@@ -52,7 +52,7 @@
                     <div style="clear: both;"></div>
                     <div class="min-height-20">
                         <span class="float-left">Total dataset downloads</span>
-                        <span class="float-right">{{TotalDatasetDownloads}}</span>
+                        <span class="float-right">{{totalDatasetDownloads}}</span>
                     </div>
                     <div style="clear: both;"></div>
                     <div class="min-height-20">
@@ -62,7 +62,7 @@
                     <div style="clear: both;"></div>
                     <div class="min-height-20">
                         <span class="float-left">Total unique users</span>
-                        <span class="float-right">{{TotalUniqueUsers}}</span>
+                        <span class="float-right">{{totalUniqueUsers}}</span>
                     </div>
                     <div style="clear: both;"></div>
                     <div class="min-height-20">
@@ -149,7 +149,7 @@
 </div>
 
 <!-- Display file level data summary -->
-<div *ngIf="filescount > 0" style="margin: 1em auto 0em auto; width: 100%; text-align: right;font-size: small;padding-right: 45px;">Total No. files: {{filescount}}, Total dataset size: {{TotalFileSize}}</div>
+<div *ngIf="filescount > 0" style="margin: 1em auto 0em auto; width: 100%; text-align: right;font-size: small;padding-right: 45px;">Total No. files: {{filescount}}, Total dataset size: {{totalFileSizeForDisplay}}</div>
 
 <!-- Display tree table -->
 <div #panel0 id="panel0" *ngIf="inBrowser; else filesLoading" class="flex-container" >

--- a/angular/src/app/metrics/metrics.component.ts
+++ b/angular/src/app/metrics/metrics.component.ts
@@ -185,7 +185,6 @@ export class MetricsComponent implements OnInit {
                         case HttpEventType.Response:
                             // this.recordLevelData = JSON.parse(JSON.stringify(event.body));
                             this.recordLevelData = JSON.parse(await event.body.text());
-
                             if(this.recordLevelData.DataSetMetrics != undefined && this.recordLevelData.DataSetMetrics.length > 0){
 
                                 this.handleRecordLevelData();
@@ -254,7 +253,7 @@ export class MetricsComponent implements OnInit {
         // this.recordLevelTotalDownloads = this.recordLevelData.DataSetMetrics[0].success_get;
 
         for(let metrics of this.recordLevelData.DataSetMetrics) {
-            if(!this.pdrid || metrics["pdrid"].toLowerCase() == 'nan' || metrics["pdrid"].trim() == this.pdrid){
+            if((!this.pdrid || metrics["pdrid"].toLowerCase() == 'nan' || metrics["pdrid"].trim() == this.pdrid) && metrics["last_time_logged"]){
                 this.firstTimeLogged = this.datePipe.transform(metrics.first_time_logged, "MMM d, y");
                 this.recordLevelTotalDownloads = metrics.success_get;
                 this.totalDatasetDownloads = metrics.record_download;

--- a/angular/src/app/metrics/metrics.component.ts
+++ b/angular/src/app/metrics/metrics.component.ts
@@ -32,6 +32,7 @@ export class MetricsComponent implements OnInit {
 
     // Data
     ediid: string;
+    pdrid: string;
     files: TreeNode[] = [];
     fileLevelData: any;
     firstTimeLogged: string = '';
@@ -43,8 +44,12 @@ export class MetricsComponent implements OnInit {
     metricsData: any[] = [];
     totalFileLevelSuccessfulGet: number = 0;
     totalFileSize: number = 0;
+    totalFileSizeForDisplay: string = "";
     totalFilesinChart: number = 0;
     noDatasetSummary: boolean = false;
+    totalDatasetDownloads: number = 0;
+    totalUniqueUsers: number = 0;
+    totalDownloadSizeInByte: number = 0;
 
     // Chart
     chartData: Array<any>;
@@ -117,6 +122,7 @@ export class MetricsComponent implements OnInit {
                     if(md) {
                         this.record = md as NerdmRes;
                         this.datasetTitle = md['title'];
+                        this.pdrid = md['@id'];
 
                         this.createNewDataHierarchy();
                         if (this.files.length != 0){
@@ -181,9 +187,8 @@ export class MetricsComponent implements OnInit {
                             this.recordLevelData = JSON.parse(await event.body.text());
 
                             if(this.recordLevelData.DataSetMetrics != undefined && this.recordLevelData.DataSetMetrics.length > 0){
-                                this.firstTimeLogged = this.datePipe.transform(this.recordLevelData.DataSetMetrics[0].first_time_logged, "MMM d, y");
 
-                                this.recordLevelTotalDownloads = this.recordLevelData.DataSetMetrics[0].success_get;
+                                this.handleRecordLevelData();
 
                                 // this.xAxisLabel = "Total Downloads Since " + this.firstTimeLogged;
                                 this.datasetSubtitle = "Metrics Since " + this.firstTimeLogged;
@@ -244,35 +249,50 @@ export class MetricsComponent implements OnInit {
         }, 0);
     }
 
+
+    handleRecordLevelData() {
+        // this.recordLevelTotalDownloads = this.recordLevelData.DataSetMetrics[0].success_get;
+
+        for(let metrics of this.recordLevelData.DataSetMetrics) {
+            if(!this.pdrid || metrics["pdrid"].toLowerCase() == 'nan' || metrics["pdrid"].trim() == this.pdrid){
+                this.firstTimeLogged = this.datePipe.transform(metrics.first_time_logged, "MMM d, y");
+                this.recordLevelTotalDownloads = metrics.success_get;
+                this.totalDatasetDownloads = metrics.record_download;
+                this.totalUniqueUsers = metrics.number_users;
+                this.totalDownloadSizeInByte = metrics["total_size_download"];
+            }
+        }
+    }
+
     /**
      * Remove outdated data and sha files from the metrics
      */
     cleanupFileLevelData(files: TreeNode[]){
         let metricsData: any[] = [];
-
         for(let node of files){
-            let found = this.metricsService.findFileLevelMatch(this.fileLevelData.FilesMetrics, node.data.ediid, node.data.pdrid, node.data.filePath);
+            //Only check leaf
+            if(node.children.length <= 0) {
+                let found = this.metricsService.findFileLevelMatch(this.fileLevelData.FilesMetrics, node.data.ediid, node.data.pdrid, node.data.filePath);
 
-            if(found){
-                metricsData.push(found);
-                node.data.success_get = found.success_get;
-                if(!node.data.download_size || node.data.download_size == 0){
-                    node.data.download_size = found.download_size;
+                if(found){
+                    metricsData.push(found);
+                    node.data.success_get = found.success_get;
+                    if(!node.data.download_size || node.data.download_size == 0){
+                        node.data.download_size = found.download_size;
+                    }
+
+                    this.totalFileLevelSuccessfulGet += found.success_get;
+                    this.totalFilesinChart += 1;
+
+                    node.data.inChart = true;
+                    if(node.parent){
+                        node.parent.data.inChart = true;
+                    }
                 }
 
-                this.totalFileLevelSuccessfulGet += found.success_get;
-                this.totalFilesinChart += 1;
-
-                node.data.inChart = true;
-                if(node.parent){
-                    node.parent.data.inChart = true;
-                }
-            }
-
-            if(node.children.length > 0){
-                this.cleanupFileLevelData(node.children);
-            }else{
                 this.filescount = this.filescount + 1;
+            }else {
+                this.cleanupFileLevelData(node.children);
             }
         }
 
@@ -293,6 +313,8 @@ export class MetricsComponent implements OnInit {
             const {downloads, fileSize} = this.sumFolder(child);
             this.totalFileSize += fileSize;
         }
+
+        this.totalFileSizeForDisplay = this.commonFunctionService.formatBytes(this.totalFileSize, 2);
     }
 
     /**
@@ -310,7 +332,13 @@ export class MetricsComponent implements OnInit {
         }
     
         var downloads = node.data.success_get;
-        var fileSize = node.data.download_size;
+
+        var fileSize;
+        if(!node.data.download_size || node.data.download_size == 'nan')
+            fileSize = 0;
+        else
+            fileSize = node.data.download_size;
+
         return {downloads, fileSize};
     }
 
@@ -343,9 +371,9 @@ export class MetricsComponent implements OnInit {
         // Add summary
         csv = "# Record id," + this.ediid + "\r\n"
             + "# Total file downloads," + this.recordLevelTotalDownloads + "\r\n"
-            + "# Total dataset downloads," + this.TotalDatasetDownloads + "\r\n"
+            + "# Total dataset downloads," + this.totalDatasetDownloads + "\r\n"
             + "# Total bytes downloaded," + this.totalDownloadSizeInByte + "\r\n"
-            + "# Total unique users," + this.TotalUniqueUsers + "\r\n"
+            + "# Total unique users," + this.totalUniqueUsers + "\r\n"
             + "\r\n" + csv;
 
         // Create link and download
@@ -359,33 +387,11 @@ export class MetricsComponent implements OnInit {
     }
 
     /**
-     * Return total dataset downloads
-     */
-    get TotalDatasetDownloads() {
-        if(this.recordLevelData.DataSetMetrics[0] != undefined){
-            return this.recordLevelData.DataSetMetrics[0].record_download;
-        }else{
-            return ""
-        }
-    }
-
-    /**
      * Return total download size from file level summary
      */
-    get TotalFileSize() {
-        return this.commonFunctionService.formatBytes(this.totalFileSize, 2);
-    }
-
-    /**
-     * Get total unique users
-     */
-    get TotalUniqueUsers() {
-        if(this.recordLevelData.DataSetMetrics[0] != undefined){
-            return this.recordLevelData.DataSetMetrics[0].number_users;
-        }else{
-            return ""
-        }
-    }
+    // get TotalFileSize() {
+    //     return this.commonFunctionService.formatBytes(this.totalFileSize, 2);
+    // }
 
     /**
      * Save the bar chart as a png file
@@ -518,15 +524,15 @@ export class MetricsComponent implements OnInit {
      * 01/08/2024 Discussed with Deoyani, use "total_size_download" in record level data. 
      * No need to add file level data anymore.
      */
-    get totalDownloadSizeInByte() {
-        let totalDownload = 0;
+    // get totalDownloadSizeInByte() {
+    //     let totalDownload = 0;
 
-        if(this.recordLevelData != undefined) {
-            totalDownload += this.recordLevelData.DataSetMetrics[0]["total_size_download"];
-        }
+    //     if(this.recordLevelData != undefined) {
+    //         totalDownload += this.recordLevelData.DataSetMetrics[0]["total_size_download"];
+    //     }
 
-        return totalDownload;
-    }
+    //     return totalDownload;
+    // }
 
      /**
      * Reture style for Title column of the file tree

--- a/angular/src/app/metrics/metrics.component.ts
+++ b/angular/src/app/metrics/metrics.component.ts
@@ -515,14 +515,11 @@ export class MetricsComponent implements OnInit {
 
     /**
      * Get total recordset level download size in bytes
+     * 01/08/2024 Discussed with Deoyani, use "total_size_download" in record level data. 
+     * No need to add file level data anymore.
      */
     get totalDownloadSizeInByte() {
         let totalDownload = 0;
-        if(this.fileLevelData != undefined) {
-            this.fileLevelData.FilesMetrics.forEach( (file) => {
-                totalDownload += file.success_get * file.total_size_download;
-            });
-        }
 
         if(this.recordLevelData != undefined) {
             totalDownload += this.recordLevelData.DataSetMetrics[0]["total_size_download"];

--- a/angular/src/app/shared/metrics-service/metrics.service.ts
+++ b/angular/src/app/shared/metrics-service/metrics.service.ts
@@ -28,8 +28,7 @@ export class MetricsService {
      * @returns http response
      */
     getFileLevelMetrics(ediid: string): Observable<any> {
-        let url = this.metricsBackend + "files?exclude=_id&include=ediid,filepath,success_get,download_size&ediid=" + ediid;
-
+        let url = this.metricsBackend + "files/" + ediid;
         const request = new HttpRequest(
             "GET", url, 
             { headers: new HttpHeaders({ 'Content-Type': 'application/json', 'responseType': 'blob' }), reportProgress: true, responseType: 'blob' });
@@ -75,9 +74,17 @@ export class MetricsService {
             }
 
             for(let x of fileLevelData) {
-                if(x.pdrid.replace('ark:/88434/', '') == _pdrid.replace('ark:/88434/', '') && x.ediid.replace('ark:/88434/', '') == _ediid && (x.filepath? x.filepath.trim()==_filepath : false) && !x.filepath.endsWith('sha256')) {
-                    ret = x;
-                    break;
+                if(_pdrid.toLowerCase() == 'nan') {
+                    if((x.filepath? x.filepath.trim()==_filepath : false) && x.ediid.replace('ark:/88434/', '') == _ediid && !x.filepath.endsWith('sha256')) {
+                        ret = x;
+                        break;
+                    }
+                }else {
+                    if(x.pdrid.replace('ark:/88434/', '') == _pdrid && x.ediid.replace('ark:/88434/', '') == _ediid && (x.filepath? x.filepath.trim()==_filepath : false) && !x.filepath.endsWith('sha256')) {
+                        ret = x;
+                        break;
+                    }
+    
                 }
             }
         }

--- a/angular/src/app/shared/metrics-service/metrics.service.ts
+++ b/angular/src/app/shared/metrics-service/metrics.service.ts
@@ -61,7 +61,6 @@ export class MetricsService {
      */
     findFileLevelMatch(fileLevelData: any, ediid: string, pdrid: string, filepath: string) {
         if(!ediid || !pdrid || !filepath) return null;
-
         // Strip off 'ark:/88434/' if any
         let _ediid = ediid.replace('ark:/88434/', '');
         let _pdrid = pdrid.replace('ark:/88434/', '');
@@ -74,7 +73,8 @@ export class MetricsService {
             }
 
             for(let x of fileLevelData) {
-                if(_pdrid.toLowerCase() == 'nan') {
+                // If file's pdrid is "NaN", do not compare pdrid
+                if(x.pdrid.toLowerCase() == 'nan') {
                     if((x.filepath? x.filepath.trim()==_filepath : false) && x.ediid.replace('ark:/88434/', '') == _ediid && !x.filepath.endsWith('sha256')) {
                         ret = x;
                         break;
@@ -84,7 +84,6 @@ export class MetricsService {
                         ret = x;
                         break;
                     }
-    
                 }
             }
         }

--- a/angular/src/app/shared/metrics-service/metrics.service.ts
+++ b/angular/src/app/shared/metrics-service/metrics.service.ts
@@ -22,6 +22,11 @@ export class MetricsService {
 
     }
 
+    /**
+     * Request file level metrics data based on ediid
+     * @param ediid 
+     * @returns http response
+     */
     getFileLevelMetrics(ediid: string): Observable<any> {
         let url = this.metricsBackend + "files?exclude=_id&include=ediid,filepath,success_get,download_size&ediid=" + ediid;
 
@@ -32,6 +37,11 @@ export class MetricsService {
         return this.http.request(request);
     }
 
+    /**
+     * Request record level metrics data based on ediid
+     * @param ediid 
+     * @returns http response
+     */
     getRecordLevelMetrics(ediid: string): Observable<any> {
         let url = this.metricsBackend + "records/" + ediid;
 
@@ -40,5 +50,38 @@ export class MetricsService {
             { headers: new HttpHeaders({ 'Content-Type': 'application/json', 'responseType': 'blob' }), reportProgress: true, responseType: 'blob' });
 
         return this.http.request(request);
+    }
+
+    /**
+     * Find a match of metrics data based on given ediid, pdrid and filepath. Ignore sha files.
+     * @param fileLevelData File level metrics data returned from getFileLevelMetrics()
+     * @param ediid ediid in nerdm record to find a match
+     * @param pdrid pdrid in nerdm record to find a match
+     * @param filepath filepath in nerdm record to find a match
+     * @returns metrics data if a match found. Otherwise return null.
+     */
+    findFileLevelMatch(fileLevelData: any, ediid: string, pdrid: string, filepath: string) {
+        if(!ediid || !pdrid || !filepath) return null;
+
+        // Strip off 'ark:/88434/' if any
+        let _ediid = ediid.replace('ark:/88434/', '');
+        let _pdrid = pdrid.replace('ark:/88434/', '');
+        let _filepath = filepath.trim();
+        let ret: any = null;
+        if(fileLevelData){
+            if(_filepath) {
+                if(filepath[0]=="/") _filepath = filepath.slice(1);
+                _filepath = _filepath.trim();
+            }
+
+            for(let x of fileLevelData) {
+                if(x.pdrid.replace('ark:/88434/', '') == _pdrid.replace('ark:/88434/', '') && x.ediid.replace('ark:/88434/', '') == _ediid && (x.filepath? x.filepath.trim()==_filepath : false) && !x.filepath.endsWith('sha256')) {
+                    ret = x;
+                    break;
+                }
+            }
+        }
+
+        return ret;
     }
 }


### PR DESCRIPTION
Issue: landing page crashed when metrics data didn't have filepath info.
Example: https://testdata.nist.gov/od/id/66AF4AFEA96764C4E0532457068100261895
Fix: Check filepath attribute before using it.
Testing: To test using testdata.nist.gov as backend, in environment.ts set useMetadataService: true, useCustomizationService: true and replace data.nist.gov with testdata.nist.gov. 
Test samples:
http://localhost:4200/metrics/mds2-2124
http://localhost:4200/lps/mds2-2124
http://localhost:4200/metrics/576CE869311197F3E0531A570681C5C71857
http://localhost:4200/lps/576CE869311197F3E0531A570681C5C71857