### PR TITLE
Removed Forensics banner pop up and fixed unit test

### DIFF
--- a/angular/src/app/landing/landingpage.component.ts
+++ b/angular/src/app/landing/landingpage.component.ts
@@ -94,7 +94,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
     modalReference: any;
     windowScrolled: boolean = false;
     showMetrics: boolean = false;
-    imageURL: string;
+    imageURL: string = "";
     theme: string;
     scienceTheme = Themes.SCIENCE_THEME;
     defaultTheme = Themes.DEFAULT_THEME;
@@ -191,7 +191,6 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
         let metadataError = "";
         this.displaySpecialMessage = false;
         this.CART_ACTIONS = CartActions.cartActions;
-        this.imageURL = 'assets/images/fingerprint.jpg';
 
         // Only listen to storage change if we are not in edit mode
         if(this.inBrowser && !this.editEnabled){

--- a/angular/src/app/landing/topic/topic.component.spec.ts
+++ b/angular/src/app/landing/topic/topic.component.spec.ts
@@ -59,7 +59,7 @@ describe('TopicComponent', () => {
     it('Research Topics should contains Information Technology', () => {
         let cmpel = fixture.nativeElement;
         let aels = cmpel.querySelectorAll(".topics");
-        expect(aels.length).toEqual(4);
+        expect(aels.length).toEqual(2);
         expect(aels[0].innerText).toContain('Information Technology');
       });
     

--- a/angular/src/assets/sample3.json
+++ b/angular/src/assets/sample3.json
@@ -11,12 +11,12 @@
   "_schema": "https://www.nist.gov/od/dm/nerdm-schema/v0.1#",
   "topic": [
     {
-      "scheme": "https://www.nist.gov/od/dm/nist-themes/v1.0",
+      "scheme": "https://data.nist.gov/od/dm/nist-themes/v1.0",
       "tag": "Information Technology",
       "@type": "Concept"
     },
     {
-      "scheme": "https://www.nist.gov/od/dm/nist-themes/v1.0",
+      "scheme": "https://data.nist.gov/od/dm/nist-themes/v1.0",
       "tag": "Information Technology: Biometrics",
       "@type": "Concept"
     }


### PR DESCRIPTION
https://sgitlab.nist.gov/oar-odd/landing-page-service/-/issues/10
Issue: Forensics image banner flashed before CHIPS banner showed up for when semiconductors page started up.
Solution: Changed the default image URL from "Forensics" to blank.

It's difficult to test it locally because the page is loaded too fast. Need to test it in oardev.