### PR TITLE
Rename Bundle Name

### DIFF
--- a/angular/src/app/datacart/bundleplan/bundleplan.component.ts
+++ b/angular/src/app/datacart/bundleplan/bundleplan.component.ts
@@ -307,7 +307,7 @@ export class BundleplanComponent implements OnInit {
 
         // Sending data to _bundle_plan and get back the plan
         this.downloadFiles = this.dataCart.getSelectedFiles();
-        let bundleBaseName = this.generateZipFileName(this.dataCart.getName());
+        let bundleBaseName = this.generateZipFileName("NIST-Data");
         
         this.bundlePlanRef = this.downloadService.getBundlePlan(bundleBaseName, this.downloadFiles).subscribe(
             blob => {

--- a/angular/src/app/datacart/bundleplan/bundleplan.component.ts
+++ b/angular/src/app/datacart/bundleplan/bundleplan.component.ts
@@ -285,12 +285,13 @@ export class BundleplanComponent implements OnInit {
         this.downloadService.download(zip, this.zipData, this.dataCart);
     }
 
-    private generateZipFileName(base : string = null) : string {
-        const MIN : number = 0;
-        const MAX : number = 100000;
-        let suffix = Math.floor(Math.random() * (MAX - MIN + 1)) + MIN;
-        return base + suffix;
-    }
+    private generateZipFileName(base: string = "NIST-Data"): string {
+        // current timestamp 
+        const now = new Date();
+        const timestamp = now.toISOString().slice(0, 16).replace(":", "-");
+
+        return `${base}-${timestamp}`;
+    } 
 
     /**
      * download the selected files from this cart.

--- a/angular/src/app/shared/download-service/download-service.service.ts
+++ b/angular/src/app/shared/download-service/download-service.service.ts
@@ -159,6 +159,10 @@ export class DownloadService {
         // create the request body
         let reqfiles = [];
         for (let item of files) {
+            let resId = item.resId;       
+            let filePath = item.filePath;
+            console.log(`resId: ${resId}, filePath: ${filePath}`);
+
             reqfiles.push({
                 "filePath": item.resId + '/' + item.filePath,
                 "downloadUrl": item.downloadURL


### PR DESCRIPTION
This PR updates the logic for generating bundle names in the datacart to address Greg's feedback.

New name format: **NIST-Data-[timestamp]**, where timestamp is in a human readable format: `YYYY-MM-DDTHH-MM`.

### Changes:

1. Updated `generateZipFileName` Method

- The new implementation generates a file name based on the current timestamp:

```typescript
private generateZipFileName(base: string = "NIST-Data"): string {
    const now = new Date();
    const timestamp = now.toISOString().slice(0, 16).replace(":", "-");
    return `${base}-${timestamp}`;
}
```
2. Replaced Bundle Name Logic

- Updated references to use the new method:

```typescript
let bundleBaseName = this.generateZipFileName("NIST-Data");
```

### Testing:
- These changes were tested locally using `oar-docker` to verify that the bundle names align with the new format when downloading bundles from the datacart.