### PR TITLE
Set data cart zip file names to be more human-oriented

### DIFF
--- a/angular/src/app/datacart/cart.service.ts
+++ b/angular/src/app/datacart/cart.service.ts
@@ -64,6 +64,8 @@ export class CartService {
             ).subscribe(
                 (result) => {
                     let data = {};
+                    // Extract the dataset ID to use as the display name
+                    const datasetId = result.metadata[0]?.aipid || cartName;
                     result.metadata.forEach((d) => {
                         let key = cartName + '/' + d.filePath;
                         d['key'] = key;
@@ -71,6 +73,11 @@ export class CartService {
                         data[key] = d;
                     });
                     let out: DataCart = new DataCart(cartName, data, null, 0);
+                    // Set the display name to the dataset ID
+                    out.setDisplayName(datasetId);
+
+                    // Save the cart
+                    out.save();
                     subscriber.next(out);
                     subscriber.complete();
                 }, 


### PR DESCRIPTION
This PR is part of an effort to make zip files created via the data cart more human-oriented; this one addresses the name assigned to zip files containing RPA data.  