### PR TITLE
Fix URLs linking to bulkdownload page to work under oar-docker

### DIFF
--- a/.github/workflows/angular-source.yml
+++ b/.github/workflows/angular-source.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 16.17
 
       - name: Setup dependency caching
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('angular/package-lock.json') }}

--- a/.github/workflows/java-source.yml
+++ b/.github/workflows/java-source.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('java/customization-api/pom.xml') }}

--- a/angular/src/app/bulk-download/bulk-download.component.html
+++ b/angular/src/app/bulk-download/bulk-download.component.html
@@ -21,7 +21,7 @@ You download files in bulk in a few ways:
       <p>
 When PDR demand is high and the dataset you want to download contains a large number of files, the
 Data Cart will struggle to provide the data.  When the number of files is larger than about 300, we
-recommend you try using <a href="/od/tools/pdrdownload.py">pdrdownload.py</a>, a Python scripts that
+recommend you try using <a href="{pdrbase}od/tools/pdrdownload.py">pdrdownload.py</a>, a Python scripts that
 will conveniently and reliably download data from the PDR.  For users that can run a python script,
 this script has several advantages:
       </p>

--- a/angular/src/app/bulk-download/bulk-download.component.html
+++ b/angular/src/app/bulk-download/bulk-download.component.html
@@ -21,7 +21,7 @@ You download files in bulk in a few ways:
       <p>
 When PDR demand is high and the dataset you want to download contains a large number of files, the
 Data Cart will struggle to provide the data.  When the number of files is larger than about 300, we
-recommend you try using <a href="{pdrbase}od/tools/pdrdownload.py">pdrdownload.py</a>, a Python scripts that
+recommend you try using <a href="{{pdrbase}}od/tools/pdrdownload.py">pdrdownload.py</a>, a Python scripts that
 will conveniently and reliably download data from the PDR.  For users that can run a python script,
 this script has several advantages:
       </p>

--- a/angular/src/app/bulk-download/bulk-download.component.spec.ts
+++ b/angular/src/app/bulk-download/bulk-download.component.spec.ts
@@ -3,23 +3,31 @@ import { ActivatedRoute, Router, Routes } from '@angular/router';
 import { BulkDownloadComponent } from './bulk-download.component';
 import * as mock from '../testing/mock.services';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TransferState } from '@angular/platform-browser';
+import { AppConfig } from '../config/config';
+import { AngularEnvironmentConfigService } from '../config/config.service';
 
 describe('BulkDownloadComponent', () => {
   let component: BulkDownloadComponent;
   let fixture: ComponentFixture<BulkDownloadComponent>;
   let route : ActivatedRoute;
+  let cfg: AppConfig;
+  let plid: Object = "browser";
+  let ts: TransferState = new TransferState();
 
   beforeEach(async () => {
     let path = "/bulkdownload";
     let params = {};
     let r : unknown = new mock.MockActivatedRoute(path, params);
     route = r as ActivatedRoute;
+    cfg = (new AngularEnvironmentConfigService(plid, ts)).getConfig() as AppConfig;
 
     await TestBed.configureTestingModule({
       declarations: [ BulkDownloadComponent ],
       imports: [ NoopAnimationsModule ],
       providers: [
         { provide: ActivatedRoute,  useValue: route },
+        { provide: AppConfig, useValue: cfg },
       ]
     })
     .compileComponents();

--- a/angular/src/app/bulk-download/bulk-download.component.ts
+++ b/angular/src/app/bulk-download/bulk-download.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, Inject, PLATFORM_ID } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { isPlatformBrowser } from '@angular/common';
 import { trigger, state, style, animate, transition } from '@angular/animations';
+import { AppConfig } from '../config/config';
 
 @Component({
     selector: 'app-bulk-download',
@@ -26,17 +27,20 @@ import { trigger, state, style, animate, transition } from '@angular/animations'
 export class BulkDownloadComponent implements OnInit {
     inBrowser: boolean = false;
     ediid: string = "dataset-id";
-    previewCommand: string;
+    previewCommand: string = "python pdrdownload.py -I " + this.ediid;
     previewCopied: boolean = false;
-    startDownloadCommand: string;
+    startDownloadCommand: string = "python pdrdownload.py -I " + this.ediid + " -D";
     startDownloadCopied: boolean = false;
-    helpCommand: string;
+    helpCommand: string = "python pdrdownload.py --help";
     helpCopied: boolean = false;
+    pdrbase: string;
 
     constructor(private route: ActivatedRoute,
-                @Inject(PLATFORM_ID) private platformId: Object)
+                @Inject(PLATFORM_ID) private platformId: Object,
+                private cfg : AppConfig)
     {
         this.inBrowser = isPlatformBrowser(platformId);
+        this.pdrbase = cfg.get<string>("locations.portalBase", "/");
     }
 
     ngOnInit(): void {
@@ -46,7 +50,6 @@ export class BulkDownloadComponent implements OnInit {
                     this.ediid = queryParams.id;
                     this.previewCommand = "python pdrdownload.py -I " + this.ediid;
                     this.startDownloadCommand = "python pdrdownload.py -I " + this.ediid + " -D";
-                    this.helpCommand = "python pdrdownload.py --help";
                 }
             });
         }

--- a/angular/src/app/landing/data-files/data-files.component.ts
+++ b/angular/src/app/landing/data-files/data-files.component.ts
@@ -161,6 +161,7 @@ export class DataFilesComponent implements OnInit, OnChanges {
     // The key of treenode whose details is currently displayed
     currentKey: string = '';
 
+    pdrHome: string;
     bulkDownloadURL: string;
     modalRef: any; // For bulk download confirm pop up
 
@@ -191,6 +192,7 @@ export class DataFilesComponent implements OnInit, OnChanges {
         }
         
         this.EDIT_MODES = LandingConstants.editModes;
+        this.pdrHome = cfg.get<string>("locations.pdrHome");
     }
 
     ngOnInit() {
@@ -287,7 +289,7 @@ export class DataFilesComponent implements OnInit, OnChanges {
 
     useMetadata() {
         this.ediid = this.record['ediid'];
-        this.bulkDownloadURL = '/bulkdownload/' + this.ediid.replace('ark:/88434/', '');
+        this.bulkDownloadURL = this.pdrHome + 'bulkdownload/' + this.ediid.replace('ark:/88434/', '');
 
         if(this.record['accessLevel'] === 'restricted public') {
             this.checkAccessPageType();

--- a/angular/src/app/landing/tools/menu.component.ts
+++ b/angular/src/app/landing/tools/menu.component.ts
@@ -52,6 +52,7 @@ export class MenuComponent implements OnInit {
     recordType: string = "";
     scienceTheme = Themes.SCIENCE_THEME;
     inBrowser: boolean = false;
+    pdrHome: string;
     bulkDownloadURL: string;
 
     // the resource record metadata that the tool menu data is drawn from
@@ -76,11 +77,13 @@ export class MenuComponent implements OnInit {
         @Inject(PLATFORM_ID) private platformId: Object,
         private cfg : AppConfig) { 
             this.inBrowser = isPlatformBrowser(platformId);
+            this.pdrHome = cfg.get<string>("locations.pdrHome", "/");
         }
 
     ngOnInit(): void {
         if(this.record)
-            this.bulkDownloadURL = '/bulkdownload/' + this.record.ediid.replace('ark:/88434/', '');
+            this.bulkDownloadURL = this.pdrHome + 'bulkdownload/' +
+                                   this.record.ediid.replace('ark:/88434/', '');
 
         this.allCollections = this.collectionService.loadAllCollections();
 
@@ -93,7 +96,8 @@ export class MenuComponent implements OnInit {
 
     ngOnChanges(ch: SimpleChanges) {
         if (this.record && ch.record)
-            this.bulkDownloadURL = '/bulkdownload/' + this.record.ediid.replace('ark:/88434/', '');
+            this.bulkDownloadURL = this.pdrHome + 'bulkdownload/' +
+                                   this.record.ediid.replace('ark:/88434/', '');
     }
 
     /**


### PR DESCRIPTION
For various reasons, the nginx URL mapping is not able to properly map the links to the bulkdownload page; thus, the links would not work under oar-docker.  To address this in this PR, absolute URLs are formed using base URLs pulled from the configuration.  (Similarly, the URL for downloading the script is now formed in a similar way.)

Also fixed is the rendering of the script execution examples on the bulkdownload page which were not showing up when accessed via the `/bulkdownloads` route (i.e. without an id included).  

Finally, two GitHub Action config files were updated to upgrade from a deprecating version of the cache action.  